### PR TITLE
Move the debugger invocation to ruby-bindings (FATE#318421)

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon May 30 14:35:05 UTC 2016 - lslezak@suse.cz
+
+- Move the debugger invocation code to yast2-ruby-bindings package
+  to use the same implementation at run time (FATE#318421)
+- 3.1.190
+
+-------------------------------------------------------------------
 Thu May 26 13:17:42 UTC 2016 - kanderssen@suse.com
 
 - System Role: centered dialog (ncurses).

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -26,8 +26,7 @@ Source0:        %{name}-%{version}.tar.bz2
 Group:          System/YaST
 License:        GPL-2.0
 Url:            http://github.com/yast/yast-installation
-# yast/debugger
-Requires:       yast2-ruby-bindings >= 3.1.47
+Requires:       yast2-ruby-bindings >= 3.1.8
 
 Summary:        YaST2 - Installation Parts
 

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation
-Version:        3.1.189
+Version:        3.1.190
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/installation/clients/installation.rb
+++ b/src/lib/installation/clients/installation.rb
@@ -47,9 +47,6 @@ module Yast
       UI.SetProductLogo(true)
       Wizard.OpenLeftTitleNextBackDialog
 
-      # start the debugger if requested (FATE#318421)
-      start_debugger
-
       Wizard.SetContents(
         # title
         "",
@@ -103,23 +100,6 @@ module Yast
       WFM.CallFunction("disintegrate_all_extensions") if Stage.initial
 
       deep_copy(@ret)
-    end
-
-  private
-
-    # start the Ruby debugger if booted with the Y2DEBUGGER option
-    def start_debugger
-      return unless (Linuxrc.InstallInf("Cmdline") || "").match(/\bY2DEBUGGER=(.*)\b/i)
-
-      option = Regexp.last_match[1]
-      log.info "Y2DEBUGGER option: #{option}"
-
-      if option == "1" || option == "remote" || option == "manual"
-        require "yast/debugger"
-        Debugger.start(remote: option == "remote", start_client: option != "manual")
-      else
-        log.warn "Unknown Y2DEBUGGER value: #{option}"
-      end
     end
   end
 end


### PR DESCRIPTION
... to use the same implementation at run time.

- 3.1.190

The related ruby-bindings PR is here: https://github.com/yast/yast-ruby-bindings/pull/168