### PR TITLE
Always enable startup scripts for Second Stage and Firstboot

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Apr 16 13:02:23 CEST 2015 - locilka@suse.com
+
+- Always enable systemd startup services for Second Stage and
+  Firstboot (bsc#924278)
+- 3.1.116.3
+
+-------------------------------------------------------------------
 Mon Feb  2 13:29:47 CET 2015 - schubi@suse.de
 
 - AutoYaST: If the system starts in multi-user mode plymouth will

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -171,7 +171,10 @@ install -m 644 %{SOURCE2} %{buildroot}%{_unitdir}
 
 # bsc#924278 Always enable these services by default, they are already listed
 # in systemd-presets-branding package, but that works for new installations
-# only, it does not work for upgrades
+# only, it does not work for upgrades from SLE 11 where scripts had different
+# name and were not handled by systemd.
+# When we upgrade/update from systemd-based system, scripts are always enabled
+# by the %service_add_post macro.
 systemctl enable YaST2-Second-Stage.service
 systemctl enable YaST2-Firstboot.service
 

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation
-Version:        3.1.116.2
+Version:        3.1.116.3
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -169,6 +169,12 @@ install -m 644 %{SOURCE2} %{buildroot}%{_unitdir}
 
 %service_add_post YaST2-Second-Stage.service YaST2-Firstboot.service
 
+# bsc#924278 Always enable these services by default, they are already listed
+# in systemd-presets-branding package, but that works for new installations
+# only, it does not work for upgrades
+systemctl enable YaST2-Second-Stage.service
+systemctl enable YaST2-Firstboot.service
+
 %pre
 %service_add_pre YaST2-Second-Stage.service YaST2-Firstboot.service
 


### PR DESCRIPTION
- The approach with %service_add_post works only for new installations but doesn't work for upgrades
- bsc#924278