### PR TITLE
Fix macro expansion in %post comment

### DIFF
--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -175,7 +175,7 @@ install -m 644 %{SOURCE2} %{buildroot}%{_unitdir}
 # only, it does not work for upgrades from SLE 11 where scripts had different
 # name and were not handled by systemd.
 # When we upgrade/update from systemd-based system, scripts are always enabled
-# by the %service_add_post macro.
+# by the service_add_post macro.
 systemctl enable YaST2-Second-Stage.service
 systemctl enable YaST2-Firstboot.service
 


### PR DESCRIPTION
rpm macros get expanded in comments as well.
This one leads to weird errors during installation,
like "Failed to execute operation: No such file or directory".