### PR TITLE
inst_proposal.rb - handle `nil` Autoyast proposal list

### DIFF
--- a/src/clients/inst_proposal.rb
+++ b/src/clients/inst_proposal.rb
@@ -898,9 +898,12 @@ module Yast
         @submodules_presentation = Builtins.maplist(modules) do |mod|
           Ops.get_string(mod, 0, "")
         end
+
         p = AutoinstConfig.getProposalList
-        @submodules_presentation = Builtins.filter(@submodules_presentation) do |v|
-          Builtins.contains(p, v) || p == []
+
+        if p != nil && p != []
+          # array intersection
+          @submodules_presentation = @submodules_presentation & v
         end
       end
 


### PR DESCRIPTION
- do not display empty proposal when `nil` is received
  from `AutoinstConfig.getProposalList()`
- small refactoring
