### PR TITLE
copy_logs_to_system: call gzip -f

### DIFF
--- a/src/clients/copy_logs_finish.rb
+++ b/src/clients/copy_logs_finish.rb
@@ -97,7 +97,7 @@ module Yast
             InjectRenamedFile(Directory.logdir, file, target_basename)
 
             compress_cmd = Builtins.sformat(
-              "gzip %1/%2/%3",
+              "gzip -f %1/%2/%3",
               Installation.destdir,
               Directory.logdir,
               target_basename


### PR DESCRIPTION
In some cases (especially when running with Y2DEBU=1) the y2log can
become too large and a race between log rotation and copying logs to the
installed system can happen, in which case the "Copying log files to
installed system" task appears to hang (in fact, gzip is asking to
overwrite the target file) (boo897091).