### PR TITLE
Move file from url

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ before_install:
     # disable rvm, use system Ruby
     - rvm reset
     - wget https://raw.githubusercontent.com/yast/yast-devtools/master/travis-tools/travis_setup.sh
-    - sh ./travis_setup.sh -p "rake yast2-devtools yast2-testsuite yast2-core-dev yast2 yast2-network" -g "rspec:3.3.0 yast-rake gettext rubocop:0.29.1 simplecov coveralls"
+    - sh ./travis_setup.sh -p "rake yast2-devtools yast2-testsuite yast2-core-dev yast2 yast2-network yast2-transfer" -g "rspec:3.3.0 yast-rake gettext rubocop:0.29.1 simplecov coveralls"
 script:
     - rake check:syntax
     - rake check:pot

--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Mar 14 09:39:50 UTC 2016 - igonzalezsosa@suse.com
+
+- Moved Yast::Transfer::FileFromUrl here from yast2-update
+  (FATE#319716).
+- 3.1.173
+
+-------------------------------------------------------------------
 Fri Mar  4 14:24:49 UTC 2016 - mvidner@suse.com
 
 - Added a System Role step in the installation (FATE#317481).

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation
-Version:        3.1.172
+Version:        3.1.173
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -206,6 +206,7 @@ systemctl enable YaST2-Firstboot.service
 %dir %{yast_yncludedir}/installation
 %{yast_yncludedir}/installation/*
 %{yast_libdir}/installation
+%{yast_libdir}/transfer
 
 # agents
 %{yast_scrconfdir}/etc_passwd.scr

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -103,7 +103,7 @@ desktop_DATA = \
 fillup_DATA = \
   fillup/sysconfig.security-checksig
 
-ylibdir = "${yast2dir}/lib"
+ylibdir = "${yast2dir}/lib/installation"
 ylib_DATA = \
   lib/installation/cio_ignore.rb \
   lib/installation/copy_logs_finish.rb \
@@ -113,8 +113,11 @@ ylib_DATA = \
   lib/installation/proposal_store.rb \
   lib/installation/remote_finish_client.rb \
   lib/installation/select_system_role.rb \
-  lib/installation/snapshots_finish.rb \
-	lib/transfer/file_from_url.rb
+  lib/installation/snapshots_finish.rb
+
+ylibtransferdir = "${yast2dir}/lib/transfer"
+ylibtransfer_DATA = \
+  lib/transfer/file_from_url.rb
 
 ylibclientdir = "${yast2dir}/lib/installation/clients"
 ylibclient_DATA = \
@@ -177,6 +180,6 @@ ylibclient_DATA = \
   lib/installation/clients/x11_finish.rb \
   lib/installation/clients/yast_inf_finish.rb
 
-EXTRA_DIST = $(module_DATA) $(client_DATA) $(ynclude_DATA) $(scrconf_DATA) $(schemafiles_DATA) $(desktop_DATA) $(fillup_DATA) $(ylib_DATA)
+EXTRA_DIST = $(module_DATA) $(client_DATA) $(ynclude_DATA) $(scrconf_DATA) $(schemafiles_DATA) $(desktop_DATA) $(fillup_DATA) $(ylib_DATA) $(ylibtransfer_DATA)
 
 include $(top_srcdir)/Makefile.am.common

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -103,7 +103,7 @@ desktop_DATA = \
 fillup_DATA = \
   fillup/sysconfig.security-checksig
 
-ylibdir = "${yast2dir}/lib/installation"
+ylibdir = "${yast2dir}/lib"
 ylib_DATA = \
   lib/installation/cio_ignore.rb \
   lib/installation/copy_logs_finish.rb \
@@ -113,7 +113,8 @@ ylib_DATA = \
   lib/installation/proposal_store.rb \
   lib/installation/remote_finish_client.rb \
   lib/installation/select_system_role.rb \
-  lib/installation/snapshots_finish.rb
+  lib/installation/snapshots_finish.rb \
+	lib/transfer/file_from_url.rb
 
 ylibclientdir = "${yast2dir}/lib/installation/clients"
 ylibclient_DATA = \

--- a/src/lib/transfer/file_from_url.rb
+++ b/src/lib/transfer/file_from_url.rb
@@ -1,0 +1,578 @@
+# encoding: utf-8
+
+# ------------------------------------------------------------------------------
+# Copyright (c) 2016 SUSE, LLC. All Rights Reserved.
+#
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of version 2 of the GNU General Public License as published by the
+# Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, contact SUSE.
+#
+# To contact SUSE about this file by physical or electronic mail, you may find
+# current contact information at www.suse.com.
+# ------------------------------------------------------------------------------
+
+require "yast"
+
+
+module Yast::Transfer
+  module FileFromUrl
+    include Yast
+
+    # lazy initialization
+    def initialize_file_from_url
+      return if @file_from_url_initialized
+      @file_from_url_initialized = true
+
+      textdomain "autoinst"
+
+      Yast.import "URL"
+      Yast.import "FTP"
+      Yast.import "Installation"
+      Yast.import "HTTP"
+      Yast.import "StorageDevices"
+      Yast.import "TFTP"
+      Yast.import "Storage"
+      Yast.import "InstURL"
+    end
+
+    # Basename
+    # @param string path
+    # @return [String]  basename
+    def basename(filePath)
+      pathComponents = Builtins.splitstring(filePath, "/")
+      ret = Ops.get_string(
+        pathComponents,
+        Ops.subtract(Builtins.size(pathComponents), 1),
+        ""
+      )
+      ret
+    end
+
+    # Get directory name
+    # @param string path
+    # @return  [String] dirname
+    def dirname(filePath)
+      pathComponents = Builtins.splitstring(filePath, "/")
+      last = Ops.get_string(
+        pathComponents,
+        Ops.subtract(Builtins.size(pathComponents), 1),
+        ""
+      )
+      ret = Builtins.substring(
+        filePath,
+        0,
+        Ops.subtract(Builtins.size(filePath), Builtins.size(last))
+      )
+      ret
+    end
+
+    # Copy a file from a URL to a local path
+    # The URL allows autoyast-specific schemes:
+    # https://www.suse.com/documentation/sles-12/singlehtml/book_autoyast/book_autoyast.html#Commandline.ay
+    #
+    # @param scheme    [String] cifs, nfs, device, usb, http, https, ...
+    # @param host      [String]
+    # @param urlpath   [String]
+    # @param localfile [String] destination filename
+    # @param urltok    [Hash{String => String}] same url as above, but better
+    # @param destdir   [String] chroot (with crazy juggling)
+    #
+    # @return [Boolean] true on success
+    def get_file_from_url(scheme:, host:, urlpath:, localfile:,
+                          urltok:, destdir:)
+      # adapt sane API to legacy implementation
+      _Scheme    = scheme
+      _Host      = host
+      _Path      = urlpath
+      _Localfile = localfile
+
+      initialize_file_from_url
+
+      @GET_error = ""
+      ok = false
+      res = {}
+      toks = deep_copy(urltok)
+      Ops.set(toks, "scheme", _Scheme)
+      Ops.set(toks, "host", _Host)
+      Builtins.y2milestone(
+        "Scheme:%1 Host:%2 Path:%3 Localfile:%4",
+        _Scheme,
+        _Host,
+        _Path,
+        _Localfile
+      )
+      if Builtins.regexpsub(_Path, "(.*)//(.*)", "\\1/\\2") != nil
+        _Path = Builtins.regexpsub(_Path, "(.*)//(.*)", "\\1/\\2")
+      end
+      Ops.set(toks, "path", _Path)
+      full_url = URL.Build(toks)
+
+      tmp_dir = Convert.to_string(WFM.Read(path(".local.tmpdir"), []))
+      mount_point = Ops.add(tmp_dir, "/tmp_mount")
+      mp_in_local = mount_point
+      chr = WFM.SCRGetName(WFM.SCRGetDefault)
+      if Builtins.search(chr, "chroot=/mnt:") == 0
+        mp_in_local = Ops.add(destdir, mount_point)
+      end
+      Builtins.y2milestone("Chr:%3 TmpDir:%1 Mp:%2", tmp_dir, mp_in_local, chr)
+      WFM.Execute(path(".local.mkdir"), mp_in_local)
+
+      if _Scheme == "http" || _Scheme == "https"
+        HTTP.easySSL(true)
+        if Ops.greater_than(
+            SCR.Read(
+              path(".target.size"),
+              "/etc/ssl/clientcerts/client-cert.pem"
+            ),
+            0
+          )
+          HTTP.clientCertSSL("/etc/ssl/clientcerts/client-cert.pem")
+        end
+        if Ops.greater_than(
+            SCR.Read(
+              path(".target.size"),
+              "/etc/ssl/clientcerts/client-key.pem"
+            ),
+            0
+          )
+          HTTP.clientKeySSL("/etc/ssl/clientcerts/client-key.pem")
+        end
+        res = HTTP.Get(full_url, _Localfile)
+        if Ops.get_integer(res, "code", 0) == 200
+          @GET_error = ""
+          return true
+        else
+          Builtins.y2error("Can't find URL: %1", full_url)
+          # autoyast tried to read a file but had no success.
+          @GET_error = Builtins.sformat(
+            _(
+              "Cannot find URL '%1' via protocol HTTP(S). Server returned code %2."
+            ),
+            full_url,
+            Ops.get_integer(res, "code", 0)
+          )
+          return false
+        end
+      end
+      if _Scheme == "ftp"
+        res = FTP.Get(full_url, _Localfile)
+        if Ops.greater_or_equal(Ops.get_integer(res, "code", -1), 200) &&
+            Ops.less_than(Ops.get_integer(res, "code", -1), 300) &&
+            Ops.greater_than(SCR.Read(path(".target.size"), _Localfile), 0)
+          @GET_error = ""
+          return true
+        else
+          Builtins.y2error("Can't find URL: %1", full_url)
+          # autoyast tried to read a file but had no success.
+          @GET_error = Builtins.sformat(
+            _("Cannot find URL '%1' via protocol FTP. Server returned code %2."),
+            full_url,
+            Ops.get_integer(res, "code", 0)
+          )
+          return false
+        end
+      elsif _Scheme == "file"
+        file = Builtins.sformat("%1/%2", Installation.sourcedir, _Path) # FIXME: I have doubts this will ever work. Too early.
+        if Ops.greater_than(SCR.Read(path(".target.size"), file), 0)
+          cpcmd = Builtins.sformat("cp %1 %2", file, _Localfile)
+          Builtins.y2milestone("Copy profile: %1", cpcmd)
+          SCR.Execute(path(".target.bash"), cpcmd)
+        else
+          @GET_error = Ops.add(
+            @GET_error,
+            Builtins.sformat(
+              _("Reading file on %1/%2 failed.\n"),
+              Installation.sourcedir,
+              _Path
+            )
+          )
+          cpcmd = Builtins.sformat("cp %1 %2", _Path, _Localfile)
+          Builtins.y2milestone("Copy profile: %1", cpcmd)
+          SCR.Execute(path(".target.bash"), cpcmd)
+        end
+
+        if Ops.greater_than(SCR.Read(path(".target.size"), _Localfile), 0)
+          @GET_error = ""
+          ok = true
+        else
+          @GET_error = Ops.add(
+            @GET_error,
+            Builtins.sformat(_("Reading file on %1 failed.\n"), _Path)
+          )
+          Builtins.y2milestone(
+            "Trying to find file on installation media: %1",
+            Installation.boot
+          )
+          # The Cdrom entry in install.inf is obsolete. So we are using the
+          # entry which is defined in InstUrl module. (bnc#908271)
+          install_url = InstURL.installInf2Url("")
+          # Builtins.regexpsub can also return nil (bnc#959723)
+          cdrom_device = install_url ? (Builtins.regexpsub(install_url, "devices=(.*)$", "\\1") || "") : ""
+          if Installation.boot == "cd" && !cdrom_device.empty?
+            already_mounted = Ops.add(
+              Ops.add("grep ", cdrom_device),
+              " /proc/mounts ;"
+            )
+            am = Convert.to_map(
+              SCR.Execute(path(".target.bash_output"), already_mounted)
+            )
+
+            if Ops.get_integer(am, "exit", -1) == 0 &&
+                Ops.greater_than(
+                  Builtins.size(Ops.get_string(am, "stdout", "")),
+                  0
+                )
+              Builtins.y2warning(
+                "%1 is already mounted, trying to bind mount...",
+                cdrom_device
+              )
+              cmd = Ops.add(
+                Ops.add(
+                  Ops.add(
+                    Ops.add("mount -v --bind `grep ", cdrom_device),
+                    " /proc/mounts |cut -f 2 -d \\ ` "
+                  ),
+                  mount_point
+                ),
+                ";"
+              )
+              am1 = Convert.to_map(
+                SCR.Execute(path(".target.bash_output"), cmd)
+              )
+              if Ops.get_integer(am1, "exit", -1) == 0
+                ok = true
+              else
+                Builtins.y2warning(
+                  "can't bind mount %1 failing...",
+                  cdrom_device
+                )
+                ok = false
+              end
+            else
+              try_again = 10
+              while Ops.greater_than(try_again, 0)
+                if !Convert.to_boolean(
+                    WFM.Execute(
+                      path(".local.mount"),
+                      [cdrom_device, mount_point, Installation.mountlog]
+                    )
+                  )
+                  # autoyast tried to mount the CD but had no success.
+                  @GET_error = Ops.add(
+                    @GET_error,
+                    Builtins.sformat(_("Mounting %1 failed."), cdrom)
+                  )
+                  Builtins.y2warning("Mount failed")
+                  ok = false
+                  try_again = Ops.subtract(try_again, 1)
+                  Builtins.sleep(3000)
+                else
+                  ok = true
+                  try_again = 0
+                end
+              end
+            end
+            if ok
+              cpcmd = Builtins.sformat(
+                Ops.add(Ops.add("cp ", mount_point), "/%1 %2"),
+                _Path,
+                _Localfile
+              )
+              Builtins.y2milestone("Copy profile: %1", cpcmd)
+              SCR.Execute(path(".target.bash"), cpcmd)
+              WFM.Execute(path(".local.umount"), mount_point)
+              if Ops.greater_than(SCR.Read(path(".target.size"), _Localfile), 0)
+                @GET_error = ""
+                return true
+              end
+            end
+          end
+          # autoyast tried to read a file but had no success.
+          @GET_error = Ops.add(
+            @GET_error,
+            Builtins.sformat(
+              _("Reading a file on CD failed. Path: %1/%2."),
+              mount_point,
+              _Path
+            )
+          )
+          ok = false
+        end
+      elsif _Scheme == "nfs" # NFS
+        if !Convert.to_boolean(
+            SCR.Execute(
+              path(".target.mount"),
+              [Ops.add(Ops.add(_Host, ":"), dirname(_Path)), mount_point],
+              "-o noatime,nolock"
+            )
+          ) &&
+            !Convert.to_boolean(
+              SCR.Execute(
+                path(".target.mount"),
+                [Ops.add(Ops.add(_Host, ":"), dirname(_Path)), mount_point],
+                "-o noatime -t nfs4"
+              )
+            )
+          Builtins.y2warning("Mount failed")
+          # autoyast tried to mount a NFS directory which failed
+          @GET_error = Builtins.sformat(
+            _("Mounting %1 failed."),
+            Ops.add(Ops.add(_Host, ":"), dirname(_Path))
+          )
+          return false
+        end
+
+        copyCmd = Ops.add(
+          Ops.add(
+            Ops.add(
+              Ops.add(Ops.add("/bin/cp ", mp_in_local), "/"),
+              basename(_Path)
+            ),
+            " "
+          ),
+          _Localfile
+        )
+        Builtins.y2milestone("Copy Command: %1", copyCmd)
+        if WFM.Execute(path(".local.bash"), copyCmd) == 0
+          @GET_error = ""
+          ok = true
+        else
+          # autoyast tried to copy a file via NFS which failed
+          @GET_error = Builtins.sformat(
+            _("Remote file %1 cannot be retrieved"),
+            Ops.add(Ops.add(mount_point, "/"), basename(_Path))
+          )
+          Builtins.y2error(
+            "remote file %1 can't be retrieved",
+            Ops.add(Ops.add(mount_point, "/"), basename(_Path))
+          )
+        end
+
+        SCR.Execute(path(".target.umount"), mount_point)
+      elsif _Scheme == "cifs" # CIFS
+        if !Convert.to_boolean(
+            SCR.Execute(
+              path(".target.mount"),
+              [Ops.add(Ops.add("//", _Host), dirname(_Path)), mount_point],
+              "-t cifs -o guest,ro,noatime"
+            )
+          )
+          Builtins.y2warning("Mount failed")
+          # autoyast tried to mount a NFS directory which failed
+          @GET_error = Builtins.sformat(
+            _("Mounting %1 failed."),
+            Ops.add(Ops.add("//", _Host), dirname(_Path))
+          )
+          return false
+        end
+
+        copyCmd = Ops.add(
+          Ops.add(
+            Ops.add(
+              Ops.add(Ops.add("/bin/cp ", mp_in_local), "/"),
+              basename(_Path)
+            ),
+            " "
+          ),
+          _Localfile
+        )
+        Builtins.y2milestone("Copy Command: %1", copyCmd)
+        if WFM.Execute(path(".local.bash"), copyCmd) == 0
+          @GET_error = ""
+          ok = true
+        else
+          # autoyast tried to copy a file via NFS which failed
+          @GET_error = Builtins.sformat(
+            _("Remote file %1 cannot be retrieved"),
+            Ops.add(Ops.add(mount_point, "/"), basename(_Path))
+          )
+          Builtins.y2error(
+            "remote file %1 can't be retrieved",
+            Ops.add(Ops.add(mount_point, "/"), basename(_Path))
+          )
+        end
+
+        SCR.Execute(path(".target.umount"), mount_point)
+      elsif _Scheme == "floppy"
+        if StorageDevices.FloppyReady
+          WFM.Execute(
+            path(".local.mount"),
+            [StorageDevices.FloppyDevice, mount_point]
+          )
+
+          if WFM.Execute(
+              path(".local.bash"),
+              Ops.add(
+                Ops.add(
+                  Ops.add(Ops.add(Ops.add("/bin/cp ", mount_point), "/"), _Path),
+                  " "
+                ),
+                _Localfile
+              )
+            ) != 0
+            Builtins.y2error(
+              "file  %1 can't be retrieved",
+              Ops.add(Ops.add(mount_point, "/"), _Path)
+            )
+          else
+            @GET_error = ""
+            ok = true
+          end
+          SCR.Execute(path(".target.umount"), mount_point)
+        end
+      elsif _Scheme == "device" || _Scheme == "usb" # Device or USB
+        if _Path != ""
+          deviceList = []
+          if _Host == ""
+            disks = _Scheme == "device" ?
+              Convert.convert(
+                SCR.Read(path(".probe.disk")),
+                :from => "any",
+                :to   => "list <map>"
+              ) :
+              Convert.convert(
+                SCR.Read(path(".probe.usb")),
+                :from => "any",
+                :to   => "list <map>"
+              )
+            Builtins.foreach(disks) do |m|
+              if _Scheme == "usb" && Ops.get_string(m, "bus", "USB") != "SCSI"
+                next
+              end
+              if Builtins.haskey(m, "dev_name")
+                i = 0
+                dev = Ops.get_string(m, "dev_name", "")
+                deviceList = Builtins.add(
+                  deviceList,
+                  Builtins.substring(dev, 5)
+                )
+                begin
+                  i = Ops.add(i, 1)
+                  dev = Ops.add(
+                    Ops.get_string(m, "dev_name", ""),
+                    Builtins.sformat("%1", i)
+                  )
+                  if SCR.Read(path(".target.lstat"), dev) != {}
+                    deviceList = Builtins.add(
+                      deviceList,
+                      Builtins.substring(dev, 5)
+                    )
+                  end
+                end while SCR.Read(path(".target.lstat"), dev) != {} ||
+                  Ops.less_than(i, 5) # not uncommon for USB sticks to have no partition
+              end
+            end
+            Builtins.y2milestone("devices to look on: %1", deviceList)
+          else
+            #   sometimes we have devices like /dev/cciss/c1d0p5
+            #   those "nested" devices will be catched here
+            #   as long as we find a directory where we expect a device,
+            #   we cut down the Path and enhance the Host (device name)
+            while SCR.Read(path(".target.dir"), Ops.add("/dev/", _Host)) != nil
+              Builtins.y2milestone("nested device found")
+              l = Builtins.splitstring(_Path, "/")
+              _Host = Ops.add(Ops.add(_Host, "/"), Ops.get(l, 0, ""))
+              l = Builtins.remove(l, 0)
+              _Path = Builtins.mergestring(l, "/")
+              Builtins.y2milestone("Host=%1 Path=%2", _Host, _Path)
+            end
+            # catching nested devices done
+            deviceList = [_Host]
+          end
+          Builtins.foreach(deviceList) do |_Host2|
+            Builtins.y2milestone("looking for profile on %1", _Host2)
+            # this is workaround for bnc#849767
+            # because of changes in autoyast startup this code is now
+            # called much sooner (before Storage stuff is initialized)
+            # call dummy method to trigger Storage initialization
+            dummy = Storage.GetUsedFs()
+            mp = Storage.DeviceMounted(Ops.add("/dev/", _Host2))
+            already_mounted = !Builtins.isempty(mp)
+            mount_point = mp if already_mounted
+            Builtins.y2milestone(
+              "already mounted=%1 mountpoint=%2 mp=%3",
+              already_mounted,
+              mount_point,
+              mp
+            )
+            if !already_mounted &&
+                !Convert.to_boolean(
+                  SCR.Execute(
+                    path(".target.mount"),
+                    [Builtins.sformat("/dev/%1", _Host2), mount_point],
+                    "-o noatime"
+                  )
+                )
+              Builtins.y2milestone(
+                "%1 is not mounted and mount failed",
+                Builtins.sformat("/dev/%1", _Host2)
+              )
+              @GET_error = Builtins.sformat(
+                _("%1 is not mounted and mount failed"),
+                Builtins.sformat("/dev/%1", _Host2)
+              )
+              next
+            end
+            if WFM.Execute(
+                path(".local.bash"),
+                Ops.add(
+                  Ops.add(
+                    Ops.add(
+                      Ops.add(Ops.add("/bin/cp ", mount_point), "/"),
+                      _Path
+                    ),
+                    " "
+                  ),
+                  _Localfile
+                )
+              ) != 0
+              # autoyast tried to copy a file but that file can't be found
+              @GET_error = Builtins.sformat(
+                _("File %1 cannot be found"),
+                Ops.add(mount_point, _Path)
+              )
+              Builtins.y2milestone(
+                "file %1 can't be found",
+                Ops.add(mount_point, _Path)
+              )
+            else
+              @GET_error = ""
+              ok = true
+              Builtins.y2milestone("found")
+            end
+            WFM.Execute(path(".local.umount"), mount_point) if !already_mounted
+            raise Break if ok == true
+          end
+        end
+      elsif _Scheme == "tftp" # Device
+        if TFTP.Get(_Host, _Path, _Localfile)
+          @GET_error = ""
+          ok = true
+        else
+          @GET_error = Builtins.sformat(
+            _("Cannot find URL '%1' via protocol TFTP."),
+            Ops.add(Ops.add(_Host, ":"), _Path)
+          )
+          Builtins.y2error("file %1 can't be found", _Path)
+        end
+      else
+        # the user wanted autoyast to fetch it's profile via an unknown protocol
+        @GET_error = Builtins.sformat(_("Unknown protocol %1."), _Scheme)
+        Builtins.y2error("Protocol not supported")
+        ok = false
+      end
+      if !Builtins.isempty(@GET_error)
+        Builtins.y2warning("GET_error:%1", @GET_error)
+      end
+      ok
+    end
+  end
+end

--- a/src/lib/transfer/file_from_url.rb
+++ b/src/lib/transfer/file_from_url.rb
@@ -31,7 +31,7 @@ module Yast::Transfer
       return if @file_from_url_initialized
       @file_from_url_initialized = true
 
-      textdomain "autoinst"
+      textdomain "installation"
 
       Yast.import "URL"
       Yast.import "FTP"

--- a/src/lib/transfer/file_from_url.rb
+++ b/src/lib/transfer/file_from_url.rb
@@ -21,7 +21,7 @@
 
 require "yast"
 
-
+# rubocop:disable all
 module Yast::Transfer
   module FileFromUrl
     include Yast
@@ -87,7 +87,7 @@ module Yast::Transfer
     #
     # @return [Boolean] true on success
     def get_file_from_url(scheme:, host:, urlpath:, localfile:,
-                          urltok:, destdir:)
+      urltok:, destdir:)
       # adapt sane API to legacy implementation
       _Scheme    = scheme
       _Host      = host
@@ -128,21 +128,21 @@ module Yast::Transfer
       if _Scheme == "http" || _Scheme == "https"
         HTTP.easySSL(true)
         if Ops.greater_than(
-            SCR.Read(
-              path(".target.size"),
-              "/etc/ssl/clientcerts/client-cert.pem"
-            ),
-            0
-          )
+          SCR.Read(
+            path(".target.size"),
+            "/etc/ssl/clientcerts/client-cert.pem"
+          ),
+          0
+        )
           HTTP.clientCertSSL("/etc/ssl/clientcerts/client-cert.pem")
         end
         if Ops.greater_than(
-            SCR.Read(
-              path(".target.size"),
-              "/etc/ssl/clientcerts/client-key.pem"
-            ),
-            0
-          )
+          SCR.Read(
+            path(".target.size"),
+            "/etc/ssl/clientcerts/client-key.pem"
+          ),
+          0
+        )
           HTTP.clientKeySSL("/etc/ssl/clientcerts/client-key.pem")
         end
         res = HTTP.Get(full_url, _Localfile)
@@ -260,11 +260,11 @@ module Yast::Transfer
               try_again = 10
               while Ops.greater_than(try_again, 0)
                 if !Convert.to_boolean(
-                    WFM.Execute(
-                      path(".local.mount"),
-                      [cdrom_device, mount_point, Installation.mountlog]
-                    )
+                  WFM.Execute(
+                    path(".local.mount"),
+                    [cdrom_device, mount_point, Installation.mountlog]
                   )
+                )
                   # autoyast tried to mount the CD but had no success.
                   @GET_error = Ops.add(
                     @GET_error,
@@ -308,12 +308,12 @@ module Yast::Transfer
         end
       elsif _Scheme == "nfs" # NFS
         if !Convert.to_boolean(
-            SCR.Execute(
-              path(".target.mount"),
-              [Ops.add(Ops.add(_Host, ":"), dirname(_Path)), mount_point],
-              "-o noatime,nolock"
-            )
-          ) &&
+          SCR.Execute(
+            path(".target.mount"),
+            [Ops.add(Ops.add(_Host, ":"), dirname(_Path)), mount_point],
+            "-o noatime,nolock"
+          )
+        ) &&
             !Convert.to_boolean(
               SCR.Execute(
                 path(".target.mount"),
@@ -359,12 +359,12 @@ module Yast::Transfer
         SCR.Execute(path(".target.umount"), mount_point)
       elsif _Scheme == "cifs" # CIFS
         if !Convert.to_boolean(
-            SCR.Execute(
-              path(".target.mount"),
-              [Ops.add(Ops.add("//", _Host), dirname(_Path)), mount_point],
-              "-t cifs -o guest,ro,noatime"
-            )
+          SCR.Execute(
+            path(".target.mount"),
+            [Ops.add(Ops.add("//", _Host), dirname(_Path)), mount_point],
+            "-t cifs -o guest,ro,noatime"
           )
+        )
           Builtins.y2warning("Mount failed")
           # autoyast tried to mount a NFS directory which failed
           @GET_error = Builtins.sformat(
@@ -409,15 +409,15 @@ module Yast::Transfer
           )
 
           if WFM.Execute(
-              path(".local.bash"),
+            path(".local.bash"),
+            Ops.add(
               Ops.add(
-                Ops.add(
-                  Ops.add(Ops.add(Ops.add("/bin/cp ", mount_point), "/"), _Path),
-                  " "
-                ),
-                _Localfile
-              )
-            ) != 0
+                Ops.add(Ops.add(Ops.add("/bin/cp ", mount_point), "/"), _Path),
+                " "
+              ),
+              _Localfile
+            )
+          ) != 0
             Builtins.y2error(
               "file  %1 can't be retrieved",
               Ops.add(Ops.add(mount_point, "/"), _Path)
@@ -435,13 +435,13 @@ module Yast::Transfer
             disks = _Scheme == "device" ?
               Convert.convert(
                 SCR.Read(path(".probe.disk")),
-                :from => "any",
-                :to   => "list <map>"
+                from: "any",
+                to:   "list <map>"
               ) :
               Convert.convert(
                 SCR.Read(path(".probe.usb")),
-                :from => "any",
-                :to   => "list <map>"
+                from: "any",
+                to:   "list <map>"
               )
             Builtins.foreach(disks) do |m|
               if _Scheme == "usb" && Ops.get_string(m, "bus", "USB") != "SCSI"
@@ -522,18 +522,18 @@ module Yast::Transfer
               next
             end
             if WFM.Execute(
-                path(".local.bash"),
+              path(".local.bash"),
+              Ops.add(
                 Ops.add(
                   Ops.add(
-                    Ops.add(
-                      Ops.add(Ops.add("/bin/cp ", mount_point), "/"),
-                      _Path
-                    ),
-                    " "
+                    Ops.add(Ops.add("/bin/cp ", mount_point), "/"),
+                    _Path
                   ),
-                  _Localfile
-                )
-              ) != 0
+                  " "
+                ),
+                _Localfile
+              )
+            ) != 0
               # autoyast tried to copy a file but that file can't be found
               @GET_error = Builtins.sformat(
                 _("File %1 cannot be found"),

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -4,6 +4,7 @@ TESTS = \
   image_installation_test.rb \
   cio_ignore_test.rb \
   copy_logs_finish_test.rb \
+	file_from_url_test.rb \
   prep_shrink_test.rb \
   proposal_store_test.rb \
   proposal_runner_test.rb \

--- a/test/file_from_url_test.rb
+++ b/test/file_from_url_test.rb
@@ -1,0 +1,184 @@
+#!/usr/bin/env rspec
+
+require_relative "test_helper"
+
+require "transfer/file_from_url"
+
+describe Yast::Transfer::FileFromUrl do
+  class FileFromUrlTest
+    include Yast::I18n
+    include Yast::Transfer::FileFromUrl
+
+    # adaptor for existing tests
+    def Get(scheme, host, urlpath, localfile)
+      get_file_from_url(scheme: scheme, host: host, urlpath: urlpath,
+                        localfile: localfile,
+                        urltok: {}, destdir: "/destdir")
+    end
+  end
+
+  # avoid BuildRequiring a package that we stub entirely anyway
+  Yast::Storage = nil
+  Yast::StorageDevices = nil
+  before do
+    allow(Yast).to receive(:import).and_call_original
+    allow(Yast).to receive(:import).with("Storage").and_return true
+    allow(Yast).to receive(:import).with("StorageDevices").and_return true
+  end
+
+  subject { FileFromUrlTest.new }
+
+  describe "#Get" do
+    before do
+      expect(Yast::WFM).to receive(:Read)
+        .and_return("/tmp_dir")
+      expect(Yast::WFM).to receive(:SCRGetDefault)
+        .and_return(333)
+      expect(Yast::WFM).to receive(:SCRGetName).with(333)
+        .and_return("chroot=/mnt:scr")
+      expect(Yast::WFM).to receive(:Execute)
+        .with(path(".local.mkdir"), "/destdir/tmp_dir/tmp_mount")
+      # the local/target mess was last modified in
+      # https://github.com/yast/yast-autoinstallation/commit/69f1966dd1456301a69102c6d3bacfe7c9f9dc49
+      # for https://bugzilla.suse.com/show_bug.cgi?id=829265
+    end
+
+    it "returns false for unknown scheme" do
+      expect(subject.Get("money_transfer_protocol",
+                         "bank", "account", "pocket")).to eq(false)
+    end
+
+    context "when scheme is 'device'" do
+      let(:scheme) { "device" }
+
+      it "returns false for an empty path" do
+        expect(subject.Get(scheme, "sda", "", "/localfile")).to eq(false)
+      end
+
+      context "when host is empty" do
+        let(:host) { "" }
+
+        it "probes disks" do
+          probed_disks = [
+            {},
+            { "dev_name" => "/dev/sda" },
+            { "dev_name" => "/dev/sdb" }
+          ]
+
+          expect(Yast::SCR).to receive(:Read)
+            .with(path(".probe.disk"))
+            .and_return(probed_disks)
+
+          lstat_mocks = {
+            "/dev/sda1" => true,
+            "/dev/sda2" => false,
+            "/dev/sda3" => false,
+            "/dev/sda4" => true,
+            "/dev/sda5" => true,
+            "/dev/sda6" => false,
+
+            "/dev/sdb1" => true,
+            "/dev/sdb2" => false,
+            "/dev/sdb3" => false,
+            "/dev/sdb4" => false,
+            "/dev/sdb5" => false
+          }
+
+          lstat_mocks.each do |device, exists|
+            expect(Yast::SCR).to receive(:Read)
+              .with(path(".target.lstat"), device).twice
+              .and_return(exists ? { "size" => 1 } : {})
+          end
+
+          allow(Yast::SCR).to receive(:Dir)
+            .with(path(".product.features.section")).and_return([])
+
+          # only up to sda5 because that is when we find the file
+          mount_points = {
+            # device    => [prior mount point, temporary mount point]
+            "/dev/sda"  => ["",          "/tmp_dir/tmp_mount"],
+            "/dev/sda1" => ["/mnt_sda1", nil],
+            "/dev/sda4" => ["",          "/mnt_sda1"],
+            "/dev/sda5" => ["",          "/mnt_sda1"]
+          }
+
+          expect(Yast::Storage).to receive(:GetUsedFs).at_least(:once)
+
+          mount_points.each do |device, mp|
+            expect(Yast::Storage).to receive(:DeviceMounted)
+              .with(device).and_return(mp.first)
+          end
+
+          # only up to sda5 because that is when we find the file
+          mount_succeeded = {
+            "/dev/sda"  => false,
+            "/dev/sda4" => true,
+            "/dev/sda5" => true,
+          }
+
+          mount_succeeded.each do |device, result|
+            expect(Yast::SCR).to receive(:Execute)
+              .with(path(".target.mount"),
+                    [device, mount_points[device].last],
+                    "-o noatime")
+              .and_return(result)
+          end
+
+          expect(Yast::WFM).to receive(:Execute)
+            .with(path(".local.bash"),
+                  "/bin/cp /mnt_sda1/mypath /localfile")
+            .exactly(3).times
+            .and_return(1, 1, 0) # sda1 fails, sda4 fails, sda5 succeeds
+
+          expect(Yast::WFM).to receive(:Execute)
+            .with(path(".local.bash"),
+#                  "/bin/cp /destdir/tmp_dir/tmp_mount/mypath /localfile")
+# Bug: it is wrong if destdir is used
+                  "/bin/cp /tmp_dir/tmp_mount/mypath /localfile")
+            .exactly(0).times
+#            .and_return(1, 0)   # sda4 fails, sda5 succeeds
+
+# Bug: local is wrong. nfs and cifs correctly use .target.umount
+          expect(Yast::WFM).to receive(:Execute)
+            .with(path(".local.umount"), "/mnt_sda1")
+            .exactly(2).times
+
+          # DO IT, this is the call that needs all the above mocking
+          expect(subject.Get(scheme, host, "mypath", "/localfile"))
+            .to eq(true)
+        end
+
+      end
+
+      context "when host specifies a device" do
+      end
+
+      context "when host+path specify a device" do
+      end
+    end
+
+    context "when scheme is 'usb'" do
+      let(:scheme) { "usb" }
+
+      it "returns false for an empty path" do
+        expect(subject.Get(scheme, "sda", "", "/localfile")).to eq(false)
+      end
+    end
+
+    # not yet covered
+    context "when scheme is 'http' or 'https'" do
+    end
+    context "when scheme is 'ftp'" do
+    end
+    context "when scheme is 'file'" do
+    end
+    context "when scheme is 'nfs'" do
+    end
+    context "when scheme is 'cifs'" do
+    end
+    context "when scheme is 'floppy'" do
+    end
+    context "when scheme is 'tftp'" do
+    end
+  end
+end

--- a/test/file_from_url_test.rb
+++ b/test/file_from_url_test.rb
@@ -18,6 +18,7 @@ describe Yast::Transfer::FileFromUrl do
   end
 
   # avoid BuildRequiring a package that we stub entirely anyway
+  # rubocop:disable ConstantName
   Yast::Storage = nil
   Yast::StorageDevices = nil
   before do
@@ -45,7 +46,7 @@ describe Yast::Transfer::FileFromUrl do
 
     it "returns false for unknown scheme" do
       expect(subject.Get("money_transfer_protocol",
-                         "bank", "account", "pocket")).to eq(false)
+        "bank", "account", "pocket")).to eq(false)
     end
 
     context "when scheme is 'device'" do
@@ -113,32 +114,32 @@ describe Yast::Transfer::FileFromUrl do
           mount_succeeded = {
             "/dev/sda"  => false,
             "/dev/sda4" => true,
-            "/dev/sda5" => true,
+            "/dev/sda5" => true
           }
 
           mount_succeeded.each do |device, result|
             expect(Yast::SCR).to receive(:Execute)
               .with(path(".target.mount"),
-                    [device, mount_points[device].last],
-                    "-o noatime")
+                [device, mount_points[device].last],
+                "-o noatime")
               .and_return(result)
           end
 
           expect(Yast::WFM).to receive(:Execute)
             .with(path(".local.bash"),
-                  "/bin/cp /mnt_sda1/mypath /localfile")
+              "/bin/cp /mnt_sda1/mypath /localfile")
             .exactly(3).times
             .and_return(1, 1, 0) # sda1 fails, sda4 fails, sda5 succeeds
 
           expect(Yast::WFM).to receive(:Execute)
             .with(path(".local.bash"),
-#                  "/bin/cp /destdir/tmp_dir/tmp_mount/mypath /localfile")
-# Bug: it is wrong if destdir is used
-                  "/bin/cp /tmp_dir/tmp_mount/mypath /localfile")
+              #                  "/bin/cp /destdir/tmp_dir/tmp_mount/mypath /localfile")
+              # Bug: it is wrong if destdir is used
+              "/bin/cp /tmp_dir/tmp_mount/mypath /localfile")
             .exactly(0).times
-#            .and_return(1, 0)   # sda4 fails, sda5 succeeds
+          #            .and_return(1, 0)   # sda4 fails, sda5 succeeds
 
-# Bug: local is wrong. nfs and cifs correctly use .target.umount
+          # Bug: local is wrong. nfs and cifs correctly use .target.umount
           expect(Yast::WFM).to receive(:Execute)
             .with(path(".local.umount"), "/mnt_sda1")
             .exactly(2).times


### PR DESCRIPTION
Moves `Transfer::FileFromUrl` from yast-update to yast-installation, as it's needed by #347. More information in https://github.com/yast/yast-update/pull/53 which moved it from AutoYaST2 to yast2-update.