### PR TITLE
clear SuSEfirewall from pending queue in systemd

### DIFF
--- a/package/YaST2-Second-Stage.service
+++ b/package/YaST2-Second-Stage.service
@@ -1,12 +1,15 @@
 [Unit]
 Description=YaST2 Second Stage
 After=apparmor.service local-fs.target plymouth-start.service
-Before=getty@tty1.service xdm.service network.service NetworkManager.service SuSEfirewall2_init.service
+Before=getty@tty1.service xdm.service network.service NetworkManager.service SuSEfirewall2_init.service SuSEfirewall2.service
 ConditionPathExists=/var/lib/YaST2/runme_at_boot
 
 [Service]
 Type=oneshot
 Environment=SYSTEMCTL_OPTIONS=--ignore-dependencies TERM=linux
+# firewall will be started by YaST Second Stage
+# ensure current queue doesn't block YaST starting it
+ExecStartPre=-/bin/systemctl stop SuSEfirewall2.service
 ExecStartPre=-/usr/bin/plymouth --hide-splash
 ExecStart=/usr/lib/YaST2/startup/YaST2.Second-Stage
 RemainAfterExit=yes


### PR DESCRIPTION
This prevent SuSEfirewall being in the pending queue of services to be started to block YaST own startup of SuSEfirewall to be blocking.

This is for bnc#798620
