### PR TITLE
Fix architecture detection

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Jun 14 14:17:53 UTC 2016 - igonzalezsosa@suse.com
+
+- Fix architecture detection during self-update (bsc#984656)
+- 3.1.194
+
+-------------------------------------------------------------------
 Thu Jun  2 11:09:33 UTC 2016 - schubi@suse.de
 
 - Adapt AutoYaST to support import of SSH server keys/configuration

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation
-Version:        3.1.193
+Version:        3.1.194
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/installation/clients/inst_update_installer.rb
+++ b/src/lib/installation/clients/inst_update_installer.rb
@@ -24,7 +24,7 @@ module Yast
     UPDATED_FLAG_FILENAME = "installer_updated"
     REMOTE_SCHEMES = ["http", "https", "ftp", "tftp", "sftp", "nfs", "nfs4", "cifs", "smb"]
 
-    Yast.import "Arch"
+    Yast.import "Pkg"
     Yast.import "GetInstArgs"
     Yast.import "Directory"
     Yast.import "Installation"
@@ -129,7 +129,7 @@ module Yast
     # @see URI.regexp
     def get_url_from(url)
       return nil unless url.is_a?(::String)
-      real_url = url.gsub(/\$arch\b/, Arch.architecture)
+      real_url = url.gsub(/\$arch\b/, Pkg.GetArchitecture)
       URI.regexp.match(real_url) ? URI(real_url) : nil
     end
 

--- a/src/lib/installation/update_repository.rb
+++ b/src/lib/installation/update_repository.rb
@@ -205,7 +205,7 @@ module Installation
       tempfile = Tempfile.new(package["name"])
       tempfile.close
       Dir.mktmpdir do |workdir|
-        log.info("DEBUG 1")
+        log.info("Trying to get #{package["name"]} from repo #{repo_id}")
         if !Yast::Pkg.ProvidePackage(repo_id, package["name"], tempfile.path.to_s)
           log.error("Package #{package} could not be retrieved.")
           raise PackageNotFound

--- a/test/inst_update_installer_test.rb
+++ b/test/inst_update_installer_test.rb
@@ -4,7 +4,6 @@ require_relative "test_helper"
 require "installation/clients/inst_update_installer"
 
 describe Yast::InstUpdateInstaller do
-  Yast.import "Arch"
   Yast.import "Linuxrc"
   Yast.import "ProductFeatures"
   Yast.import "GetInstArgs"
@@ -19,7 +18,7 @@ describe Yast::InstUpdateInstaller do
   let(:repo) { double("repo") }
 
   before do
-    allow(Yast::Arch).to receive(:architecture).and_return(arch)
+    allow(Yast::Pkg).to receive(:GetArchitecture).and_return(arch)
     allow(Yast::Mode).to receive(:auto).and_return(false)
     allow(Yast::NetworkService).to receive(:isNetworkRunning).and_return(network_running)
     allow(::Installation::UpdatesManager).to receive(:new).and_return(manager)


### PR DESCRIPTION
Fix architecture detection. It fixes [bsc#984656](https://bugzilla.suse.com/show_bug.cgi?id=984656).