### PR TITLE
properly setup locale in installation start script (bnc#902411)

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Thu Oct 30 07:35:52 UTC 2014 - lslezak@suse.cz
+
+- properly setup locale in installation start script to display
+  texts and labels correctly in a texmode installation and also
+  to translate all buttons in graphical mode (removed "testutf8"
+  calls, it has been dropped, always set UTF-8 locale) (bnc#902411)
+- 3.1.117
+
+-------------------------------------------------------------------
 Wed Sep 17 16:04:11 UTC 2014 - lslezak@suse.cz
 
 - additionaly return file system type in ".run.df" agent result,

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation
-Version:        3.1.116
+Version:        3.1.117
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/startup/common/language.sh
+++ b/startup/common/language.sh
@@ -55,54 +55,26 @@ function check_run_fbiterm () {
 #----[ set_language_init ]----#
 function set_language_init () {
 #--------------------------------------------------
-# setup LANG variable to a UTF-8 locale if testutf8
-# returns an appropriate exit code. This code only
-# works in first stage (init)
+# setup LANG variable to a UTF-8 locale
+# this code only works in first stage (init)
 # ---
-	if [ ! -x /bin/testutf8 ];then
-		return
-	fi
-	if [ -n "$Console" -o -d /proc/iSeries ];then
-		if testutf8 ; [ $? = 2 ] ; then
-			# append UTF-8
-			[ "$LANGUAGE" ] && LANG="${LANGUAGE%%.*}.UTF-8"
-		else
-			# don't use UTF-8 in case of a serial console
-			[ "$LANGUAGE" ] && LANG=$LANGUAGE
-		fi
-	else
-		# append UTF-8
-		[ "$LANGUAGE" ] && LANG="${LANGUAGE%%.*}.UTF-8"
-	fi
+        # append UTF-8
+        [ "$LANGUAGE" ] && LANG="${LANGUAGE%%.*}.UTF-8"
 }
 
 #----[ set_language_cont ]----#
 function set_language_cont () {
 #--------------------------------------------------
-# setup LANG variable to a UTF-8 locale if testutf8
-# returns an appropriate exit code. This code only
-# works in second stage (continue)
+# setup LANG variable to a UTF-8 locale
+# This code only works in second stage (continue)
 # ---
         if [ -z "$RC_LANG" ]; then
                 log "\tRC_LANG not set, using en_US as default..."
                 export RC_LANG=en_US
         fi
 
-	if [ ! -x /bin/testutf8 ];then
-		return
-	fi
-	if [ -n "$Console" -o -d /proc/iSeries ];then
-		if testutf8 ; [ $? = 2 ] ; then
-			# get rid of encoding and/or modifier
-			export LANG=${RC_LANG%%[.@]*}.UTF-8
-		else
-			# don't use UTF-8 in case of a serial console
-			export LANG=$RC_LANG
-		fi
-	else
-		# get rid of encoding and/or modifier
-		export LANG=${RC_LANG%%[.@]*}.UTF-8
-	fi
+        # get rid of encoding and/or modifier
+        export LANG=${RC_LANG%%[.@]*}.UTF-8
 }
 
 #----[ start_unicode ]-----#


### PR DESCRIPTION
to display texts and labels correctly in a texmode installation and also to
translate all buttons in graphical mode (removed `testutf8` calls, it has been
dropped, always set UTF-8 locale)
- 3.1.117
