### PR TITLE
- remove trang from BuildRequires: rng can be created during

### DIFF
--- a/control/Makefile.am
+++ b/control/Makefile.am
@@ -23,7 +23,7 @@ xml_files = \
 # the file. 
 
 
-EXTRA_DIST =  $(control_DATA) $(product_DATA) $(xml_files)
+EXTRA_DIST =  $(control_DATA) $(product_DATA) $(xml_files) control.rng
 
 include $(top_srcdir)/Makefile.am.common
 

--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Aug  2 14:25:07 CEST 2013 - jsuchome@suse.cz
+
+- remove trang from BuildRequires: rng can be created during
+  packaging, not needed during build
+
+-------------------------------------------------------------------
 Thu Aug  1 11:21:35 CEST 2013 - jsuchome@suse.cz
 
 - correctly write supporturl (port of bnc#520169) 

--- a/yast2-installation.spec.in
+++ b/yast2-installation.spec.in
@@ -18,9 +18,6 @@ BuildRequires:	yast2-storage >= 2.24.1
 # xmllint
 BuildRequires:	libxml2
 
-# to convert control.rnc o control.rng
-BuildRequires:	trang
-
 # PackageCallbacks::RegisterEmptyProgressCallbacks()
 BuildRequires:	yast2 >= 2.16.52
 


### PR DESCRIPTION
packaging, not needed during build
