### PR TITLE
Remove systemd dependency on xinetd

### DIFF
--- a/package/YaST2-Second-Stage.service
+++ b/package/YaST2-Second-Stage.service
@@ -2,7 +2,7 @@
 Description=YaST2 Second Stage
 # If xinetd is enabled, make sure it's already running so we can stop it during
 # initialization of the VNC server
-After=apparmor.service local-fs.target plymouth-start.service xinetd.service
+After=apparmor.service local-fs.target plymouth-start.service
 Before=getty@tty1.service display-manager.service network.service NetworkManager.service SuSEfirewall2_init.service SuSEfirewall2.service
 ConditionPathExists=/var/lib/YaST2/runme_at_boot
 

--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Oct  1 15:55:54 UTC 2015 - ancor@suse.com
+
+- Simplified second stage systemd unit to avoid dependencies cycles
+  (bnc#947521 and bnc#931643). Logic moved to YaST startup scripts.
+- 3.1.160
+
+-------------------------------------------------------------------
 Fri Sep  4 07:07:33 UTC 2015 - jsrain@suse.cz
 
 - fix bug preventing to finish proposal in some sutuations

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation
-Version:        3.1.159
+Version:        3.1.160
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/startup/YaST2.call
+++ b/startup/YaST2.call
@@ -158,9 +158,24 @@ function prepare_for_vnc () {
 	setupVNCAuthentication
 	if [ $VNCPASS_EXCEPTION = 0 ];then
 		disable_splash
-		disable_xinetd
+		displayVNCMessage
+		stop_xinetd
 		startVNCServer
 		wait_for_x11
+		if is_xinetd_active; then
+			# xinetd shouldn't be running since we stopped it right
+			# before starting VNC. But there is still one small
+			# chance that xinetd was started by the systemd boot
+			# sequence during VNC startup. If it's running we cannot
+			# be sure that our VNC got the ports, so retry.
+			#
+			# Using systemd dependencies to ensure the correct order
+			# looks nicer, but is fragile (bnc#931643, bnc#947521).
+			killall Xvnc >/dev/null 2>&1
+			stop_xinetd
+			startVNCServer
+			wait_for_x11
+		fi
 		restore_xinetd
 		if [ "$server_running" = 1 ];then
 			log "\tXvnc-Server is ready: $xserver_pid"

--- a/startup/common/misc.sh
+++ b/startup/common/misc.sh
@@ -186,13 +186,29 @@ function disable_splash () {
 	[ -f /proc/splash ] && echo "verbose" > /proc/splash
 }
 
-#----[ disable_xinetd ]-----#
-function disable_xinetd () {
+#----[ stop_xinetd ]-----#
+function stop_xinetd () {
 #--------------------------------------------------
 # stop xinetd since its default configuration collides
 # with the Xvnc server used for VNC installation
 # ---
 	systemctl stop xinetd.service >/dev/null 2>&1
+}
+
+#----[ is_xinetd_enabled ]-----#
+function is_xinetd_enabled () {
+# return 0 if xinetd is enabled
+# ---
+	systemctl --quiet is-enabled xinetd.service >/dev/null 2>&1
+	return $?
+}
+
+#----[ is_xinetd_active ]-----#
+function is_xinetd_active () {
+# return 0 if xinetd is currently running
+# ---
+	systemctl --quiet is-active xinetd.service >/dev/null 2>&1
+	return $?
 }
 
 #----[ restore_xinetd ]-----#
@@ -201,8 +217,7 @@ function restore_xinetd () {
 # start xinetd again if it is enabled, once the Xvnc
 # server already owns its port
 # ---
-	systemctl --quiet is-enabled xinetd.service >/dev/null 2>&1
-	if [ $? -eq 0 ]; then
+	if is_xinetd_enabled; then
 		systemctl start xinetd.service
 	fi
 }

--- a/startup/common/vnc.sh
+++ b/startup/common/vnc.sh
@@ -38,15 +38,14 @@ setupVNCAuthentication () {
 	fi
 }
 
-#----[ startVNCServer ]------#
-startVNCServer () {
+#----[ displayVNCMessage ]------#
+displayVNCMessage () {
 #---------------------------------------------------
-# start Xvnc server and write a log file from the
-# VNC server process
+# inform the user that VNC server is going to be executed and provide
+# instructions on how to connect to it
 #
 	# The IP set in install.inf may not be valid if the DHCP server
 	# gave us a different lease in the meantime (#43974).
-
 	echo
 	echo starting VNC server...
 	echo A log file will be written to: /var/log/YaST2/vncserver.log ...
@@ -64,13 +63,17 @@ startVNCServer () {
 	EOF
 	list_ifaces
 	echo
+}
 
-	#==========================================
-	# Start Xvnc...
-	# For -noreset see BNC #351338
-	#------------------------------------------
+#----[ startVNCServer ]------#
+startVNCServer () {
+#---------------------------------------------------
+# start Xvnc server and write a log file from the
+# VNC server process
+#
 	[ -z "$VNCSize" ] && VNCSize=1024x768
 
+	# For -noreset see BNC #351338
 	$Xbindir/Xvnc $Xvncparam :0 \
 		-noreset \
 		-rfbauth /root/.vnc/passwd.yast \


### PR DESCRIPTION
It was introduced to avoid a very remote possibility of race condition. Now it's double checked in the startup script.

Tested manually with a successful vnc+autoyast installation and also simulating the race condition.

@imobach is running it through the entire autoyast test suite.