### PR TITLE
Self update takes place before searching for system files

### DIFF
--- a/src/lib/installation/clients/inst_system_analysis.rb
+++ b/src/lib/installation/clients/inst_system_analysis.rb
@@ -124,6 +124,11 @@ module Yast
         WFM.CallFunction("inst_features", [])
       end
 
+      # FATE #319716: Installer self-update
+      actions_todo      << _("Update Installer")
+      actions_doing     << _("Updating installer...")
+      actions_functions << fun_ref(method(:update_installer), "boolean ()")
+
       # FATE #302980: Simplified user config during installation
       actions_todo      << _("Search for system files")
       actions_doing     << _("Searching for system files...")
@@ -132,10 +137,6 @@ module Yast
       actions_todo      << _("Initialize software manager")
       actions_doing     << _("Initializing software manager...")
       actions_functions << fun_ref(method(:InitInstallationRepositories), "boolean ()")
-
-      actions_todo      << _("Update Installer")
-      actions_doing     << _("Updating installer...")
-      actions_functions << fun_ref(method(:update_installer), "boolean ()")
 
       Progress.New(
         # TRANSLATORS: dialog caption

--- a/src/lib/installation/clients/inst_update_installer.rb
+++ b/src/lib/installation/clients/inst_update_installer.rb
@@ -184,9 +184,7 @@ module Yast
     def apply_update
       return false unless applicable?
       log.info("Applying installer updates")
-      Popup.Feedback(_("YaST update"), _("Applying installer updates")) do
-        updates_manager.apply_all
-      end
+      updates_manager.apply_all
       true
     end
 


### PR DESCRIPTION
Reviewing the workflow, it looks like the best moment to search for an update is right after USB, FireWire and hard disks are initialized:

* Probe USB devices
* Probe FireWire devices
* Probe floppy disk devices
* Probe hard disks controllers
* Load kernel modules for hard disk controllers
* Probe hard disks
* **Update Installer** <- USB, floppy and hard disks are initialized
* Search for system files
* Initialize software manager

There's no point in searching for system files or initializing the software manager if we need to update the installer later. So I would prefer to update the system before those tasks are executed.