### PR TITLE
Changing the system role may undo adjustments you may have done.

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Mar 14 13:09:52 UTC 2016 - mvidner@suse.com
+
+- System Role: align labels (FATE#317481).
+- System Role: pop-up if changing the role to a different one.
+- 3.1.174
+
+-------------------------------------------------------------------
 Mon Mar 14 09:39:50 UTC 2016 - igonzalezsosa@suse.com
 
 - Moved Yast::Transfer::FileFromUrl here from yast2-update

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation
-Version:        3.1.173
+Version:        3.1.174
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/installation/select_system_role.rb
+++ b/src/lib/installation/select_system_role.rb
@@ -80,7 +80,7 @@ module Installation
       if !orig_role_id.nil? && orig_role_id != role_id
         # A Continue-Cancel popup
         msg = _("Changing the system role may undo adjustments you may have done.")
-        Yast::Popup.ContinueCancel(msg) || return
+        return unless Yast::Popup.ContinueCancel(msg)
       end
       self.class.original_role_id = role_id
 

--- a/src/lib/installation/select_system_role.rb
+++ b/src/lib/installation/select_system_role.rb
@@ -56,7 +56,7 @@ module Installation
       ui_roles = role_attributes.each_with_object(VBox()) do |r, vbox|
         vbox << Left(RadioButton(Id(r[:id]), r[:label]))
         vbox << HBox(
-          HSpacing(4),
+          HSpacing(Yast::UI.TextMode ? 4 : 2),
           Left(Label(r[:description]))
         )
         vbox << VSpacing(2)

--- a/test/select_system_role_test.rb
+++ b/test/select_system_role_test.rb
@@ -65,8 +65,8 @@ describe ::Installation::SelectSystemRole do
         expect(subject.run).to eq(:back)
       end
 
-      context "when re-selecting a role" do
-        it "just proceeds on the same role" do
+      context "when re-selecting the same role" do
+        it "just proceeds without a popup" do
           subject.class.original_role_id = "foo"
 
           allow(Yast::Wizard).to receive(:SetContents)
@@ -82,8 +82,10 @@ describe ::Installation::SelectSystemRole do
 
           expect(subject.run).to eq(:next)
         end
+      end
 
-        it "displays popup, and proceeds on Continue" do
+      context "when re-selecting a different role" do
+        it "displays a popup, and proceeds if Continue is answered" do
           subject.class.original_role_id = "bar"
 
           allow(Yast::Wizard).to receive(:SetContents)
@@ -101,7 +103,7 @@ describe ::Installation::SelectSystemRole do
           expect(subject.run).to eq(:next)
         end
 
-        it "displays popup, and stays on Cancel" do
+        it "displays a popup, and does not proceed if Cancel is answered" do
           subject.class.original_role_id = "bar"
 
           allow(Yast::Wizard).to receive(:SetContents)

--- a/test/select_system_role_test.rb
+++ b/test/select_system_role_test.rb
@@ -64,6 +64,60 @@ describe ::Installation::SelectSystemRole do
 
         expect(subject.run).to eq(:back)
       end
+
+      context "when re-selecting a role" do
+        it "just proceeds on the same role" do
+          subject.class.original_role_id = "foo"
+
+          allow(Yast::Wizard).to receive(:SetContents)
+          allow(Yast::UI).to receive(:UserInput)
+            .and_return(:next)
+          allow(Yast::UI).to receive(:QueryWidget)
+            .with(Id(:roles), :CurrentButton).and_return("foo")
+
+          expect(Yast::Popup).to_not receive(:ContinueCancel)
+
+          expect(Yast::ProductFeatures).to receive(:ClearOverlay)
+          expect(Yast::ProductFeatures).to receive(:SetOverlay)
+
+          expect(subject.run).to eq(:next)
+        end
+
+        it "displays popup, and proceeds on Continue" do
+          subject.class.original_role_id = "bar"
+
+          allow(Yast::Wizard).to receive(:SetContents)
+          allow(Yast::UI).to receive(:UserInput)
+            .and_return(:next)
+          allow(Yast::UI).to receive(:QueryWidget)
+            .with(Id(:roles), :CurrentButton).and_return("foo")
+
+          expect(Yast::Popup).to receive(:ContinueCancel)
+            .and_return(true)
+
+          expect(Yast::ProductFeatures).to receive(:ClearOverlay)
+          expect(Yast::ProductFeatures).to receive(:SetOverlay)
+
+          expect(subject.run).to eq(:next)
+        end
+
+        it "displays popup, and stays on Cancel" do
+          subject.class.original_role_id = "bar"
+
+          allow(Yast::Wizard).to receive(:SetContents)
+          allow(Yast::UI).to receive(:UserInput)
+            .and_return(:next, :back)
+          allow(Yast::UI).to receive(:QueryWidget)
+            .with(Id(:roles), :CurrentButton).and_return("foo")
+
+          expect(Yast::Popup).to receive(:ContinueCancel)
+            .and_return(false)
+          expect(Yast::ProductFeatures).to receive(:ClearOverlay)
+          expect(Yast::ProductFeatures).to_not receive(:SetOverlay)
+
+          expect(subject.run).to eq(:back)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
A missing piece to complete https://trello.com/c/0mOtUy45/467-8-sle-12-sp2-p4-m-feature-317481-add-system-role-capabilities-to-installer , continuing #340.