### PR TITLE
Plymouth bug 903682

### DIFF
--- a/package/YaST2-Second-Stage.service
+++ b/package/YaST2-Second-Stage.service
@@ -9,8 +9,11 @@ Type=oneshot
 Environment=SYSTEMCTL_OPTIONS=--ignore-dependencies TERM=linux
 # Workaround of bug in plymouth --> using deactivate option
 # in second boot stage in order to start ncurses yast correctly
-# (bnc#886488)
-ExecStartPre=-/usr/bin/plymouth deactivate --hide-splash
+# (bnc#886488).
+# If the system starts in multi-user mode plymouth will be quit while
+# installation in order to ensure that installation will be finished on
+# console 1 and the login prompt. (bnc#903682,889757,897956)
+ExecStartPre=/bin/sh -c 'if [ `/usr/bin/systemctl get-default` = "multi-user.target" ];then /usr/bin/plymouth quit; else /usr/bin/plymouth deactivate --hide-splash; fi'
 ExecStart=/usr/lib/YaST2/startup/YaST2.Second-Stage
 RemainAfterExit=yes
 TimeoutSec=0

--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,14 @@
 -------------------------------------------------------------------
+Mon Feb  2 13:29:47 CET 2015 - schubi@suse.de
+
+- AutoYaST: If the system starts in multi-user mode plymouth will
+  be quit while installation in order to ensure that installation
+  will be finished on console 1 and the login prompt will be
+  shown.
+  (bnc#903682,889757,897956)
+- 3.1.116.2
+
+-------------------------------------------------------------------
 Thu Oct 16 10:25:37 UTC 2014 - ancor@suse.com
 
 - Fixed the "previously used repositories" step to work properly

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation
-Version:        3.1.116.1
+Version:        3.1.116.2
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/startup/YaST2.Second-Stage
+++ b/startup/YaST2.Second-Stage
@@ -40,6 +40,22 @@ function startYaST2 () {
 . /usr/lib/YaST2/startup/common/functions.sh
 
 #=============================================
+# 1.0) Checking for text installation in
+#      Multi-User mode
+#---------------------------------------------
+# If the system starts in multi-user mode plymouth
+# will be quit while installation in order to ensure
+# that installation will be finished on console 1 and the
+# login prompt. So we have to ensure that the second
+# stage of installation has to be run in ncurses mode.
+# (bnc#903682,889757,897956)
+if [ `systemctl get-default` = "multi-user.target" ];then
+    if [ -f /etc/install.inf ];then
+	sed -i 's/Textmode: 0/Textmode: 1/g' /etc/install.inf
+    fi
+fi
+
+#=============================================
 # 1.1) turn off splash screen, be verbose
 #---------------------------------------------
 disable_splash


### PR DESCRIPTION
AutoYaST: If the system starts in multi-user mode plymouth will
be quit while installation in order to ensure that installation
will be finished on console 1 and the login prompt will be
shown.