### PR TITLE
fix online update dialog

### DIFF
--- a/src/clients/inst_ask_online_update.rb
+++ b/src/clients/inst_ask_online_update.rb
@@ -80,7 +80,7 @@ module Yast
 
       # vv   MAIN (WIZARD) LAYOUT  vv
       @sr_layout = nil
-      @sr_layout = HVCenter(
+      @sr_layout = HVSquash(
         VBox(
           Left(Label(@ask_update_main)),
           Left(


### PR DESCRIPTION
The dialog that asks during the installation if an online update should be run is now centered instead of left aligned. This makes the ugly dialog much nicer.

This fix is also applicable for the openSUSE-13_1 branch (I tested the fix with an RC2 installation), but I guess its too late. If you have to submit a new yast2-installation for 13.1 anyway then please include this fix as well.
