### PR TITLE
Review 319624 AutoYaST

### DIFF
--- a/src/lib/installation/clients/ssh_import_auto.rb
+++ b/src/lib/installation/clients/ssh_import_auto.rb
@@ -22,13 +22,55 @@ module Installation
       ret
     end
 
+    # Importing data from the AutoYaST configuration module
+    # AutoYaST data format:
+    #
+    # <ssh_import>
+    #   <import config:type="boolean">true</import>
+    #   <config config:type="boolean">true</config>
+    #   <device>/dev/sda4</device>
+    # </ssh_import>
     def import(data)
-      ::Installation::SshImporter.instance.import(data)
+      if data["import"]
+        log.info "Importing AutoYaST data: #{data}"
+        ssh_importer.copy_config = data["config"] == true
+        if data["device"] && !data["device"].empty?
+          if ssh_importer.configurations.key?(data["device"])
+            ssh_importer.device = data["device"]
+          else
+            Yast::Report.Warning(
+              # TRANSLATORS: %s is the device name like /dev/sda0
+              _("Device %s not found. Taking default entry.") %
+              data["device"]
+              )
+          end
+        end
+      else
+        ssh_importer.device = nil # do not copy ssh keys into the installed system
+      end
       true
     end
 
+    # Returns a human readable summary
     def summary
-      "<UL>" + ::Installation::SshImporter.instance.summary + "</UL>"
+      message =
+        if ssh_importer.configurations.empty?
+          _("No previous Linux installation found - not importing any SSH Key")
+        elsif ssh_importer.device.nil?
+          _("No existing SSH host keys will be copied")
+        else
+          name = ssh_config.system_name
+          if ssh_importer.copy_config?
+            # TRANSLATORS: %s is the name of a Linux system found in the hard
+            # disk, like 'openSUSE 13.2'
+            _("SSH host keys and configuration will be copied from %s") % name
+          else
+            # TRANSLATORS: %s is the name of a Linux system found in the hard
+            # disk, like 'openSUSE 13.2'
+            _("SSH host keys will be copied from %s") % name
+          end
+        end
+      "<UL>#{message}</UL>"
     end
 
     def modified?
@@ -40,36 +82,41 @@ module Installation
     end
 
     def reset
-      ::Installation::SshImporter.instance.reset
+      ssh_importer.reset
     end
 
     def change
-      begin
-        args = {
-          "enable_back" => true,
-          "enable_next" => false,
-          "going_back"  => true
-        }
-        Yast::Wizard.OpenAcceptDialog
-        result = WFM.CallFunction("inst_ssh_import", [args])
-      ensure
-        Yast::Wizard.CloseDialog
-      end
+      args = {
+        "enable_back" => true,
+        "enable_next" => false,
+        "going_back"  => true
+      }
+      Yast::Wizard.OpenAcceptDialog
+      WFM.CallFunction("inst_ssh_import", [args])
+    ensure
+      Yast::Wizard.CloseDialog
     end
 
-    # Return configuration data
-    #
-    # return map
+    # Exporting data to the AutoYaST configuration module.
+    # That's are default entries.
     def export
-      ::Installation::SshImporter.instance.export
+      ret = { "import" => true, "config" => false }
+      # Device will not be set because it is optional and the
+      # most-recently-accessed device (biggest keys_atime)
+      # will be used for.
+      # ret["device"] = device
+      ret
     end
 
+    # Writes the SSH keys from the selected device (and also other
+    # configuration files if #copy_config? is true) in the target
+    # filesystem
     def write
       if Mode.config
         Popup.Notify _("It makes no sense to write these settings to system.")
-        return true
+        true
       else
-        return ::Installation::SshImporter.instance.write
+        ssh_importer.write(::Installation.destdir)
       end
     end
 
@@ -78,5 +125,21 @@ module Installation
       true
     end
 
+  protected
+
+    # Helper method to access to the SshImporter
+    #
+    # @return [::Installation::SshImporter] SSH importer
+    def ssh_importer
+      @ssh_importer ||= ::Installation::SshImporter.instance
+    end
+
+    # Helper method to access to SshConfig for the selected device
+    #
+    # @return [::Installation::SshConfig] SSH configuration
+    def ssh_config
+      # TODO: add a method #current_config to SshImporter (?)
+      ssh_importer.device ? ssh_importer.configurations[ssh_importer.device] : nil
+    end
   end
 end

--- a/src/lib/installation/clients/ssh_import_auto.rb
+++ b/src/lib/installation/clients/ssh_import_auto.rb
@@ -8,7 +8,7 @@ Yast.import "Mode"
 Yast.import "Popup"
 
 module Installation
-  # Autoyast client for ssh_import
+  # AutoYaST client for ssh_import
   class SSHImportAutoClient < ::Installation::AutoClient
     class << self
       attr_accessor :changed

--- a/src/lib/installation/clients/ssh_import_auto.rb
+++ b/src/lib/installation/clients/ssh_import_auto.rb
@@ -55,7 +55,7 @@ module Installation
     def summary
       message =
         if ssh_importer.configurations.empty?
-          _("No previous Linux installation found - not importing any SSH Key")
+          _("No previous Linux installation found")
         elsif ssh_importer.device.nil?
           _("No existing SSH host keys will be copied")
         else
@@ -70,7 +70,8 @@ module Installation
             _("SSH host keys will be copied from %s") % name
           end
         end
-      "<UL>#{message}</UL>"
+      # FIXME: we should use the Summary module.
+      "<UL><LI>#{message}</LI></UL>"
     end
 
     def modified?

--- a/src/lib/installation/ssh_importer.rb
+++ b/src/lib/installation/ssh_importer.rb
@@ -76,7 +76,7 @@ module Installation
       if configurations.empty?
         return _("No previous Linux installation found - not importing any SSH Key")
       end
-      if @device.nil?
+      if device.nil?
         return _("No existing SSH host keys will be copied")
       else
         ssh_config = configurations[@device]
@@ -118,7 +118,7 @@ module Installation
           end
         end
       else
-        @device = nil # do not copy ssh keys into the installed system
+        self.device = nil # do not copy ssh keys into the installed system
       end
     end
 

--- a/src/lib/installation/ssh_importer.rb
+++ b/src/lib/installation/ssh_importer.rb
@@ -17,7 +17,6 @@
 #  you may find current contact information at www.suse.com
 
 require "installation/ssh_config"
-Yast.import "Report"
 
 module Installation
   # Entry point for the SSH keys importing functionality.
@@ -26,7 +25,6 @@ module Installation
   # in the hard disk and to copy its files to the target system
   class SshImporter
     include Singleton
-    include Yast::I18n
     include Yast::Logger
 
     # @return [String] device name of the source filesystem (i.e. the
@@ -69,68 +67,6 @@ module Installation
 
       configurations[device] = config
       set_device
-    end
-
-    # Returns a human readable summary
-    def summary
-      if configurations.empty?
-        return _("No previous Linux installation found - not importing any SSH Key")
-      end
-      if device.nil?
-        return _("No existing SSH host keys will be copied")
-      else
-        ssh_config = configurations[@device]
-        partition = ssh_config.system_name
-        if copy_config?
-          # TRANSLATORS: %s is the name of a Linux system found in the hard
-          # disk, like 'openSUSE 13.2'
-          return _("SSH host keys and configuration will be copied from %s") % partition
-        else
-          # TRANSLATORS: %s is the name of a Linux system found in the hard
-          # disk, like 'openSUSE 13.2'
-          return _("SSH host keys will be copied from %s") % partition
-        end
-      end
-    end
-
-    # Importing data from the AutoYaST configuration module
-    # AutoYaST data format:
-    #
-    # <ssh_import>
-    #   <import config:type="boolean">true</import>
-    #   <config config:type="boolean">true</config>
-    #   <device>/dev/sda4</device>
-    # </ssh_import>
-    def import(data)
-      log.info "Importing AutoYaST data: #{data}"
-      if data["import"]
-        set_device # set default device
-        @copy_config = data["config"] || false
-        if data["device"] && !data["device"].empty?
-          if configurations.has_key?( data["device"] )
-            @device = data["device"]
-          else
-            Yast::Report.Warning(
-              # TRANSLATORS: %s is the device name like /dev/sda0
-              _("Device %s not found. Taking default entry.") %
-              data["device"]
-            )
-          end
-        end
-      else
-        self.device = nil # do not copy ssh keys into the installed system
-      end
-    end
-
-    # Exporting data to the AutoYaST configuration module.
-    # That's are default entries.
-    def export
-      ret = { "import" => true, "config" => false }
-      # Device will not be set because it is optional and the
-      # most-recently-accessed device (biggest keys_atime)
-      # will be used for.
-      # ret["device"] = device
-      ret
     end
 
     # Writes the SSH keys from the selected device (and also other configuration

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -13,6 +13,7 @@ TESTS = \
   remote_finish_test.rb \
   select_system_role_test.rb \
   snapshots_finish_test.rb \
+  ssh_import_auto_test.rb \
   updates_manager_test.rb \
   update_repository_test.rb
 

--- a/test/ssh_import_auto_test.rb
+++ b/test/ssh_import_auto_test.rb
@@ -1,0 +1,215 @@
+#!/usr/bin/env rspec
+
+require_relative "test_helper"
+require "installation/clients/ssh_import_auto"
+
+describe ::Installation::SSHImportAutoClient do
+  let(:importer) { ::Installation::SshImporter.instance }
+  let(:args) { [] }
+
+  before do
+    allow(Yast::WFM).to receive(:Args).and_return([func, args])
+  end
+
+  describe "#run" do
+    before do
+      importer.configurations.clear
+      importer.reset
+    end
+
+    context "Export" do
+      let(:func) { "Export" }
+
+      it "returns a hash with default configuration" do
+        expect(subject.run).to eq("config" => false, "import" => true)
+      end
+    end
+
+    context "Summary" do
+      let(:func) { "Summary" }
+      let(:device) { "dev" }
+      let(:copy_config) { false }
+
+      before do
+        importer.add_config(FIXTURES_DIR.join(config), "dev")
+        importer.device = device
+        importer.copy_config = copy_config
+      end
+
+      context "when no previous configurations were found" do
+        let(:config) { "root3" }
+        let(:message) do
+          _("No previous Linux installation found - " \
+            "not importing any SSH Key")
+        end
+
+        it "returns 'No previous Linux...' message" do
+          expect(subject.run).to eq("<UL>#{message}</UL>")
+        end
+      end
+
+      context "when no device was selected" do
+        let(:config) { "root1" }
+        let(:device) { nil }
+        let(:message) { _("No existing SSH host keys will be copied") }
+
+        it "returns 'No existing SSH...'" do
+          expect(subject.run).to eq("<UL>#{message}</UL>")
+        end
+      end
+
+      context "when device is set and copy config is enabled" do
+        let(:config) { "root1" }
+        let(:copy_config) { true }
+        let(:message) do
+          _("SSH host keys and configuration will be copied from %s") %
+            "Operating system 1"
+        end
+
+        it "returns 'No existing SSH...'" do
+          expect(subject.run).to eq("<UL>#{message}</UL>")
+        end
+      end
+
+      context "when device is set and copy config is disabled" do
+        let(:config) { "root1" }
+        let(:copy_config) { false }
+        let(:message) do
+          _("SSH host keys will be copied from %s") %
+            "Operating system 1"
+        end
+
+        it "returns 'No existing SSH...'" do
+          expect(subject.run).to eq("<UL>#{message}</UL>")
+        end
+      end
+    end
+
+    context "Import" do
+      let(:func) { "Import" }
+
+      before do
+        importer.add_config(FIXTURES_DIR.join("root1"), "dev")
+      end
+
+      context "when importing is disabled" do
+        let(:args) { { "import" => false } }
+
+        it "unset the device" do
+          subject.run
+          expect(importer.device).to be_nil
+        end
+      end
+
+      context "when no device is set" do
+        let(:args) { { "import" => true } }
+
+        it "sets default device to be used" do
+          subject.run
+          expect(importer.device).to eq("dev")
+        end
+      end
+
+      context "when given device exist" do
+        let(:args) { { "import" => true, "device" => "other" } }
+
+        it "sets given device to be used" do
+          importer.add_config(FIXTURES_DIR.join("root1"), "other")
+          subject.run
+          expect(importer.device).to eq("other")
+        end
+      end
+
+      context "when given device does not exist" do
+        let(:args) { { "import" => true, "device" => "missing" } }
+
+        it "sets default device to be used" do
+          subject.run
+          expect(importer.device).to eq("dev")
+        end
+      end
+
+      context "when copying configuration is disabled" do
+        let(:args) { { "import" => true, "config" => false } }
+
+        it "disable copy_config to false" do
+          subject.run
+          expect(importer.copy_config).to eq(false)
+        end
+      end
+
+      context "when copying configuration is enabled" do
+        let(:args) { { "import" => true, "config" => true } }
+
+        it "disable copy_config to true" do
+          subject.run
+          expect(importer.copy_config).to eq(true)
+        end
+      end
+    end
+
+    context "Write" do
+      let(:func) { "Write" }
+
+      before do
+        importer.add_config(FIXTURES_DIR.join("root1"), "dev")
+        allow(::Installation).to receive(:destdir).and_return("/")
+      end
+
+      it "writes the keys/configuration to the installation directory" do
+        configuration = importer.configurations["dev"]
+        expect(configuration).to receive(:write_files).with("/",
+          write_keys: true, write_config_files: importer.copy_config)
+        subject.run
+      end
+    end
+
+    context "Read" do
+      let(:func) { "Read" }
+
+      it "returns true" do
+        expect(subject.run).to eq(true)
+      end
+    end
+
+    context "Reset" do
+      let(:func) { "Reset" }
+
+      it "resets the importer" do
+        expect(importer).to receive(:reset)
+        subject.run
+      end
+    end
+
+    context "GetModified" do
+      let(:func) { "GetModified" }
+
+      before { described_class.changed = false }
+
+      context "when client was not changed" do
+        it "returns false" do
+          expect(subject.run).to eq(false)
+        end
+      end
+
+      context "when client was changed" do
+        before { subject.modified }
+
+        it "returns true" do
+          expect(subject.run).to eq(true)
+        end
+      end
+    end
+
+    context "SetModified" do
+      let(:func) { "SetModified" }
+
+      before { described_class.changed = false }
+
+      it "sets the client as 'modified'" do
+        expect { subject.run }.to change { subject.modified? }
+          .from(false).to(true)
+      end
+    end
+  end
+end

--- a/test/ssh_import_auto_test.rb
+++ b/test/ssh_import_auto_test.rb
@@ -38,13 +38,10 @@ describe ::Installation::SSHImportAutoClient do
 
       context "when no previous configurations were found" do
         let(:config) { "root3" }
-        let(:message) do
-          _("No previous Linux installation found - " \
-            "not importing any SSH Key")
-        end
+        let(:message) { _("No previous Linux installation found") }
 
         it "returns 'No previous Linux...' message" do
-          expect(subject.run).to eq("<UL>#{message}</UL>")
+          expect(subject.run).to eq("<UL><LI>#{message}</LI></UL>")
         end
       end
 
@@ -54,7 +51,7 @@ describe ::Installation::SSHImportAutoClient do
         let(:message) { _("No existing SSH host keys will be copied") }
 
         it "returns 'No existing SSH...'" do
-          expect(subject.run).to eq("<UL>#{message}</UL>")
+          expect(subject.run).to eq("<UL><LI>#{message}</LI></UL>")
         end
       end
 
@@ -67,7 +64,7 @@ describe ::Installation::SSHImportAutoClient do
         end
 
         it "returns 'No existing SSH...'" do
-          expect(subject.run).to eq("<UL>#{message}</UL>")
+          expect(subject.run).to eq("<UL><LI>#{message}</LI></UL>")
         end
       end
 
@@ -80,7 +77,7 @@ describe ::Installation::SSHImportAutoClient do
         end
 
         it "returns 'No existing SSH...'" do
-          expect(subject.run).to eq("<UL>#{message}</UL>")
+          expect(subject.run).to eq("<UL><LI>#{message}</LI></UL>")
         end
       end
     end


### PR DESCRIPTION
This PR is based on #380:

* Add unit test for `SSHImportAutoClient`.
* Move code from `SshImporter` to `SSHImportAutoClient`. IMHO, the main responsible for handling the import/write/etc. at a "top-level" should be the client itself. SshImporter class shouldn't now anything about AutoYaST, although it's the class that does the final job.

On the other hand, I'm not sure if `SSHImportAutoClient` should be here or in `yast-autoinstallation`.

@schubi2 Of course, I could be wrong :). In that case, you can use at least the unit tests :) Feel free to cherry pick them.