### PR TITLE
Unifying network button position in activation of disks client. (FATE#319716)

### DIFF
--- a/src/lib/installation/clients/inst_disks_activate.rb
+++ b/src/lib/installation/clients/inst_disks_activate.rb
@@ -170,7 +170,7 @@ module Yast
   private
 
     def network_button
-      Right(PushButton(Id(:network), _("Network Configuration...")))
+      Right(PushButton(Id(:network), _("Net&work Configuration...")))
     end
 
     def show_base_dialog

--- a/src/lib/installation/clients/inst_disks_activate.rb
+++ b/src/lib/installation/clients/inst_disks_activate.rb
@@ -100,19 +100,20 @@ module Yast
                     missing_part
                   end
 
-      @contents = HBox(
-        HWeight(999, HStretch()),
+      @contents =
         VBox(
+          network_button,
           VStretch(),
-          *dasd_part,
-          *zfcp_part,
-          *fcoe_part,
-          *(button_with_spacing(:iscsi, _("Configure &iSCSI Disks"))),
-          button(:network, _("Change Net&work Configuration")),
+          HSquash(
+            VBox(
+              *dasd_part,
+              *zfcp_part,
+              *fcoe_part,
+              *(button_with_spacing(:iscsi, _("Configure &iSCSI Disks")))
+            )
+          ),
           VStretch()
-        ),
-        HWeight(999, HStretch())
-      )
+        )
 
       @disks_changed = false
 
@@ -167,6 +168,10 @@ module Yast
     end
 
   private
+
+    def network_button
+      Right(PushButton(Id(:network), _("Network Configuration...")))
+    end
 
     def show_base_dialog
       Wizard.SetContents(

--- a/test/inst_disks_activate_test.rb
+++ b/test/inst_disks_activate_test.rb
@@ -1,0 +1,90 @@
+#!/usr/bin/env rspec
+
+require_relative "test_helper"
+require "installation/clients/inst_disks_activate"
+
+describe Yast::InstDisksActivateClient do
+  Yast.import "Arch"
+  Yast.import "Linuxrc"
+  Yast.import "ProductFeatures"
+  Yast.import "GetInstArgs"
+  Yast.import "UI"
+  Yast.import "Popup"
+
+  describe "#main" do
+    let(:probed_disks) { [] }
+
+    before do
+      allow(Yast::Linuxrc).to receive(:InstallInf).with("WithFCoE").and_return("0")
+      allow(Yast::UI).to receive(:OpenDialog)
+      allow(Yast::UI).to receive(:CloseDialog)
+      allow(Yast::Popup).to receive(:ConfirmAbort).with(:painless).and_return(true)
+    end
+
+    context "when architecture is s390" do
+      before do
+        allow(Yast::UI).to receive(:UserInput).and_return(:abort)
+        allow(Yast::Arch).to receive(:s390).and_return(true)
+      end
+
+      it "detects DASD disks" do
+        expect(Yast::SCR).to receive(:Read).with(path(".probe.disk"))
+          .and_return(probed_disks)
+        allow(Yast::SCR).to receive(:Read).with(path(".probe.storage"))
+          .and_return(probed_disks)
+        expect(subject).to receive(:show_base_dialog)
+
+        expect(subject.main).to eq(:abort)
+      end
+
+      it "detects zFCP disks" do
+        allow(Yast::SCR).to receive(:Read).with(path(".probe.disk"))
+          .and_return(probed_disks)
+        expect(Yast::SCR).to receive(:Read).with(path(".probe.storage"))
+          .and_return(probed_disks)
+        expect(subject).to receive(:show_base_dialog)
+
+        expect(subject.main).to eq(:abort)
+      end
+
+      context "when dasd button is clicked" do
+        before do
+          allow(Yast::UI).to receive(:UserInput).and_return(:dasd, :abort)
+        end
+
+        it "calls inst_dasd client" do
+          expect(Yast::WFM).to receive(:call).with("inst_dasd")
+          expect(subject).to receive(:show_base_dialog).twice
+
+          subject.main
+        end
+      end
+
+      context "when network button is clicked" do
+        before do
+          allow(Yast::UI).to receive(:UserInput).and_return(:network, :abort)
+        end
+
+        it "calls inst_lan client" do
+          expect(Yast::WFM).to receive(:call).with("inst_lan", ["skip_detection" => true])
+          expect(subject).to receive(:show_base_dialog).twice
+
+          subject.main
+        end
+      end
+
+      context "when abort button is clicked" do
+        before do
+          allow(Yast::UI).to receive(:UserInput).and_return(:abort)
+        end
+
+        it "returns :abort" do
+          expect(subject).to receive(:show_base_dialog).once
+
+          expect(subject.main).to eq(:abort)
+        end
+      end
+
+    end
+  end
+end

--- a/test/inst_disks_activate_test.rb
+++ b/test/inst_disks_activate_test.rb
@@ -10,21 +10,25 @@ describe Yast::InstDisksActivateClient do
   Yast.import "GetInstArgs"
   Yast.import "UI"
   Yast.import "Popup"
+  Yast.import "Storage"
 
   describe "#main" do
     let(:probed_disks) { [] }
+    let(:s390) { false }
 
     before do
       allow(Yast::Linuxrc).to receive(:InstallInf).with("WithFCoE").and_return("0")
       allow(Yast::UI).to receive(:OpenDialog)
       allow(Yast::UI).to receive(:CloseDialog)
       allow(Yast::Popup).to receive(:ConfirmAbort).with(:painless).and_return(true)
+      allow(Yast::Arch).to receive(:s390).and_return(s390)
+      allow(Yast::Storage).to receive(:ReReadTargetMap)
     end
 
     context "when architecture is s390" do
+      let(:s390) { true }
       before do
         allow(Yast::UI).to receive(:UserInput).and_return(:abort)
-        allow(Yast::Arch).to receive(:s390).and_return(true)
       end
 
       it "detects DASD disks" do
@@ -46,45 +50,44 @@ describe Yast::InstDisksActivateClient do
 
         expect(subject.main).to eq(:abort)
       end
+    end
 
-      context "when dasd button is clicked" do
-        before do
-          allow(Yast::UI).to receive(:UserInput).and_return(:dasd, :abort)
-        end
-
-        it "calls inst_dasd client" do
-          expect(Yast::WFM).to receive(:call).with("inst_dasd")
-          expect(subject).to receive(:show_base_dialog).twice
-
-          subject.main
-        end
+    context "when dasd button is clicked" do
+      before do
+        allow(Yast::UI).to receive(:UserInput).and_return(:dasd, :abort)
       end
 
-      context "when network button is clicked" do
-        before do
-          allow(Yast::UI).to receive(:UserInput).and_return(:network, :abort)
-        end
+      it "calls inst_dasd client" do
+        expect(Yast::WFM).to receive(:call).with("inst_dasd")
+        expect(subject).to receive(:show_base_dialog).twice
 
-        it "calls inst_lan client" do
-          expect(Yast::WFM).to receive(:call).with("inst_lan", ["skip_detection" => true])
-          expect(subject).to receive(:show_base_dialog).twice
+        subject.main
+      end
+    end
 
-          subject.main
-        end
+    context "when network button is clicked" do
+      before do
+        allow(Yast::UI).to receive(:UserInput).and_return(:network, :abort)
       end
 
-      context "when abort button is clicked" do
-        before do
-          allow(Yast::UI).to receive(:UserInput).and_return(:abort)
-        end
+      it "calls inst_lan client" do
+        expect(Yast::WFM).to receive(:call).with("inst_lan", ["skip_detection" => true])
+        expect(subject).to receive(:show_base_dialog).twice
 
-        it "returns :abort" do
-          expect(subject).to receive(:show_base_dialog).once
+        subject.main
+      end
+    end
 
-          expect(subject.main).to eq(:abort)
-        end
+    context "when abort button is clicked" do
+      before do
+        allow(Yast::UI).to receive(:UserInput).and_return(:abort)
       end
 
+      it "returns :abort" do
+        expect(subject).to receive(:show_base_dialog).once
+
+        expect(subject.main).to eq(:abort)
+      end
     end
   end
 end


### PR DESCRIPTION
I had unified the distribution of `[Network Configuration]` button.

**Previous**
![diskactivation](https://cloud.githubusercontent.com/assets/7056681/14308707/b6a17d04-fbcf-11e5-9eb1-ab5b28c76826.png)

**Now**
![diskactivationnet](https://cloud.githubusercontent.com/assets/7056681/14313064/61cbd62c-fbe7-11e5-8e53-bf0ce51abaf5.png)
