### PR TITLE
removed ProductControl.InitAutomaticConfiguration obsolete call

### DIFF
--- a/src/include/installation/inst_inc_first.rb
+++ b/src/include/installation/inst_inc_first.rb
@@ -148,10 +148,6 @@ module Yast
         end
       end
 
-      # Initializing the default values for AC
-      # @see bnc #404122
-      ProductControl.InitAutomaticConfiguration
-
       nil
     end
 


### PR DESCRIPTION
it has been removed, AC is not supported anymore
