### PR TITLE
SSH Importer: Width fix to avoid cut of CheckBoxFrame Label

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,7 +1,8 @@
 -------------------------------------------------------------------
-Tue Jun  7 06:34:43 UTC 2016 - kanderssen@suse.com
+Tue Aug 16 15:34:43 UTC 2016 - kanderssen@suse.com
 
 - SSH Importer: Width fix to avoid cut of CheckBoxFrame Label
+  (fate##319624)
 - 3.1.208
 
 -------------------------------------------------------------------

--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Jun  7 06:34:43 UTC 2016 - kanderssen@suse.com
+
+- SSH Importer: Width fix to avoid cut of CheckBoxFrame Label
+- 3.1.208
+
+-------------------------------------------------------------------
 Fri Aug  5 07:22:59 UTC 2016 - igonzalezsosa@suse.com
 
 - Fix the registration screen initialization when SCC server

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation
-Version:        3.1.207
+Version:        3.1.208
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/installation/dialogs/ssh_import.rb
+++ b/src/lib/installation/dialogs/ssh_import.rb
@@ -68,7 +68,8 @@ module Yast
           # For some reason the CheckBoxFrame Label is cut if the label size
           # exceeds the CheckBoxFrame content's width. MinWidth with label length
           # is used to avoid this issue.
-          MinWidth(label.length,
+          MinWidth(
+            label.length,
             CheckBoxFrame(
               Id(:import_ssh_key),
               label,

--- a/src/lib/installation/dialogs/ssh_import.rb
+++ b/src/lib/installation/dialogs/ssh_import.rb
@@ -62,23 +62,26 @@ module Yast
     end
 
     def dialog_content
+      label = _("I would like to import SSH keys from a previous installation")
       HSquash(
         VBox(
-          CheckBoxFrame(
-            Id(:import_ssh_key),
-            _("I would like to import SSH keys from a previous installation"),
-            !(importer.device.nil? || importer.device.empty?),
-            VBox(
-              HStretch(),
-              VSpacing(1),
-              HBox(
-                HSpacing(2),
-                Mode.config ? device_name : partitions_list_widget
-              ),
-              VSpacing(3),
-              HBox(
-                HSpacing(2),
-                Left(copy_config_widget)
+          MinWidth(label.length,
+            CheckBoxFrame(
+              Id(:import_ssh_key),
+              label,
+              !(importer.device.nil? || importer.device.empty?),
+              VBox(
+                HStretch(),
+                VSpacing(1),
+                HBox(
+                  HSpacing(2),
+                  Mode.config ? device_name : partitions_list_widget
+                ),
+                VSpacing(3),
+                HBox(
+                  HSpacing(2),
+                  Left(copy_config_widget)
+                )
               )
             )
           ),

--- a/src/lib/installation/dialogs/ssh_import.rb
+++ b/src/lib/installation/dialogs/ssh_import.rb
@@ -65,6 +65,9 @@ module Yast
       label = _("I would like to import SSH keys from a previous installation")
       HSquash(
         VBox(
+          # For some reason the CheckBoxFrame Label is cut if the label size
+          # exceeds the CheckBoxFrame content's width. MinWidth with label length
+          # is used to avoid this issue.
           MinWidth(label.length,
             CheckBoxFrame(
               Id(:import_ssh_key),


### PR DESCRIPTION
By some reason the Label of the CheckBoxFrame is being cut. Now width is forced, but could be nice if some UI expert reviewed it as i'm not sure if could be some problem with long texts **(translations)**.

## Previously
![ssh-key_dialog_new](https://cloud.githubusercontent.com/assets/7056681/15848102/b3cd0254-2c82-11e6-91f5-604d16ee521d.png)


## With MinWidth

![ssh-key_dialog_new_length](https://cloud.githubusercontent.com/assets/7056681/15853940/3100da22-2c9f-11e6-8e6b-3f02d367ea06.png)






