### PR TITLE
avoid suplicating release notes for products (bsc#935599)

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Jul 24 13:01:22 UTC 2015 - jsrain@suse.cz
+
+- avoid suplicating release notes for products (bsc#935599)
+- 3.1.151
+
+-------------------------------------------------------------------
 Tue Jul 21 09:16:03 UTC 2015 - mvidner@suse.com
 
 - Moved client code to lib/installation/clients to enable test

--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,7 +1,7 @@
 -------------------------------------------------------------------
 Fri Jul 24 13:01:22 UTC 2015 - jsrain@suse.cz
 
-- avoid suplicating release notes for products (bsc#935599)
+- avoid duplicating release notes for products (bsc#935599)
 - 3.1.151
 
 -------------------------------------------------------------------

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation
-Version:        3.1.150
+Version:        3.1.151
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/installation/clients/inst_download_release_notes.rb
+++ b/src/lib/installation/clients/inst_download_release_notes.rb
@@ -70,15 +70,15 @@ module Yast
           log.info("Skipping release notes download due to previous download issues")
           break
         end
-        if InstData.downloaded_release_notes.include? product["name"]
-          log.info("Release notes for #{product["name"]} already downloaded, skipping...")
+        if InstData.downloaded_release_notes.include? product["short_name"]
+          log.info("Release notes for #{product["short_name"]} already downloaded, skipping...")
           next
         end
         url = product["relnotes_url"]
         log.debug("URL: #{url}")
         # protect from wrong urls
         if url.nil? || url.empty?
-          log.warn("Skipping invalid URL #{url.inspect} for product #{product["name"]}")
+          log.warn("Skipping invalid URL #{url.inspect} for product #{product["short_name"]}")
           next
         end
         pos = url.rindex("/")
@@ -108,8 +108,8 @@ module Yast
           log.info("Downloading release notes: #{cmd} returned #{ret}")
           if ret == 0
             log.info("Release notes downloaded successfully")
-            InstData.release_notes[product["name"]] = SCR.Read(path(".target.string"), filename)
-            InstData.downloaded_release_notes << product["name"]
+            InstData.release_notes[product["short_name"]] = SCR.Read(path(".target.string"), filename)
+            InstData.downloaded_release_notes << product["short_name"]
             break
           # exit codes (see "man curl"):
           #  7 = Failed to connect to host.

--- a/src/lib/installation/clients/inst_system_analysis.rb
+++ b/src/lib/installation/clients/inst_system_analysis.rb
@@ -301,7 +301,7 @@ module Yast
       # push button
       Wizard.ShowReleaseNotesButton(_("Re&lease Notes..."), "rel_notes")
 
-      product_name = Product.name || _("Unknown Product")
+      product_name = Product.short_name || _("Unknown Product")
       InstData.release_notes[product_name] = @media_text
       UI::SetReleaseNotes(product_name => @media_text)
     end


### PR DESCRIPTION
This is covered by openQA (that's how the bugreport appeared)