### PR TITLE
SSH import proposal summary interface improvements (Fate#319624)

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed May 25 15:49:41 UTC 2016 - kanderssen@suse.com
+
+- More visual improvements in the SSH keys importing proposal
+  summary based on blog entry feedback.
+
+-------------------------------------------------------------------
 Wed May 25 13:07:59 UTC 2016 - lslezak@suse.cz
 
 - Start the Ruby debugger at the beginning of installation

--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -3,6 +3,7 @@ Wed May 25 15:49:41 UTC 2016 - kanderssen@suse.com
 
 - More visual improvements in the SSH keys importing proposal
   summary based on blog entry feedback. (Fate#319624)
+- 3.1.189
 
 -------------------------------------------------------------------
 Wed May 25 13:07:59 UTC 2016 - lslezak@suse.cz

--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -2,7 +2,7 @@
 Wed May 25 15:49:41 UTC 2016 - kanderssen@suse.com
 
 - More visual improvements in the SSH keys importing proposal
-  summary based on blog entry feedback.
+  summary based on blog entry feedback. (Fate#319624)
 
 -------------------------------------------------------------------
 Wed May 25 13:07:59 UTC 2016 - lslezak@suse.cz

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation
-Version:        3.1.188
+Version:        3.1.189
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/installation/clients/inst_pre_install.rb
+++ b/src/lib/installation/clients/inst_pre_install.rb
@@ -94,6 +94,12 @@ module Yast
         read_ssh_info(device, mount_point)
       end
 
+      # The ssh_import proposal doesn't make sense if there is no
+      # configuration to import from.
+      if ::Installation::SshImporter.instance.configurations.empty?
+        ProductControl.DisableSubProposal("inst_initial", "ssh_import")
+      end
+
       # free the memory
       @useful_partitions = nil
 

--- a/src/lib/installation/clients/ssh_import_proposal.rb
+++ b/src/lib/installation/clients/ssh_import_proposal.rb
@@ -20,7 +20,9 @@ module Yast
         "rich_text_title" => _("Import SSH Host Keys and Configuration"),
         # menubutton entry
         "menu_title"      => _("&Import SSH Host Keys and Configuration"),
-        "id"              => "ssh_import"
+        # empty string is returned in case of not previous installation to
+        # avoid text link.
+        "id"              => importer.configurations.empty? ? "" : "ssh_import"
       }
     end
 

--- a/src/lib/installation/clients/ssh_import_proposal.rb
+++ b/src/lib/installation/clients/ssh_import_proposal.rb
@@ -40,7 +40,7 @@ module Yast
 
     def preformatted_proposal
       if importer.configurations.empty?
-        return _("No previous Linux installation found - not importing any SSH Key")
+        return Yast::HTML.List([_("No previous Linux installation found")])
       end
       if importer.device.nil?
         res = _("No existing SSH host keys will be copied")
@@ -57,8 +57,6 @@ module Yast
           res = _("SSH host keys will be copied from %s") % partition
         end
       end
-      # TRANSLATORS: link to change the proposal
-      res += " " + _("(<a href=%s>change</a>)") % '"ssh_import"'
       Yast::HTML.List([res])
     end
 
@@ -69,15 +67,18 @@ module Yast
         "going_back"  => true
       }
 
-      log.info "Asking user which SSH keys to import"
-      begin
-        Yast::Wizard.OpenAcceptDialog
-        result = WFM.CallFunction("inst_ssh_import", [args])
-      ensure
-        Yast::Wizard.CloseDialog
+      if importer.configurations.empty?
+        result = :next
+      else
+        log.info "Asking user which SSH keys to import"
+        begin
+          Yast::Wizard.OpenAcceptDialog
+          result = WFM.CallFunction("inst_ssh_import", [args])
+        ensure
+          Yast::Wizard.CloseDialog
+        end
+        log.info "Returning from ssh_import ask_user with #{result}"
       end
-      log.info "Returning from ssh_import ask_user with #{result}"
-
       { "workflow_sequence" => result }
     end
   end

--- a/src/lib/installation/clients/ssh_import_proposal.rb
+++ b/src/lib/installation/clients/ssh_import_proposal.rb
@@ -20,9 +20,7 @@ module Yast
         "rich_text_title" => _("Import SSH Host Keys and Configuration"),
         # menubutton entry
         "menu_title"      => _("&Import SSH Host Keys and Configuration"),
-        # empty string is returned in case of not previous installation to
-        # avoid text link.
-        "id"              => importer.configurations.empty? ? "" : "ssh_import"
+        "id"              => "ssh_import"
       }
     end
 
@@ -67,18 +65,15 @@ module Yast
         "going_back"  => true
       }
 
-      if importer.configurations.empty?
-        result = :next
-      else
-        log.info "Asking user which SSH keys to import"
-        begin
-          Yast::Wizard.OpenAcceptDialog
-          result = WFM.CallFunction("inst_ssh_import", [args])
-        ensure
-          Yast::Wizard.CloseDialog
-        end
-        log.info "Returning from ssh_import ask_user with #{result}"
+      log.info "Asking user which SSH keys to import"
+      begin
+        Yast::Wizard.OpenAcceptDialog
+        result = WFM.CallFunction("inst_ssh_import", [args])
+      ensure
+        Yast::Wizard.CloseDialog
       end
+      log.info "Returning from ssh_import ask_user with #{result}"
+
       { "workflow_sequence" => result }
     end
   end

--- a/src/lib/installation/dialogs/ssh_import.rb
+++ b/src/lib/installation/dialogs/ssh_import.rb
@@ -63,7 +63,7 @@ module Yast
     def dialog_content
       HSquash(
         VBox(
-          Left(CheckBoxFrame(
+          CheckBoxFrame(
             Id(:import_ssh_key),
             _("I would like to import SSH keys from a previous installation"),
             true,
@@ -80,7 +80,7 @@ module Yast
                 Left(copy_config_widget)
               )
             )
-          )),
+          ),
           HStretch()
         )
       )

--- a/src/lib/installation/dialogs/ssh_import.rb
+++ b/src/lib/installation/dialogs/ssh_import.rb
@@ -61,8 +61,7 @@ module Yast
     end
 
     def dialog_content
-      HBox(
-        HStretch(),
+      HSquash(
         VBox(
           Left(CheckBoxFrame(
             Id(:import_ssh_key),
@@ -75,13 +74,14 @@ module Yast
                 HSpacing(2),
                 partitions_list_widget
               ),
-              VSpacing(1),
+              VSpacing(3),
               HBox(
                 HSpacing(2),
                 Left(copy_config_widget)
               )
             )
           )),
+          HStretch()
         )
       )
     end
@@ -97,7 +97,7 @@ module Yast
         "thus the identity- of its SSH server. The key files found in /etc/ssh " \
         "(one pair of files per host key) will be copied to the new system " \
         "being installed.</p>" \
-        "<p>Check <b>Insert SSH Configuration</b> to also copy other files " \
+        "<p>Check <b>Import SSH Configuration</b> to also copy other files " \
         "found in /etc/ssh, in addition to the keys.</p>"
       )
     end
@@ -125,7 +125,7 @@ module Yast
     end
 
     def copy_config_widget
-      CheckBox(Id(:copy_config), _("Insert SSH Configuration"), copy_config)
+      CheckBox(Id(:copy_config), _("Import SSH Configuration"), copy_config)
     end
   end
 end

--- a/src/lib/installation/dialogs/ssh_import.rb
+++ b/src/lib/installation/dialogs/ssh_import.rb
@@ -34,7 +34,7 @@ module Yast
     # Event callback for the 'ok' button
     def next_handler
       partition = UI.QueryWidget(Id(:device), :Value)
-      partition = nil if partition == :none
+      partition = nil unless UI.QueryWidget(Id(:import_ssh_key), :Value)
       copy_config = UI.QueryWidget(Id(:copy_config), :Value)
       log.info "SshImportDialog partition => #{partition} copy_config => #{copy_config}"
       importer.device = partition
@@ -61,12 +61,27 @@ module Yast
     end
 
     def dialog_content
-      HSquash(
+      HBox(
+        HStretch(),
         VBox(
-          Left(Label(_("System to Import SSH Host Keys from"))),
-          partitions_list_widget,
-          VSpacing(1),
-          Left(copy_config_widget)
+          Left(CheckBoxFrame(
+            Id(:import_ssh_key),
+            _("I would like to import SSH keys from a previous installation"),
+            true,
+            VBox(
+              HStretch(),
+              VSpacing(1),
+              HBox(
+                HSpacing(2),
+                partitions_list_widget
+              ),
+              VSpacing(1),
+              HBox(
+                HSpacing(2),
+                Left(copy_config_widget)
+              )
+            )
+          )),
         )
       )
     end
@@ -82,7 +97,7 @@ module Yast
         "thus the identity- of its SSH server. The key files found in /etc/ssh " \
         "(one pair of files per host key) will be copied to the new system " \
         "being installed.</p>" \
-        "<p>Check <b>Copy Whole SSH Configuration</b> to also copy other files " \
+        "<p>Check <b>Insert SSH Configuration</b> to also copy other files " \
         "found in /etc/ssh, in addition to the keys.</p>"
       )
     end
@@ -96,8 +111,6 @@ module Yast
       RadioButtonGroup(
         Id(:device),
         VBox(
-          # TRANSLATORS: option to select no partition for SSH keys import
-          Left(RadioButton(Id(:none), _("None"), device.nil?)),
           *part_widgets
         )
       )
@@ -112,7 +125,7 @@ module Yast
     end
 
     def copy_config_widget
-      CheckBox(Id(:copy_config), _("Copy Whole SSH Configuration"), copy_config)
+      CheckBox(Id(:copy_config), _("Insert SSH Configuration"), copy_config)
     end
   end
 end


### PR DESCRIPTION
This pull request is just for some minor changes based on [blog entry](https://lizards.opensuse.org/2016/05/18/highlights-of-yast-development-sprint-19/) feedback. The functionality was added and is explained in #374.

https://trello.com/c/EQzfj9Kf

## Screenshots

In case that there is not a previous installation the proposal will be disable:

![ssh-key_proposal_link_no_partition](https://cloud.githubusercontent.com/assets/7056681/15573500/6429056e-233f-11e6-851c-35acbfb3fdf2.png)

![ssh-key_proposal_link_text_mode_no_partition](https://cloud.githubusercontent.com/assets/7056681/15573501/68e6a37c-233f-11e6-9947-c9b89e5b2842.png)

In other case:

![ssh-key_proposal_link_with_partition](https://cloud.githubusercontent.com/assets/7056681/15573547/b484b490-233f-11e6-8233-8b47a1adc113.png)
![ssh-key_proposal_link_text_mode_with_partition](https://cloud.githubusercontent.com/assets/7056681/15573552/b8d04618-233f-11e6-8a33-20875df3074e.png)


And the new dialog suggested by @kwwii:

![ssh-key_dialog_new](https://cloud.githubusercontent.com/assets/7056681/15573526/93a4d02a-233f-11e6-9ff2-cc4d5b171e37.png)

![ssh-key_dialog_text_mode_new](https://cloud.githubusercontent.com/assets/7056681/15573531/9e121f68-233f-11e6-960d-8ac22e7b7584.png)
