### PR TITLE
Remove an extra popup during installer update

### DIFF
--- a/src/lib/installation/clients/inst_update_installer.rb
+++ b/src/lib/installation/clients/inst_update_installer.rb
@@ -184,9 +184,7 @@ module Yast
     def apply_update
       return false unless applicable?
       log.info("Applying installer updates")
-      Popup.Feedback(_("YaST update"), _("Applying installer updates")) do
-        updates_manager.apply_all
-      end
+      updates_manager.apply_all
       true
     end
 


### PR DESCRIPTION
Part of https://trello.com/c/LoAaDF97/468-8-sle-12-sp2-p1a-m-feature-319716-automatic-update-of-yast-at-beginning-of-the-installation

As it's shown as another step in the system analysis, I guess we should remove this popup (it's a leftover from the previous UI).