### PR TITLE
Support for self update in AY mode

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Fri Apr 15 12:51:00 UTC 2016 - lslezak@suse.cz
+
+- Run the automatic installer self update also in the AutoYaST
+  mode, read the optional custom URL from the profile ("general" ->
+  "self_update_url" node) (FATE#319716)
+- 3.1.180
+
+-------------------------------------------------------------------
 Wed Apr 13 07:14:09 UTC 2016 - mfilka@suse.com
 
 - bsc#956473

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation
-Version:        3.1.179
+Version:        3.1.180
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/installation/clients/inst_update_installer.rb
+++ b/src/lib/installation/clients/inst_update_installer.rb
@@ -34,6 +34,7 @@ module Yast
     Yast.import "Popup"
     Yast.import "Report"
     Yast.import "NetworkService"
+    Yast.import "Mode"
 
     def main
       textdomain "installation"
@@ -82,8 +83,10 @@ module Yast
     #
     # @see #self_update_url_from_linuxrc
     # @see #self_update_url_from_control
+    # @see #self_update_url_from_profile
     def self_update_url
-      url = self_update_url_from_linuxrc || self_update_url_from_control
+      url = self_update_url_from_linuxrc || self_update_url_from_profile ||
+        self_update_url_from_control
       log.info("self-update URL is #{url}")
       url
     end
@@ -99,6 +102,19 @@ module Yast
     #
     def self_update_url_from_control
       get_url_from(ProductFeatures.GetStringFeature("globals", "self_update_url"))
+    end
+
+    # Return the self-update URL from the AutoYaST profile
+    # @return [URI,nil] the self-update URL, nil if not running in AutoYaST mode
+    #   or when the URL is not defined in the profile
+    def self_update_url_from_profile
+      return nil unless Mode.auto
+
+      Yast.import "Profile"
+      profile = Yast::Profile.current
+      profile_url = profile.fetch("general", {})["self_update_url"]
+
+      get_url_from(profile_url)
     end
 
     # Converts the string into an URI if it's valid

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,10 +11,20 @@ module Yast
   class AutoinstConfigClass
     # we need at least one non-default methods, otherwise ruby-bindings thinks
     # it is just namespace
-    def fake_method
+    def cio_ignore
+    end
+
+    def second_stage
     end
   end
   AutoinstConfig = AutoinstConfigClass.new
+
+  # Faked Profile module
+  class Profile
+    def current
+    end
+  end
+  Profile = Profile.new
 end
 
 if ENV["COVERAGE"]


### PR DESCRIPTION
Extends #352, #356 also to AutoYaST mode.

See [FATE#319716](https://fate.suse.com/319716).

The AY profile schema is updated in https://github.com/yast/yast-autoinstallation/pull/206.