### PR TITLE
inst_upgrade_urls.rb: set the target distribution (bnc#881320)

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Jun 17 12:34:33 UTC 2014 - lslezak@suse.cz
+
+- inst_upgrade_urls.rb: set the future target distribution to not
+  ignore the SCC online repositories in libzypp (bnc#881320)
+- 3.1.92
+
+-------------------------------------------------------------------
 Mon Jun 16 12:33:18 UTC 2014 - jreidinger@suse.com
 
 - write list of active devices for cio_ignore ( partially written

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation
-Version:        3.1.91
+Version:        3.1.92
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/clients/inst_upgrade_urls.rb
+++ b/src/clients/inst_upgrade_urls.rb
@@ -849,7 +849,8 @@ module Yast
 
         # force reloading the libzypp repomanager to notice the removed files
         Pkg.TargetFinish
-        Pkg.TargetInitialize(Installation.destdir)
+        Pkg.TargetInitializeOptions(Installation.destdir,
+            "target_distro" => target_distribution)
         Pkg.TargetLoad
       end
 
@@ -1300,6 +1301,21 @@ module Yast
 
       :next
     end
+
+    private
+
+    # TODO FIXME: share this code better
+    def target_distribution
+      base_products = Product.FindBaseProducts
+
+      # empty target distribution disables service compatibility check in case
+      # the base product cannot be found
+      target_distro = base_products ? base_products.first["register_target"] : ""
+      log.info "Base product target distribution: #{target_distro}"
+
+      target_distro
+    end
+
   end
 end
 


### PR DESCRIPTION
to not ignore the SCC online repositories in libzypp
- 3.1.92
