### PR TITLE
System Role: centered dialog for ncurses.

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Thu May 26 13:17:42 UTC 2016 - kanderssen@suse.com
+
+- System Role: centered dialog (ncurses).
+
+-------------------------------------------------------------------
 Wed May 25 15:49:41 UTC 2016 - kanderssen@suse.com
 
 - More visual improvements in the SSH keys importing proposal

--- a/src/lib/installation/select_system_role.rb
+++ b/src/lib/installation/select_system_role.rb
@@ -53,10 +53,12 @@ module Installation
     end
 
     def dialog_content
-      VBox(
-        Left(Label(Yast::ProductControl.GetTranslatedText("roles_text"))),
-        VSpacing(2),
-        role_buttons
+      HSquash(
+        VBox(
+          Left(Label(Yast::ProductControl.GetTranslatedText("roles_text"))),
+          VSpacing(2),
+          role_buttons
+        )
       )
     end
 


### PR DESCRIPTION
Testing #382 i realized that system role dialog was also not centered.

![rolesselectionleft](https://cloud.githubusercontent.com/assets/7056681/15576152/67ea9c30-234e-11e6-968b-b923bef68a8d.png)

So, after merge this PR it will look like..

![rolesselection](https://cloud.githubusercontent.com/assets/7056681/15576093/0edb312c-234e-11e6-96fd-731f2f609717.png)