### PR TITLE
Set Xvnc server resolution to 96 dpi (bsc#919456)

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed May 20 19:29:48 UTC 2015 - lslezak@suse.cz
+
+- set Xvnc server resolution to 96 dpi to fix broken layout in VNC
+  installations (defaults to 75 dpi) (bsc#919456)
+- 3.1.142
+
+-------------------------------------------------------------------
 Fri Apr 24 06:01:14 UTC 2015 - ancor@suse.com
 
 - Fixed an error preventing the VNC connection during second

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation
-Version:        3.1.141
+Version:        3.1.142
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/startup/common/vnc.sh
+++ b/startup/common/vnc.sh
@@ -77,6 +77,7 @@ startVNCServer () {
 		-desktop "Installation" \
 		-geometry "$VNCSize" \
 		-depth 16 \
+                -dpi 96 \
 		-rfbwait 120000 \
 		-httpd /usr/share/vnc/classes \
 		-rfbport 5901 \


### PR DESCRIPTION
...to fix broken layout in VNC installations (defaults to 75 dpi).

The installation stylesheet uses units like 'em' or 'pt' [*] which
depend on the display resolution (dpi).

- 3.1.142

[*] see http://www.w3.org/Style/Examples/007/units.en.html