### PR TITLE
Ruby debugger integration (FATE#318421)

### DIFF
--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -26,7 +26,8 @@ Source0:        %{name}-%{version}.tar.bz2
 Group:          System/YaST
 License:        GPL-2.0
 Url:            http://github.com/yast/yast-installation
-Requires:       yast2-ruby-bindings >= 3.1.8
+# yast/debugger
+Requires:       yast2-ruby-bindings >= 3.1.47
 
 Summary:        YaST2 - Installation Parts
 

--- a/src/lib/installation/clients/installation.rb
+++ b/src/lib/installation/clients/installation.rb
@@ -47,18 +47,8 @@ module Yast
       UI.SetProductLogo(true)
       Wizard.OpenLeftTitleNextBackDialog
 
-      # start the debugger if required (FATE#318421)
-      if (Linuxrc.InstallInf("Cmdline") || "").match(/\bY2DEBUGGER=(.*)\b/i)
-        option = Regexp.last_match[1]
-        log.info "Y2DEBUGGER option: #{option}"
-
-        if option == "1" || option == "remote" || option == "manual"
-          require "yast/debugger"
-          Debugger.start(remote: option == "remote", start_client: option != "manual")
-        else
-          log.warn "Unknown Y2DEBUGGER value: #{option}"
-        end
-      end
+      # start the debugger if requested (FATE#318421)
+      start_debugger
 
       Wizard.SetContents(
         # title
@@ -113,6 +103,23 @@ module Yast
       WFM.CallFunction("disintegrate_all_extensions") if Stage.initial
 
       deep_copy(@ret)
+    end
+
+  private
+
+    # start the Ruby debugger if booted with the Y2DEBUGGER option
+    def start_debugger
+      return unless (Linuxrc.InstallInf("Cmdline") || "").match(/\bY2DEBUGGER=(.*)\b/i)
+
+      option = Regexp.last_match[1]
+      log.info "Y2DEBUGGER option: #{option}"
+
+      if option == "1" || option == "remote" || option == "manual"
+        require "yast/debugger"
+        Debugger.start(remote: option == "remote", start_client: option != "manual")
+      else
+        log.warn "Unknown Y2DEBUGGER value: #{option}"
+      end
     end
   end
 end


### PR DESCRIPTION
Optionally start the Ruby debugger at the beginning of installation. The debugger is started using `Y2DEBUGGER` boot option.

*Note: the debugger invocation is implemented here: https://github.com/yast/yast-ruby-bindings/pull/167*

The supported modes are:

- `Y2DEBUGGER=1` - enable the debugger, in Qt UI the debugger frontend is started automatically
- `Y2DEBUGGER=remote` - make the debugger remotely accessible, connect using `byebug -R <host>:3344` command (in the other cases the debugger can be accessed *only localy*)
- `Y2DEBUGGER=manual` - like `1`, but does not start the the debugger frontend automatically

### Screenshots

(Click a screenshot to see the full size image.)

- GUI with `Y2DEBUGGER=1` - the debugger console is opened automatically
  ![debugger_qt_default](https://cloud.githubusercontent.com/assets/907998/15495724/ee672526-2191-11e6-992f-b147150d829d.png)

- Text mode with `Y2DEBUGGER=1` - the debugger console must be connected manually (you have to switch to a different virtual terminal and run the debugger frontend there)
  ![debugger_ncurses_default](https://cloud.githubusercontent.com/assets/907998/15495771/569d251e-2192-11e6-93b1-d7e4bccc8597.png)

- GUI with `Y2DEBUGGER=remote` - it displays the machine IP address in the `byebug` command to easily connect to the machine (the same dialog is displayed in the text mode)
  ![debugger_qt_remote](https://cloud.githubusercontent.com/assets/907998/15495796/7745096c-2192-11e6-9b28-faa451659eca.png)

- GUI with `Y2DEBUGGER=manual` - behaves like the default in the text mode
  ![debugger_qt_manual](https://cloud.githubusercontent.com/assets/907998/15495849/c777f3a4-2192-11e6-861c-eee33f339422.png)
