### PR TITLE
use WFM::ClientExists() call instead of checking *.ycp file

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Jun  5 13:02:06 UTC 2013 - lslezak@suse.cz
+
+- use WFM::ClientExists() call instead of checking *.ycp file
+  presence (works also with non-YCP clients and checks also e.g.
+  /y2update/clients path)
+
+-------------------------------------------------------------------
 Mon May 27 15:27:12 CEST 2013 - locilka@suse.com
 
 - Using unique IDs while calling rpmcopy_secondstage to prevent

--- a/src/include/inst_inc_second.ycp
+++ b/src/include/inst_inc_second.ycp
@@ -399,7 +399,7 @@ Note: You may have to enter some information again.");
             SCR::Execute (.target.remove, Installation::current_step);
         }
 
-        if (WFM::Read (.local.size, "/usr/share/YaST2/clients/product_post.ycp") > 0)
+        if (WFM::ClientExists("product_post"))
             WFM::CallFunction ("product_post", [Mode::update ()]);
     }
 

--- a/src/inst_finish/driver_update2_finish.ycp
+++ b/src/inst_finish/driver_update2_finish.ycp
@@ -64,8 +64,9 @@ if (func == "Info")
 else if (func == "Write")
 {
     Vendor::DriverUpdate2 ();
-    if (WFM::Read (.local.size, "/usr/share/YaST2/clients/product_finish.ycp") > 0)
-	WFM::CallFunction ("product_finish", [Mode::update ()]);
+
+    if (WFM::ClientExists("product_finish"))
+        WFM::CallFunction ("product_finish", [Mode::update ()]);
 }
 else
 {


### PR DESCRIPTION
presence (works also with non-YCP clients and checks also e.g.
/y2update/clients path)
