### PR TITLE
Don't let getty kill YaST on further serial consoles (bsc#935965)

### DIFF
--- a/package/YaST2-Firstboot.service
+++ b/package/YaST2-Firstboot.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=YaST2 Firstboot
 After=apparmor.service local-fs.target YaST2-Second-Stage.service plymouth-start.service
-Before=getty@tty1.service serial-getty@ttyS0.service display-manager.service network.service NetworkManager.service
+Before=getty@tty1.service serial-getty@ttyS0.service serial-getty@ttyS1.service serial-getty@ttyS2.service display-manager.service network.service NetworkManager.service
 ConditionPathExists=/var/lib/YaST2/reconfig_system
 
 [Service]

--- a/package/YaST2-Firstboot.service
+++ b/package/YaST2-Firstboot.service
@@ -1,7 +1,8 @@
 [Unit]
 Description=YaST2 Firstboot
 After=apparmor.service local-fs.target YaST2-Second-Stage.service plymouth-start.service
-Before=getty@tty1.service serial-getty@ttyS0.service serial-getty@ttyS1.service serial-getty@ttyS2.service display-manager.service network.service NetworkManager.service
+Before=getty@tty1.service serial-getty@ttyS0.service serial-getty@ttyS1.service serial-getty@ttyS2.service
+Before=display-manager.service network.service NetworkManager.service
 ConditionPathExists=/var/lib/YaST2/reconfig_system
 
 [Service]

--- a/package/YaST2-Second-Stage.service
+++ b/package/YaST2-Second-Stage.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=YaST2 Second Stage
 After=apparmor.service local-fs.target plymouth-start.service
-Before=getty@tty1.service serial-getty@ttyS0.service display-manager.service network.service NetworkManager.service SuSEfirewall2_init.service SuSEfirewall2.service
+Before=getty@tty1.service serial-getty@ttyS0.service serial-getty@ttyS1.service serial-getty@ttyS2.service display-manager.service network.service NetworkManager.service SuSEfirewall2_init.service SuSEfirewall2.service
 ConditionPathExists=/var/lib/YaST2/runme_at_boot
 
 [Service]

--- a/package/YaST2-Second-Stage.service
+++ b/package/YaST2-Second-Stage.service
@@ -1,7 +1,8 @@
 [Unit]
 Description=YaST2 Second Stage
 After=apparmor.service local-fs.target plymouth-start.service
-Before=getty@tty1.service serial-getty@ttyS0.service serial-getty@ttyS1.service serial-getty@ttyS2.service display-manager.service network.service NetworkManager.service SuSEfirewall2_init.service SuSEfirewall2.service
+Before=getty@tty1.service serial-getty@ttyS0.service serial-getty@ttyS1.service serial-getty@ttyS2.service
+Before=display-manager.service network.service NetworkManager.service SuSEfirewall2_init.service SuSEfirewall2.service
 ConditionPathExists=/var/lib/YaST2/runme_at_boot
 
 [Service]

--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Nov 19 09:38:48 UTC 2015 - mvidner@suse.com
+
+- Ensure second stage and YaST-Firstboot don't get killed by
+  getty when running over 2nd or 3rd serial console (bsc#935965)
+- 3.1.116.7
+
+-------------------------------------------------------------------
 Fri Nov  6 11:59:26 UTC 2015 - ancor@suse.com
 
 - Ensure second stage and YaST-Firstboot don't get killed by

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation
-Version:        3.1.116.6
+Version:        3.1.116.7
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
[bsc#935965](https://bugzilla.suse.com/show_bug.cgi?id=935965)
https://trello.com/c/q47excv8
A follow-up to #320.
It turns out that the failure the customer reported was a real problem with our earlier fix, caused by an even more uncommon setup.