### PR TITLE
Implemented "triggers" for calling installation proposals again when needed

### DIFF
--- a/doc/proposal_api.md
+++ b/doc/proposal_api.md
@@ -92,14 +92,17 @@ Makes proposal for installation.
   For intance, when partitioning or software selection changes.
   Mandatory keys of the trigger are:
 
-  * _FunRef_ `expect` a FunRef reference to method that will be called and its result compared with `value`
+  * _map_ `expect` containing _string_ `class` and _string_ `method` that will be called and its result compared with `value`
   * _any_ `value` expected value, if the evaluated code does not match the `value`, proposal will be called again
 
   Example:
 
       {
         "trigger" => {
-          "expect" => Yast::FunRef.new(Yast::Packages.method(:CountSizeToBeDownloaded), "integer ()"),
+          "expect" => {
+            "class"  => "Yast::Packages",
+            "method" => "CountSizeToBeDownloaded"
+          }
           "value" => 88883333
         }
       }

--- a/doc/proposal_api.md
+++ b/doc/proposal_api.md
@@ -88,6 +88,25 @@ Makes proposal for installation.
 * _string_ `help` (optional) Helptext for this module which appears in the standard dialog
   help (particular helps for modules sorted by presentation order).
 
+* _map_ `trigger` defines circumstances when the proposal should be called again at the end.
+  For intance, when partitioning or software selection changes.
+  Mandatory keys of the trigger are:
+
+  * _string_ `expect` with multi-line code to be executed with `eval`, all necessary libraries must be loaded within this code
+  * _any_ `value` expected value, if the evaluated code does not match the `value`, proposal will be called again
+
+  Example:
+
+      {
+        "trigger" => {
+          "expect" => "
+            Yast.import \"Packages\"
+            Yast::Packages.CountSizeToBeDownloaded()
+          ",
+          "value" => 88883333
+        }
+      }
+
 ### AskUser
 Run an interactive workflow - let user decide upon values he might want to change.
 May contain one single dialog, a sequence of dialogs or one master dialog with

--- a/doc/proposal_api.md
+++ b/doc/proposal_api.md
@@ -92,17 +92,14 @@ Makes proposal for installation.
   For intance, when partitioning or software selection changes.
   Mandatory keys of the trigger are:
 
-  * _string_ `expect` with multi-line code to be executed with `eval`, all necessary libraries must be loaded within this code
+  * _FunRef_ `expect` a FunRef reference to method that will be called and its result compared with `value`
   * _any_ `value` expected value, if the evaluated code does not match the `value`, proposal will be called again
 
   Example:
 
       {
         "trigger" => {
-          "expect" => "
-            Yast.import \"Packages\"
-            Yast::Packages.CountSizeToBeDownloaded()
-          ",
+          "expect" => Yast::FunRef.new(Yast::Packages.method(:CountSizeToBeDownloaded), "integer ()"),
           "value" => 88883333
         }
       }

--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,14 @@
 -------------------------------------------------------------------
+Wed Jun 17 09:29:09 CEST 2015 - locilka@suse.com
+
+- Implemented 'trigger's for installation proposal (FATE #317488).
+  Any *_proposal client can define 'trigger' in 'MakeProposal'
+  that defines in which circumstances it should be called again
+  after all proposals have been called, e.g., if partitioning or
+  software selection changes.
+- 3.1.145
+
+-------------------------------------------------------------------
 Tue Jun  2 08:41:03 UTC 2015 - jreidinger@suse.com
 
 - fix crash in Upgrade when creating post upgrade snapshot

--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,7 +1,7 @@
 -------------------------------------------------------------------
 Wed Jun 17 09:29:09 CEST 2015 - locilka@suse.com
 
-- Implemented 'trigger's for installation proposal (FATE #317488).
+- Implemented triggers for installation proposal (FATE #317488).
   Any *_proposal client can define 'trigger' in 'MakeProposal'
   that defines in which circumstances it should be called again
   after all proposals have been called, e.g., if partitioning or

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation
-Version:        3.1.144
+Version:        3.1.145
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/installation/proposal_runner.rb
+++ b/src/lib/installation/proposal_runner.rb
@@ -745,7 +745,7 @@ module Installation
 
       # now build the menu button
       menu_list = @submodules_presentation.each_with_object([]) do |submod, menu|
-        descr = @store.descriptions[submod] || {}
+        descr = @store.description_for(submod) || {}
         next if descr.empty?
 
         id = descr["id"]

--- a/src/lib/installation/proposal_store.rb
+++ b/src/lib/installation/proposal_store.rb
@@ -131,8 +131,13 @@ module Installation
 
       @proposal_names.map!(&:first) # first element is name of client
 
-      # FIXME: add filter to only installed clients
-      @proposal_names
+      missing_proposals = @proposal_names.reject { |proposal| Yast::WFM::ClientExists(proposal) }
+      unless missing_proposals.empty?
+        log.warn "These proposals are missing on system: #{missing_proposals}"
+      end
+
+      # Filter missing proposals out
+      @proposal_names -= missing_proposals
     end
 
     # returns single list of modules presentation order or list of tabs with list of modules
@@ -146,72 +151,70 @@ module Installation
     # @param callback Called after each client/part, to report progress. Gets
     #   part name and part result as arguments
     def make_proposals(force_reset: false, language_changed: false, callback: Proc.new)
-      @link2submod = {}
+      proposal_names.each do |client|
+        description_map = make_proposal(client, force_reset: force_reset,
+          language_changed: language_changed, callback: callback)
 
-      proposal_names.each do |submod|
-        proposal_map = make_proposal(submod, force_reset:      force_reset,
-                                             language_changed: language_changed)
-
-        callback.call(submod, proposal_map)
-
-        # update link map
-        (proposal_map["links"] || []).each do |link|
-          @link2submod[link] = submod
-        end
-
-        if proposal_map["language_changed"]
-          @descriptions = nil # invalid descriptions cache
+        if description_map["language_changed"]
+          # Invalidate all of them at once
+          invalidate_description
           return make_proposals(force_reset: force_reset, language_changed: true)
         end
 
-        break if proposal_map["warning_level"] == :fatal
+        break if description_map["warning_level"] == :fatal
       end
     end
 
-    # Calls all clients/parts to retrieve the description
-    # @return [Hash{String => Hash}] map client/part names to hashes with keys
-    # "id", "menu_title" "rich_text_title" http://www.rubydoc.info/github/yast/yast-yast2/Installation/ProposalClient:description
+    # Calls a given client/part to retrieve their description
+    # @return [Hash] with keys "id", "menu_title" "rich_text_title"
+    # @see http://www.rubydoc.info/github/yast/yast-yast2/Installation/ProposalClient:description
+    def description_for(client)
+      @descriptions ||= {}
+      return @descriptions[client] if @descriptions.has_key?(client)
+
+      description = Yast::WFM.CallFunction(client, ["Description", {}])
+
+      if !description.has_key?("id")
+        log.warn "proposal client #{client} is missing key 'id' in #{description}"
+        @missing_no ||= 1
+        description["id"] = "module_#{@missing_no}"
+        @missing_no += 1
+      end
+
+      @descriptions[client] = description
+    end
+
+    # Returns all currently cached client descriptions
+    #
+    # @return [Hash] with descriptions
     def descriptions
-      return @descriptions if @descriptions
-
-      missing_no = 1
-      @id_mapping = {}
-      @descriptions = proposal_names.each_with_object({}) do |client, res|
-        description = Yast::WFM.CallFunction(client, ["Description", {}])
-        if !description["id"]
-          log.warn "proposal client #{client} missing key 'id' in #{description}"
-
-          description["id"] = "module_#{missing_no}"
-          missing_no += 1
-        end
-
-        @id_mapping[description["id"]] = client
-
-        res[client] = description
-      end
+      @descriptions ||= {}
+      @descriptions
     end
 
+    # Returns ID for given client
+    #
     # @return [String] an id provided by the description API
     def id_for(client)
-      descriptions[client]["id"]
+      description_for(client).fetch("id", client)
     end
 
+    # Returns UI title for given client
+    #
+    # @param [String] client
+    # @return [String] a title provided by the description API
     def title_for(client)
-      descriptions[client]["rich_text_title"] ||
-        descriptions[client]["rich_text_raw_title"] ||
+      description = description_for(client)
+
+      description["rich_text_title"] ||
+        description["rich_text_raw_title"] ||
         client
     end
 
-    # Calls `ask_user`, to change a setting interactively (if link is the
+    # Calls client('AskUser'), to change a setting interactively (if link is the
     # heading for the part) or noninteractively (if it is a "shortcut")
     def handle_link(link)
-      client = @id_mapping[link]
-      client ||= @link2submod[link]
-
-      if !client
-        log.error "unknown link #{link}. Broken proposal client?"
-        return nil
-      end
+      client = client_for_link(link)
 
       data = {
         "has_next"  => false,
@@ -221,7 +224,37 @@ module Installation
       Yast::WFM.CallFunction(client, ["AskUser", data])
     end
 
+    # Returns client name that handles the given link returned by UI,
+    # returns nil if link is unknown.
+    # Link can be either the client ID or a shortcut link.
+    #
+    # @param [String] link
+    # @return [String] client name
+    def client_for_link(link)
+      raise "There are no client descriptions known, call 'client(Description)' first" if @descriptions.nil?
+
+      matching_client = @descriptions.find do |client, description|
+        description.fetch("id", nil) == link ||
+          description.fetch("links", []).include?(link)
+      end
+
+      raise "Unknown user request #{link}. Broken proposal client?" if matching_client.nil?
+
+      matching_client.first
+    end
+
   private
+
+    # Invalidates proposal description coming from a given client
+    #
+    # @param [String] client or nil for all descriptions
+    def invalidate_description(client = nil)
+      if client.nil?
+        @descriptions.clear
+      else
+        @descriptions.delete(client)
+      end
+    end
 
     def properties
       @proposal_properties ||= Yast::ProductControl.getProposalProperties(
@@ -231,7 +264,7 @@ module Installation
       )
     end
 
-    def make_proposal(client, force_reset: false, language_changed: false)
+    def make_proposal(client, force_reset: false, language_changed: false, callback: Proc.new)
       proposal = Yast::WFM.CallFunction(
         client,
         [
@@ -244,6 +277,8 @@ module Installation
       )
 
       log.debug "#{client} MakeProposal() returns #{proposal}"
+
+      callback.call(client, proposal_map)
 
       proposal
     end
@@ -352,9 +387,8 @@ module Installation
         modules_order = modules_order[current_tab]
 
         modules_order.each_with_object("") do |client, text|
-          if descriptions[client] && !descriptions[client]["help"].to_s.empty?
-            text << descriptions[client]["help"]
-          end
+          description = description_for(client)
+          text << description["help"] unless !description["help"].to_s.empty?
         end
       else
         ""

--- a/src/lib/installation/proposal_store.rb
+++ b/src/lib/installation/proposal_store.rb
@@ -326,11 +326,11 @@ module Installation
       end
 
       if value == expectation_value
-        log.info "Proposal client #{client}: returned value matches expectation '#{value}'"
+        log.info "Proposal client #{client}: returned value matches expectation '#{value.inspect}'"
         return false
       else
-        log.info "Proposal client #{client}: returned value '#{value}' "
-          "does not match expected value '#{expectation_value}'"
+        log.info "Proposal client #{client}: returned value '#{value.inspect}' "
+          "does not match expected value '#{expectation_value.inspect}'"
         return true
       end
     end

--- a/src/lib/installation/proposal_store.rb
+++ b/src/lib/installation/proposal_store.rb
@@ -279,25 +279,30 @@ module Installation
       @triggers ||= {}
       return false unless @triggers.has_key?(client)
 
-      if @triggers[client].has_key?("expect") &&
-         @triggers[client]["expect"].is_a?(String) &&
-         @triggers[client].has_key?("value")
+      unless @triggers[client].has_key?("expect") &&
+        @triggers[client]["expect"].is_a?(String) &&
+        @triggers[client].has_key?("value")
 
-        expectation_code = @triggers[client]["expect"]
-        expectation_value = @triggers[client]["value"]
-        value = eval(expectation_code)
-
-        if value == expectation_value
-          log.info "Proposal client #{client}: returned value matches expectation '#{value}'"
-          return false
-        else
-          log.info "Proposal client #{client}: returned value '#{value}' "
-            "does not match expected value '#{expectation_value}'"
-          return true
-        end
-      else
         raise "Incorrect definition of 'trigger': #{@triggers[client]} "
           "both [String] 'expect' and [Any] 'value' must be set"
+      end
+
+      expectation_code = @triggers[client]["expect"]
+      expectation_value = @triggers[client]["value"]
+
+      begin
+        value = eval(expectation_code)
+      rescue Exception => error
+        raise "Checking the trigger expectations for #{client} have failed:\n#{error}"
+      end
+
+      if value == expectation_value
+        log.info "Proposal client #{client}: returned value matches expectation '#{value}'"
+        return false
+      else
+        log.info "Proposal client #{client}: returned value '#{value}' "
+          "does not match expected value '#{expectation_value}'"
+        return true
       end
     end
 

--- a/src/lib/installation/proposal_store.rb
+++ b/src/lib/installation/proposal_store.rb
@@ -150,10 +150,12 @@ module Installation
     # Makes proposal for all proposal clients.
     # @param callback Called after each client/part, to report progress. Gets
     #   part name and part result as arguments
-    def make_proposals(force_reset: false, language_changed: false, callback: Proc.new)
+    def make_proposals(force_reset: false, language_changed: false, callback: Proc.new {})
       proposal_names.each do |client|
         description_map = make_proposal(client, force_reset: force_reset,
           language_changed: language_changed, callback: callback)
+
+        raise "Invalid proposal from client #{client}" if description_map.nil?
 
         if description_map["language_changed"]
           # Invalidate all of them at once
@@ -264,7 +266,7 @@ module Installation
       )
     end
 
-    def make_proposal(client, force_reset: false, language_changed: false, callback: Proc.new)
+    def make_proposal(client, force_reset: false, language_changed: false, callback: Proc.new {})
       proposal = Yast::WFM.CallFunction(
         client,
         [
@@ -278,7 +280,8 @@ module Installation
 
       log.debug "#{client} MakeProposal() returns #{proposal}"
 
-      callback.call(client, proposal_map)
+      raise "Callback is not a block: #{callback.class}" unless callback.is_a? Proc
+      callback.call(client, proposal)
 
       proposal
     end

--- a/test/proposal_store_test.rb
+++ b/test/proposal_store_test.rb
@@ -210,7 +210,10 @@ describe ::Installation::ProposalStore do
       "menu_title"      => "&Proposal A",
       "id"              => "proposal_a",
       "trigger"         => {
-        "expect" => Yast::FunRef.new(Yast::Installation.method(:scr_destdir), "string ()"),
+        "expect" => {
+          "class"  => "Yast::Installation",
+          "method" => "destdir"
+        },
         "value"  => proposal_a_expected_val
       }
     }
@@ -268,7 +271,10 @@ describe ::Installation::ProposalStore do
       "menu_title"      => "&Proposal C",
       "trigger"         => {
         # 'expect' must be a string that is evaluated later
-        "expect" => Yast::FunRef.new(method(:raise), "string ()"),
+        "expect" => {
+          "class"  => "Erroneous",
+          "method" => "big_mistake"
+        },
         "value"  => 22
       }
     }
@@ -311,7 +317,7 @@ describe ::Installation::ProposalStore do
         allow(Yast::WFM).to receive(:CallFunction).with("proposal_a", anything).and_return(proposal_a_with_trigger)
 
         # Mock evaluation of the trigger
-        allow_any_instance_of(Yast::FunRef).to receive(:call).and_return("/x", "/y", proposal_a_expected_val)
+        allow(Yast::Installation).to receive(:destdir).and_return("/x", "/y", proposal_a_expected_val)
 
         # 1. initial call 2. (...) via trigger
         expect(subject).to receive(:make_proposal).with("proposal_a", anything).exactly(3).times.and_call_original

--- a/test/proposal_store_test.rb
+++ b/test/proposal_store_test.rb
@@ -262,6 +262,19 @@ describe ::Installation::ProposalStore do
     }
   }}
 
+  let(:proposal_c_with_exception) {{
+    "rich_text_title" => "Proposal C",
+    "menu_title"      => "&Proposal C",
+    "trigger"         => {
+      # 'expect' must be a string that is evaluated later
+      "expect"        => "
+        test2 = nil
+        test2.first
+      ",
+      "value"         => 22,
+    }
+  }}
+
   describe "#make_proposals" do
     before do
       allow(subject).to receive(:proposal_names).and_return(proposal_names)
@@ -347,6 +360,14 @@ describe ::Installation::ProposalStore do
         allow(Yast::WFM).to receive(:CallFunction).with("proposal_c", anything()).and_return(proposal_c_with_incorrect_trigger)
 
         expect { subject.make_proposals }.to raise_error /Incorrect definition/
+      end
+    end
+
+    context "when trigger from proposal raises an exception" do
+      it "raises an exception" do
+        allow(Yast::WFM).to receive(:CallFunction).with("proposal_c", anything()).and_return(proposal_c_with_exception)
+
+        expect { subject.make_proposals }.to raise_error /Checking the trigger expectations for proposal_c have failed/
       end
     end
   end

--- a/test/proposal_store_test.rb
+++ b/test/proposal_store_test.rb
@@ -192,134 +192,152 @@ describe ::Installation::ProposalStore do
 
   let(:proposal_names) { ["proposal_a", "proposal_b", "proposal_c"] }
 
-  let(:proposal_a) {{
-    "rich_text_title" => "Proposal A",
-    "menu_title"      => "&Proposal A",
-    "id"              => "proposal_a",
-    "links"           => [ "proposal_a-link_1", "proposal_a-link_2" ]
-  }}
+  let(:proposal_a) do
+    {
+      "rich_text_title" => "Proposal A",
+      "menu_title"      => "&Proposal A",
+      "id"              => "proposal_a",
+      "links"           => ["proposal_a-link_1", "proposal_a-link_2"]
+    }
+  end
 
   let(:proposal_a_expected_val) { 3 }
 
-  let(:proposal_a_with_trigger) {{
-    "rich_text_title" => "Proposal A",
-    "menu_title"      => "&Proposal A",
-    "id"              => "proposal_a",
-    "trigger"         => {
-      "expect"        => "Yast::ProductControl.proposal_a_val",
-      "value"         => proposal_a_expected_val,
+  let(:proposal_a_with_trigger) do
+    {
+      "rich_text_title" => "Proposal A",
+      "menu_title"      => "&Proposal A",
+      "id"              => "proposal_a",
+      "trigger"         => {
+        "expect" => "Yast::ProductControl.proposal_a_val",
+        "value"  => proposal_a_expected_val
+      }
     }
-  }}
+  end
 
-  let(:proposal_b) {{
-    "rich_text_title" => "Proposal B",
-    "menu_title"      => "&Proposal B",
-    "id"              => "proposal_b"
-  }}
+  let(:proposal_b) do
+    {
+      "rich_text_title" => "Proposal B",
+      "menu_title"      => "&Proposal B",
+      "id"              => "proposal_b"
+    }
+  end
 
-  let(:proposal_b_with_language_change) {{
-    "rich_text_title"  => "Proposal B",
-    "menu_title"       => "&Proposal B",
-    "id"               => "proposal_b",
-    "language_changed" => true
-  }}
+  let(:proposal_b_with_language_change) do
+    {
+      "rich_text_title"  => "Proposal B",
+      "menu_title"       => "&Proposal B",
+      "id"               => "proposal_b",
+      "language_changed" => true
+    }
+  end
 
-  let(:proposal_b_with_fatal_error) {{
-    "rich_text_title" => "Proposal B",
-    "menu_title"      => "&Proposal B",
-    "id"              => "proposal_b",
-    "warning_level"   => :fatal,
-    "warning"         => "some fatal error"
-  }}
+  let(:proposal_b_with_fatal_error) do
+    {
+      "rich_text_title" => "Proposal B",
+      "menu_title"      => "&Proposal B",
+      "id"              => "proposal_b",
+      "warning_level"   => :fatal,
+      "warning"         => "some fatal error"
+    }
+  end
 
-  let(:proposal_c) {{
-    "rich_text_title" => "Proposal C",
-    "menu_title"      => "&Proposal C"
-  }}
+  let(:proposal_c) do
+    {
+      "rich_text_title" => "Proposal C",
+      "menu_title"      => "&Proposal C"
+    }
+  end
 
   let(:proposal_c_expected_val) { true }
 
-  let(:proposal_c_with_trigger) {{
-    "rich_text_title" => "Proposal C",
-    "menu_title"      => "&Proposal C",
-    "trigger"         => {
-      "expect"        => "
-        # multi-line with coments
-        1 + 1 + 1 + 1 + 1
-        Yast::ProductControl.proposal_c_val
-      ",
-      "value"         => proposal_c_expected_val,
+  let(:proposal_c_with_trigger) do
+    {
+      "rich_text_title" => "Proposal C",
+      "menu_title"      => "&Proposal C",
+      "trigger"         => {
+        "expect" => "
+          # multi-line with coments
+          1 + 1 + 1 + 1 + 1
+          Yast::ProductControl.proposal_c_val
+        ",
+        "value"  => proposal_c_expected_val
+      }
     }
-  }}
+  end
 
-  let(:proposal_c_with_incorrect_trigger) {{
-    "rich_text_title" => "Proposal C",
-    "menu_title"      => "&Proposal C",
-    "trigger"         => {
-      # 'expect' must be a string that is evaluated later
-      "expect"        => 333,
-      "value"         => "anything",
+  let(:proposal_c_with_incorrect_trigger) do
+    {
+      "rich_text_title" => "Proposal C",
+      "menu_title"      => "&Proposal C",
+      "trigger"         => {
+        # 'expect' must be a string that is evaluated later
+        "expect" => 333,
+        "value"  => "anything"
+      }
     }
-  }}
+  end
 
-  let(:proposal_c_with_exception) {{
-    "rich_text_title" => "Proposal C",
-    "menu_title"      => "&Proposal C",
-    "trigger"         => {
-      # 'expect' must be a string that is evaluated later
-      "expect"        => "
-        test2 = nil
-        test2.first
-      ",
-      "value"         => 22,
+  let(:proposal_c_with_exception) do
+    {
+      "rich_text_title" => "Proposal C",
+      "menu_title"      => "&Proposal C",
+      "trigger"         => {
+        # 'expect' must be a string that is evaluated later
+        "expect" => "
+          test2 = nil
+          test2.first
+        ",
+        "value"  => 22
+      }
     }
-  }}
+  end
 
   describe "#make_proposals" do
     before do
       allow(subject).to receive(:proposal_names).and_return(proposal_names)
-      allow(Yast::WFM).to receive(:CallFunction).with("proposal_a", anything()).and_return(proposal_a)
-      allow(Yast::WFM).to receive(:CallFunction).with("proposal_b", anything()).and_return(proposal_b)
-      allow(Yast::WFM).to receive(:CallFunction).with("proposal_c", anything()).and_return(proposal_c)
+      allow(Yast::WFM).to receive(:CallFunction).with("proposal_a", anything).and_return(proposal_a)
+      allow(Yast::WFM).to receive(:CallFunction).with("proposal_b", anything).and_return(proposal_b)
+      allow(Yast::WFM).to receive(:CallFunction).with("proposal_c", anything).and_return(proposal_c)
     end
 
     context "when all proposals return correct data" do
       it "for each proposal client, calls given callback and creates new proposal" do
         @callback = 0
-        callback = Proc.new { @callback += 1 }
+        callback = proc { @callback += 1 }
 
-        expect{ subject.make_proposals(callback: callback) }.not_to raise_exception
+        expect { subject.make_proposals(callback: callback) }.not_to raise_exception
         expect(@callback).to eq(proposal_names.size)
       end
     end
 
     context "when some proposal returns invalid data (e.g. crashes)" do
       it "raises an exception" do
-        allow(Yast::WFM).to receive(:CallFunction).with("proposal_b", anything()).and_return(nil)
+        allow(Yast::WFM).to receive(:CallFunction).with("proposal_b", anything).and_return(nil)
 
-        expect { subject.make_proposals }.to raise_exception /Invalid proposal from client/
+        expect { subject.make_proposals }.to raise_exception(/Invalid proposal from client/)
       end
     end
 
     context "when given callback is not a block" do
       it "raises an exception" do
-        expect { subject.make_proposals(callback: 4) }.to raise_exception /Callback is not a block/
+        expect { subject.make_proposals(callback: 4) }.to raise_exception(/Callback is not a block/)
       end
     end
 
     context "when returned proposal contains a 'trigger' section" do
       it "for each proposal client, creates new proposal and calls the client while trigger evaluates to true" do
-        allow(Yast::WFM).to receive(:CallFunction).with("proposal_a", anything()).and_return(proposal_a_with_trigger)
-        allow(Yast::WFM).to receive(:CallFunction).with("proposal_c", anything()).and_return(proposal_c_with_trigger)
+        allow(Yast::WFM).to receive(:CallFunction).with("proposal_a", anything).and_return(proposal_a_with_trigger)
+        allow(Yast::WFM).to receive(:CallFunction).with("proposal_c", anything).and_return(proposal_c_with_trigger)
 
         # Proposal A wants to be additionally called twice
         allow(Yast::ProductControl).to receive(:proposal_a_val).and_return(0, 0, proposal_a_expected_val)
         # Proposal C wants to be additionally called once
         allow(Yast::ProductControl).to receive(:proposal_c_val).and_return(false, proposal_c_expected_val)
 
-        expect(subject).to receive(:make_proposal).with("proposal_a", anything()).exactly(3).times.and_call_original
-        expect(subject).to receive(:make_proposal).with("proposal_b", anything()).exactly(1).times.and_call_original
-        expect(subject).to receive(:make_proposal).with("proposal_c", anything()).exactly(2).times.and_call_original
+        expect(subject).to receive(:make_proposal).with("proposal_a", anything).exactly(3).times.and_call_original
+        expect(subject).to receive(:make_proposal).with("proposal_b", anything).exactly(1).times.and_call_original
+        expect(subject).to receive(:make_proposal).with("proposal_c", anything).exactly(2).times.and_call_original
 
         subject.make_proposals
       end
@@ -327,16 +345,16 @@ describe ::Installation::ProposalStore do
 
     context "when returned proposal triggers changing a language" do
       it "calls all proposals again with language_changed: true" do
-        allow(Yast::WFM).to receive(:CallFunction).with("proposal_b", anything()).and_return(proposal_b_with_language_change, proposal_b)
+        allow(Yast::WFM).to receive(:CallFunction).with("proposal_b", anything).and_return(proposal_b_with_language_change, proposal_b)
 
         # Call proposals till the one that changes the language
-        expect(subject).to receive(:make_proposal).with("proposal_a", hash_including(:language_changed => false)).once.and_call_original
-        expect(subject).to receive(:make_proposal).with("proposal_b", hash_including(:language_changed => false)).once.and_call_original
+        expect(subject).to receive(:make_proposal).with("proposal_a", hash_including(language_changed: false)).once.and_call_original
+        expect(subject).to receive(:make_proposal).with("proposal_b", hash_including(language_changed: false)).once.and_call_original
 
         # Call all again with language_changed: true
-        expect(subject).to receive(:make_proposal).with("proposal_a", hash_including(:language_changed => true)).once.and_call_original
-        expect(subject).to receive(:make_proposal).with("proposal_b", hash_including(:language_changed => true)).once.and_call_original
-        expect(subject).to receive(:make_proposal).with("proposal_c", hash_including(:language_changed => true)).once.and_call_original
+        expect(subject).to receive(:make_proposal).with("proposal_a", hash_including(language_changed: true)).once.and_call_original
+        expect(subject).to receive(:make_proposal).with("proposal_b", hash_including(language_changed: true)).once.and_call_original
+        expect(subject).to receive(:make_proposal).with("proposal_c", hash_including(language_changed: true)).once.and_call_original
 
         subject.make_proposals
       end
@@ -344,12 +362,12 @@ describe ::Installation::ProposalStore do
 
     context "when returned proposal contains a fatal error" do
       it "calls all proposals till fatal error is received, then it stops proceeding immediately" do
-        allow(Yast::WFM).to receive(:CallFunction).with("proposal_b", anything()).and_return(proposal_b_with_fatal_error)
+        allow(Yast::WFM).to receive(:CallFunction).with("proposal_b", anything).and_return(proposal_b_with_fatal_error)
 
-        expect(subject).to receive(:make_proposal).with("proposal_a", anything()).once.and_call_original
-        expect(subject).to receive(:make_proposal).with("proposal_b", anything()).once.and_call_original
+        expect(subject).to receive(:make_proposal).with("proposal_a", anything).once.and_call_original
+        expect(subject).to receive(:make_proposal).with("proposal_b", anything).once.and_call_original
         # Proposal C is never called, as it goes after proposal B
-        expect(subject).not_to receive(:make_proposal).with("proposal_c", anything())
+        expect(subject).not_to receive(:make_proposal).with("proposal_c", anything)
 
         subject.make_proposals
       end
@@ -357,17 +375,17 @@ describe ::Installation::ProposalStore do
 
     context "when trigger from proposal is incorrectly set" do
       it "raises an exception" do
-        allow(Yast::WFM).to receive(:CallFunction).with("proposal_c", anything()).and_return(proposal_c_with_incorrect_trigger)
+        allow(Yast::WFM).to receive(:CallFunction).with("proposal_c", anything).and_return(proposal_c_with_incorrect_trigger)
 
-        expect { subject.make_proposals }.to raise_error /Incorrect definition/
+        expect { subject.make_proposals }.to raise_error(/Incorrect definition/)
       end
     end
 
     context "when trigger from proposal raises an exception" do
       it "raises an exception" do
-        allow(Yast::WFM).to receive(:CallFunction).with("proposal_c", anything()).and_return(proposal_c_with_exception)
+        allow(Yast::WFM).to receive(:CallFunction).with("proposal_c", anything).and_return(proposal_c_with_exception)
 
-        expect { subject.make_proposals }.to raise_error /Checking the trigger expectations for proposal_c have failed/
+        expect { subject.make_proposals }.to raise_error(/Checking the trigger expectations for proposal_c have failed/)
       end
     end
 
@@ -377,21 +395,23 @@ describe ::Installation::ProposalStore do
         # Proposal C wants to be called again and again
         allow(subject).to receive(:should_be_called_again?).with("proposal_c").and_return(true)
 
-        expect(subject).to receive(:make_proposal).with(/proposal_(a|b)/, anything()).twice.and_call_original
+        expect(subject).to receive(:make_proposal).with(/proposal_(a|b)/, anything).twice.and_call_original
         # Number of calls including the initial one
-        expect(subject).to receive(:make_proposal).with("proposal_c", anything()).exactly(8).times.and_call_original
+        expect(subject).to receive(:make_proposal).with("proposal_c", anything).exactly(8).times.and_call_original
 
         subject.make_proposals
       end
     end
   end
 
-  let(:client_description) {{
-    "rich_text_title" => "Software",
-    "menu_title"      => "&Software",
-    "id"              => "software",
-    "links"           => [ "software_link_1", "software_link_2" ]
-  }}
+  let(:client_description) do
+    {
+      "rich_text_title" => "Software",
+      "menu_title"      => "&Software",
+      "id"              => "software",
+      "links"           => ["software_link_1", "software_link_2"]
+    }
+  end
 
   let(:client_name) { "software_proposal" }
 
@@ -431,7 +451,7 @@ describe ::Installation::ProposalStore do
 
     context "when client('Description') has not been called before" do
       it "raises an exception" do
-        expect { subject.handle_link("software") }.to raise_error /no client descriptions known/
+        expect { subject.handle_link("software") }.to raise_error(/no client descriptions known/)
       end
     end
 
@@ -440,7 +460,7 @@ describe ::Installation::ProposalStore do
         # Cache some desriptipn first
         subject.description_for(client_name)
 
-        expect { subject.handle_link("unknown_link") }.to raise_error /Unknown user request/
+        expect { subject.handle_link("unknown_link") }.to raise_error(/Unknown user request/)
       end
     end
 
@@ -450,7 +470,7 @@ describe ::Installation::ProposalStore do
         subject.description_for(client_name)
 
         expect(Yast::WFM).to receive(:CallFunction).with(client_name,
-          ["AskUser", {"has_next"=>false, "chosen_id"=>"software"}]).and_return(:next)
+          ["AskUser", { "has_next" => false, "chosen_id" => "software" }]).and_return(:next)
         expect(subject.handle_link("software")).to eq(:next)
       end
     end


### PR DESCRIPTION
## Use Case
In some cases, proposals depend on each other. For instance, kdump sets required packages for software proposal, but software proposal influences space available on disk and kdump needs to evaluate this space whether dump fits there (FATE#317488). There have been several other cases in the past. That's why I've created a generic handling using triggers.

## Implementation details
Each proposal client can define so called `trigger` with keys `expect` and `value`. All these triggers are evaluated at the end of the proposal and if output of the `expect` does not match `value`, proposal will be called again. All such proposals are called after all triggers are evaluated and then triggers are evaluated again. There is a counter that breaks from an infinite loop if needed.