### PR TITLE
Fixed spec file

### DIFF
--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -216,7 +216,6 @@ systemctl enable YaST2-Firstboot.service
 %{yast_scrconfdir}/etc_install_inf.scr
 %{yast_scrconfdir}/etc_install_inf_alias.scr
 %{yast_scrconfdir}/etc_install_inf_options.scr
-%{yast_scrconfdir}/proc_modules.scr
 %{yast_scrconfdir}/run_df.scr
 # fillup
 /var/adm/fillup-templates/sysconfig.security-checksig


### PR DESCRIPTION
This is a fix up for the previous PR #357, the `proc_modules.scr` file has been moved to yast2 but the spec file was not updated.

Unfortunately not found by Travis as we do not build the package there, found by Jenkins later...