### PR TITLE
ssh import: updates from code review

### DIFF
--- a/autoyast_desktop/ssh_import.desktop
+++ b/autoyast_desktop/ssh_import.desktop
@@ -20,7 +20,7 @@ X-SuSE-YaST-AutoInstClonable=true
 Icon=yast-ssh_import
 Exec=
 
-Name=SHH Key Import
-GenericName=Importing SSH keys from a previous installtion
+Name=SSH Key Import
+GenericName=Importing SSH keys from a previous installation
 
 StartupNotify=true

--- a/src/lib/installation/clients/ssh_import_auto.rb
+++ b/src/lib/installation/clients/ssh_import_auto.rb
@@ -30,23 +30,31 @@ module Installation
     #   <config config:type="boolean">true</config>
     #   <device>/dev/sda4</device>
     # </ssh_import>
+    #
+    # @param data [Hash] AutoYaST specification.
+    # @option data [Boolean] :import Import SSH keys
+    # @option data [Boolean] :config Import SSH server configuration
+    #   in addition to keys.
+    # @option data [Boolean] :device Device to import the keys/configuration from.
     def import(data)
-      if data["import"]
-        log.info "Importing AutoYaST data: #{data}"
-        ssh_importer.copy_config = data["config"] == true
-        if data["device"] && !data["device"].empty?
-          if ssh_importer.configurations.key?(data["device"])
-            ssh_importer.device = data["device"]
-          else
-            Yast::Report.Warning(
-              # TRANSLATORS: %s is the device name like /dev/sda0
-              _("Device %s not found. Taking default entry.") %
-              data["device"]
-              )
-          end
-        end
-      else
+      if !data["import"]
+        log.info("Do not import ssh keys/configuration")
         ssh_importer.device = nil # do not copy ssh keys into the installed system
+        return true
+      end
+
+      log.info "Importing AutoYaST data: #{data}"
+      ssh_importer.copy_config = data["config"] == true
+      if data["device"] && !data["device"].empty?
+        if ssh_importer.configurations.key?(data["device"])
+          ssh_importer.device = data["device"]
+        else
+          Yast::Report.Warning(
+            # TRANSLATORS: %s is the device name like /dev/sda0
+            _("Device %s not found. Taking default entry.") %
+            data["device"]
+            )
+        end
       end
       true
     end

--- a/src/lib/installation/clients/ssh_import_auto.rb
+++ b/src/lib/installation/clients/ssh_import_auto.rb
@@ -2,6 +2,7 @@ require "yast"
 
 require "installation/auto_client"
 require "installation/ssh_importer"
+require "installation/ssh_importer_presenter"
 
 Yast.import "Progress"
 Yast.import "Mode"
@@ -60,27 +61,10 @@ module Installation
     end
 
     # Returns a human readable summary
+    #
+    # @see ::Installation::SshImporterPresenter
     def summary
-      message =
-        if ssh_importer.configurations.empty? && (Mode.installation || Mode.autoinst)
-          _("No previous Linux installation found")
-        elsif ssh_importer.device.nil?
-          _("No existing SSH host keys will be copied")
-        else
-          name = ssh_config.system_name if ssh_config
-          name ||= ssh_importer.device || "default"
-          if ssh_importer.copy_config?
-            # TRANSLATORS: %s is the name of a Linux system found in the hard
-            # disk, like 'openSUSE 13.2'
-            _("SSH host keys and configuration will be copied from %s") % name
-          else
-            # TRANSLATORS: %s is the name of a Linux system found in the hard
-            # disk, like 'openSUSE 13.2'
-            _("SSH host keys will be copied from %s") % name
-          end
-        end
-      # FIXME: we should use the Summary module.
-      "<UL><LI>#{message}</LI></UL>"
+      ::Installation::SshImporterPresenter.new(ssh_importer).summary
     end
 
     def modified?
@@ -166,14 +150,6 @@ module Installation
     # @return [::Installation::SshImporter] SSH importer
     def ssh_importer
       @ssh_importer ||= ::Installation::SshImporter.instance
-    end
-
-    # Helper method to access to SshConfig for the selected device
-    #
-    # @return [::Installation::SshConfig] SSH configuration
-    def ssh_config
-      # TODO: add a method #current_config to SshImporter (?)
-      ssh_importer.device ? ssh_importer.configurations[ssh_importer.device] : nil
     end
   end
 end

--- a/src/lib/installation/clients/ssh_import_proposal.rb
+++ b/src/lib/installation/clients/ssh_import_proposal.rb
@@ -1,5 +1,6 @@
 require "installation/proposal_client"
 require "installation/ssh_importer"
+require "installation/ssh_importer_presenter"
 
 module Yast
   # Proposal client for SSH keys import
@@ -37,25 +38,7 @@ module Yast
     end
 
     def preformatted_proposal
-      if importer.configurations.empty?
-        return Yast::HTML.List([_("No previous Linux installation found")])
-      end
-      if importer.device.nil?
-        res = _("No existing SSH host keys will be copied")
-      else
-        ssh_config = importer.configurations[importer.device]
-        partition = ssh_config.system_name
-        if importer.copy_config?
-          # TRANSLATORS: %s is the name of a Linux system found in the hard
-          # disk, like 'openSUSE 13.2'
-          res = _("SSH host keys and configuration will be copied from %s") % partition
-        else
-          # TRANSLATORS: %s is the name of a Linux system found in the hard
-          # disk, like 'openSUSE 13.2'
-          res = _("SSH host keys will be copied from %s") % partition
-        end
-      end
-      Yast::HTML.List([res])
+      ::Installation::SshImporterPresenter.new(ssh_importer).summary
     end
 
     def ask_user(param)

--- a/src/lib/installation/clients/ssh_import_proposal.rb
+++ b/src/lib/installation/clients/ssh_import_proposal.rb
@@ -37,9 +37,24 @@ module Yast
     end
 
     def preformatted_proposal
-      res = importer.summary
-      # TRANSLATORS: link to change the proposal
-      res += " " + _("(<a href=%s>change</a>)") % '"ssh_import"'
+      if importer.configurations.empty?
+        return Yast::HTML.List([_("No previous Linux installation found")])
+      end
+      if importer.device.nil?
+        res = _("No existing SSH host keys will be copied")
+      else
+        ssh_config = importer.configurations[importer.device]
+        partition = ssh_config.system_name
+        if importer.copy_config?
+          # TRANSLATORS: %s is the name of a Linux system found in the hard
+          # disk, like 'openSUSE 13.2'
+          res = _("SSH host keys and configuration will be copied from %s") % partition
+        else
+          # TRANSLATORS: %s is the name of a Linux system found in the hard
+          # disk, like 'openSUSE 13.2'
+          res = _("SSH host keys will be copied from %s") % partition
+        end
+      end
       Yast::HTML.List([res])
     end
 

--- a/src/lib/installation/ssh_importer_presenter.rb
+++ b/src/lib/installation/ssh_importer_presenter.rb
@@ -61,7 +61,7 @@ module Installation
       Yast::HTML.List([message])
     end
 
-    private
+  private
 
     # Helper method to access to SshConfig for the selected device
     #

--- a/src/lib/installation/ssh_importer_presenter.rb
+++ b/src/lib/installation/ssh_importer_presenter.rb
@@ -1,0 +1,74 @@
+# Copyright (c) 2016 SUSE LLC.
+#  All Rights Reserved.
+
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of version 2 or 3 of the GNU General
+#  Public License as published by the Free Software Foundation.
+
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.   See the
+#  GNU General Public License for more details.
+
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, contact SUSE LLC.
+
+#  To contact SUSE about this file by physical or electronic mail,
+#  you may find current contact information at www.suse.com
+
+require "yast"
+
+module Installation
+  # This class is responsible for building a summary for SshImporter
+  # objects. Moving the presentation to a different class, avoid
+  # SshImporter knowing about i18n and HTML.
+  class SshImporterPresenter
+    include Yast::I18n
+
+    # @return [SshImporter] Importer
+    attr_reader :importer
+
+    def initialize(importer)
+      Yast.import "Mode"
+      Yast.import "HTML"
+
+      textdomain "installation"
+      @importer = importer
+    end
+
+    # Build a formatted summary based on the status of the importer
+    #
+    # @return [String] HTML formatted summary.
+    def summary
+      message =
+        if importer.configurations.empty? && (Yast::Mode.installation || Yast::Mode.autoinst)
+          _("No previous Linux installation found")
+        elsif importer.device.nil?
+          _("No existing SSH host keys will be copied")
+        else
+          name = ssh_config.system_name if ssh_config
+          name ||= importer.device || "default"
+          if importer.copy_config?
+            # TRANSLATORS: %s is the name of a Linux system found in the hard
+            # disk, like 'openSUSE 13.2'
+            _("SSH host keys and configuration will be copied from %s") % name
+          else
+            # TRANSLATORS: %s is the name of a Linux system found in the hard
+            # disk, like 'openSUSE 13.2'
+            _("SSH host keys will be copied from %s") % name
+          end
+        end
+      Yast::HTML.List([message])
+    end
+
+    private
+
+    # Helper method to access to SshConfig for the selected device
+    #
+    # @return [::Installation::SshConfig] SSH configuration
+    def ssh_config
+      # TODO: add a method #current_config to SshImporter (?)
+      importer.device ? importer.configurations[importer.device] : nil
+    end
+  end
+end

--- a/test/ssh_import_auto_test.rb
+++ b/test/ssh_import_auto_test.rb
@@ -29,59 +29,14 @@ describe ::Installation::SSHImportAutoClient do
 
     context "Summary" do
       let(:func) { "Summary" }
-      let(:device) { "dev" }
-      let(:copy_config) { false }
+      let(:presenter) { double("presenter", summary: "Summary") }
 
       before do
-        importer.add_config(FIXTURES_DIR.join(config), "dev")
-        importer.device = device
-        importer.copy_config = copy_config
+        allow(::Installation::SshImporterPresenter).to receive(:new).and_return(presenter)
       end
 
-      context "when no previous configurations were found" do
-        let(:config) { "root3" }
-        let(:message) { _("No previous Linux installation found") }
-        let(:device) { nil }
-
-        it "returns 'No previous Linux...' message" do
-          expect(subject.run).to eq("<UL><LI>#{message}</LI></UL>")
-        end
-      end
-
-      context "when no device was selected" do
-        let(:config) { "root1" }
-        let(:device) { nil }
-        let(:message) { _("No existing SSH host keys will be copied") }
-
-        it "returns 'No existing SSH...'" do
-          expect(subject.run).to eq("<UL><LI>#{message}</LI></UL>")
-        end
-      end
-
-      context "when device is set and copy config is enabled" do
-        let(:config) { "root1" }
-        let(:copy_config) { true }
-        let(:message) do
-          _("SSH host keys and configuration will be copied from %s") %
-            "Operating system 1"
-        end
-
-        it "returns 'No existing SSH...'" do
-          expect(subject.run).to eq("<UL><LI>#{message}</LI></UL>")
-        end
-      end
-
-      context "when device is set and copy config is disabled" do
-        let(:config) { "root1" }
-        let(:copy_config) { false }
-        let(:message) do
-          _("SSH host keys will be copied from %s") %
-            "Operating system 1"
-        end
-
-        it "returns 'No existing SSH...'" do
-          expect(subject.run).to eq("<UL><LI>#{message}</LI></UL>")
-        end
+      it "returns SSH importer summary" do
+        expect(subject.run).to eq(presenter.summary)
       end
     end
 

--- a/test/ssh_importer_presenter_test.rb
+++ b/test/ssh_importer_presenter_test.rb
@@ -1,0 +1,84 @@
+#!/usr/bin/env rspec
+
+require_relative "test_helper"
+require "installation/ssh_importer_presenter"
+require "installation/ssh_importer"
+
+describe ::Installation::SshImporterPresenter do
+  Yast.import "Mode"
+
+  let(:importer) { ::Installation::SshImporter.instance }
+  let(:presenter) { described_class.new(importer) }
+
+  describe "#summary" do
+    let(:mode) { "installation" }
+    let(:device) { "dev" }
+    let(:copy_config) { false }
+
+    before do
+      importer.configurations.clear
+      importer.reset
+      importer.add_config(FIXTURES_DIR.join(config), "dev")
+      importer.device = device
+      importer.copy_config = copy_config
+      allow(Yast::Mode).to receive(:mode).and_return(mode)
+    end
+
+    context "when no previous configurations were found" do
+      let(:config) { "root3" }
+      let(:device) { nil }
+
+      context "and mode is installation" do
+        let(:mode) { "installation" }
+        let(:message) { _("No previous Linux installation found") }
+
+        it "returns 'No previous Linux...' message" do
+          expect(presenter.summary).to eq("<ul><li>#{message}</li></ul>")
+        end
+      end
+
+      context "and mode is autoinstallation" do
+        let(:mode) { "autoinstallation" }
+        let(:message) { _("No previous Linux installation found") }
+
+        it "returns 'No previous Linux...' message" do
+          expect(presenter.summary).to eq("<ul><li>#{message}</li></ul>")
+        end
+      end
+
+      context "and mode is not installation or autoinstallation" do
+        let(:mode) { "normal" }
+        let(:message) { _("No existing SSH host keys will be copied") }
+
+        it "returns 'No previous Linux...' message" do
+          expect(presenter.summary).to eq("<ul><li>#{message}</li></ul>")
+        end
+      end
+    end
+
+    context "when device is set and copy config is enabled" do
+      let(:config) { "root1" }
+      let(:copy_config) { true }
+      let(:message) do
+        _("SSH host keys and configuration will be copied from %s") %
+          "Operating system 1"
+      end
+
+      it "returns 'SSH host keys and configuration...'" do
+        expect(presenter.summary).to eq("<ul><li>#{message}</li></ul>")
+      end
+    end
+
+    context "when device is set and copy config is disabled" do
+      let(:config) { "root1" }
+      let(:message) do
+        _("SSH host keys will be copied from %s") %
+          "Operating system 1"
+      end
+
+      it "returns 'SSH host keys will be copied...'" do
+        expect(presenter.summary).to eq("<ul><li>#{message}</li></ul>")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Updates from code review for #380.

As we need `SshImporterProposal` and `SshImporterAutoClient` to show the same `summary`, instead of moving this logic to `SshImporter#summary`, I preferred to add a presenter. I don't like the idea of `SshImporter` knowing about i18n or HTML.