### PR TITLE
Fix release notes loading when network is not working

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Aug  7 12:53:08 UTC 2015 - igonzalezsosa@suse.com
+
+- Fix release notes loading when network is not working (bsc#940648)
+- 3.1.153
+
+-------------------------------------------------------------------
 Wed Aug  5 11:45:25 UTC 2015 - jsrain@suse.cz
 
 - store cio_ignore settings before installing bootloader

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation
-Version:        3.1.152
+Version:        3.1.153
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/installation/clients/inst_system_analysis.rb
+++ b/src/lib/installation/clients/inst_system_analysis.rb
@@ -293,7 +293,7 @@ module Yast
       # try on-line release notes first
       WFM.CallFunction("inst_download_release_notes")
 
-      if !InstData.release_notes.empty? &&
+      if !InstData.release_notes.empty? ||
           !load_release_notes(Packages.GetBaseSourceID)
         return
       end

--- a/test/inst_system_analysis_test.rb
+++ b/test/inst_system_analysis_test.rb
@@ -3,11 +3,11 @@
 require_relative "./test_helper"
 require "installation/clients/inst_system_analysis"
 
-describe Yast::InstSystemAnalysisClient do
-  before do
-    subject.main # Initialization and dependencies import
-  end
+Yast.import "Product"
+Yast.import "InstData"
+Yast.import "Packages"
 
+describe Yast::InstSystemAnalysisClient do
   describe "#download_and_show_release_notes" do
     let(:product) { "openSUSE" }
     let(:notes) { "some release notes" }

--- a/test/inst_system_analysis_test.rb
+++ b/test/inst_system_analysis_test.rb
@@ -1,0 +1,61 @@
+#!/usr/bin/env rspec
+
+require_relative "./test_helper"
+require "installation/clients/inst_system_analysis"
+
+describe Yast::InstSystemAnalysisClient do
+  before do
+    subject.main # Initialization and dependencies import
+  end
+
+  describe "#download_and_show_release_notes" do
+    let(:product) { "openSUSE" }
+    let(:notes) { "some release notes" }
+
+    before do
+      allow(Yast::WFM).to receive(:CallFunction).with("inst_download_release_notes").
+        and_return(:auto)
+      allow(Yast::Product).to receive(:short_name).and_return(product)
+      allow(Yast::InstData).to receive(:release_notes).and_return(release_notes)
+    end
+
+    context "when release notes were downloaded" do
+      let(:release_notes) { { product => notes } }
+
+      it "does not enable the button nor load release notes again" do
+        expect(Yast::Wizard).to_not receive(:ShowReleaseNotesButton)
+        expect(Yast::UI).to_not receive(:SetReleaseNotes)
+        subject.download_and_show_release_notes
+      end
+    end
+
+    context "when release notes were not downloaded" do
+      let(:release_notes) { {} }
+
+      context "but can be loaded from media" do
+        before do
+          expect(subject).to receive(:load_release_notes).and_return(true)
+          subject.instance_variable_set(:@media_text, notes)
+        end
+
+        it "enables the button and load the release notes" do
+          expect(Yast::Wizard).to receive(:ShowReleaseNotesButton)
+          expect(Yast::UI).to receive(:SetReleaseNotes).with(product => notes)
+          subject.download_and_show_release_notes
+        end
+      end
+
+      context "and could not be loaded from media" do
+        before do
+          expect(subject).to receive(:load_release_notes).and_return(false)
+        end
+
+        it "does not enable the button nor load release notes" do
+          expect(Yast::Wizard).to_not receive(:ShowReleaseNotesButton)
+          expect(Yast::UI).to_not receive(:SetReleaseNotes)
+          subject.download_and_show_release_notes
+        end
+      end
+    end
+  end
+end

--- a/test/inst_system_analysis_test.rb
+++ b/test/inst_system_analysis_test.rb
@@ -13,8 +13,8 @@ describe Yast::InstSystemAnalysisClient do
     let(:notes) { "some release notes" }
 
     before do
-      allow(Yast::WFM).to receive(:CallFunction).with("inst_download_release_notes").
-        and_return(:auto)
+      allow(Yast::WFM).to receive(:CallFunction).with("inst_download_release_notes")
+        .and_return(:auto)
       allow(Yast::Product).to receive(:short_name).and_return(product)
       allow(Yast::InstData).to receive(:release_notes).and_return(release_notes)
     end
@@ -42,7 +42,7 @@ describe Yast::InstSystemAnalysisClient do
           expect(Yast::Wizard).to receive(:ShowReleaseNotesButton)
           expect(Yast::UI).to receive(:SetReleaseNotes).with(product => notes)
           subject.download_and_show_release_notes
-          expect(Yast::InstData.release_notes).to eq({ product => notes })
+          expect(Yast::InstData.release_notes).to eq(product => notes)
         end
       end
 

--- a/test/inst_system_analysis_test.rb
+++ b/test/inst_system_analysis_test.rb
@@ -34,7 +34,7 @@ describe Yast::InstSystemAnalysisClient do
 
       context "but can be loaded from media" do
         before do
-          expect(subject).to receive(:load_release_notes).and_return(true)
+          allow(subject).to receive(:load_release_notes).and_return(true)
           subject.instance_variable_set(:@media_text, notes)
         end
 
@@ -42,12 +42,13 @@ describe Yast::InstSystemAnalysisClient do
           expect(Yast::Wizard).to receive(:ShowReleaseNotesButton)
           expect(Yast::UI).to receive(:SetReleaseNotes).with(product => notes)
           subject.download_and_show_release_notes
+          expect(Yast::InstData.release_notes).to eq({ product => notes })
         end
       end
 
       context "and could not be loaded from media" do
         before do
-          expect(subject).to receive(:load_release_notes).and_return(false)
+          allow(subject).to receive(:load_release_notes).and_return(false)
         end
 
         it "does not enable the button nor load release notes" do


### PR DESCRIPTION
This PR fixes [bsc#940648](https://bugzilla.suse.com/show_bug.cgi?id=940648). BTW, unit tests were added.