### PR TITLE
- use pure ruby solution when sorting proposal items

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Wed Aug  7 12:57:05 CEST 2013 - jsuchome@suse.cz
+
+- use pure ruby solution when sorting proposal items
+
+-------------------------------------------------------------------
 Tue Aug  6 11:30:53 CEST 2013 - jsuchome@suse.cz
 
 - use pure ruby solution when sorting destkop items, so major desktop

--- a/src/clients/inst_proposal.rb
+++ b/src/clients/inst_proposal.rb
@@ -892,12 +892,7 @@ module Yast
       else
         Builtins.y2milestone("Proposal doesn't use tabs")
         # sort modules according to presentation ordering
-        modules = Builtins.sort(modules) do |mod1, mod2|
-          Ops.less_than(
-            Ops.get_integer(mod1, 1, 50),
-            Ops.get_integer(mod2, 1, 50)
-          )
-        end
+        modules.sort!{|mod1,mod2| (mod1[1] || 50) <=> (mod2[1] || 50) }
 
         # setup the list
         @submodules_presentation = Builtins.maplist(modules) do |mod|


### PR DESCRIPTION
For live installation, the order is not defined in control.xml so all items use the same default order number
