### PR TITLE
Avoid restarting YaST when self-update repo is empty

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Jun 16 13:31:16 UTC 2016 - igonzalezsosa@suse.com
+
+- Avoid restarting YaST when self-update repository exists but
+  is empty (bsc#985113)
+- 3.1.196
+
+-------------------------------------------------------------------
 Wed Jun 15 15:15:15 CEST 2016 - snwint@suse.de
 
 - call set_videomode to adjust video mode (bsc#974821)

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation
-Version:        3.1.195
+Version:        3.1.196
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/installation/clients/inst_update_installer.rb
+++ b/src/lib/installation/clients/inst_update_installer.rb
@@ -173,10 +173,14 @@ module Yast
     # @return [Boolean] true if installer was updated; false otherwise.
     def update_installer
       log.info("Adding update from #{self_update_url}")
-      updates_manager.add_repository(self_update_url)
-      log.info("Applying installer updates")
-      updates_manager.apply_all
-      true
+      if updates_manager.add_repository(self_update_url)
+        log.info("Applying installer updates")
+        updates_manager.apply_all
+        true
+      else
+        log.info("No packages were found")
+        false
+      end
 
     rescue ::Installation::UpdatesManager::NotValidRepo
       if !using_default_url?

--- a/src/lib/installation/clients/inst_update_installer.rb
+++ b/src/lib/installation/clients/inst_update_installer.rb
@@ -173,14 +173,13 @@ module Yast
     # @return [Boolean] true if installer was updated; false otherwise.
     def update_installer
       log.info("Adding update from #{self_update_url}")
-      if updates_manager.add_repository(self_update_url)
+      updates_manager.add_repository(self_update_url)
+      updated = updates_manager.repositories?
+      if updated
         log.info("Applying installer updates")
         updates_manager.apply_all
-        true
-      else
-        log.info("No packages were found")
-        false
       end
+      updated
 
     rescue ::Installation::UpdatesManager::NotValidRepo
       if !using_default_url?

--- a/src/lib/installation/update_repository.rb
+++ b/src/lib/installation/update_repository.rb
@@ -189,6 +189,15 @@ module Installation
       Yast::Pkg.SourceDelete(repo_id)
     end
 
+    # Determine whether the repository is empty or not
+    #
+    # @return [Boolean] true if the repository is empty; false otherwise.
+    #
+    # @see #packages
+    def empty?
+      packages.empty?
+    end
+
   private
 
     # Fetch and build a squashfs filesytem for a given package

--- a/src/lib/installation/updates_manager.rb
+++ b/src/lib/installation/updates_manager.rb
@@ -81,13 +81,13 @@ module Installation
     def add_repository(uri)
       new_repository = Installation::UpdateRepository.new(uri)
       new_repository.fetch
-      if new_repository.empty?
-        log.info("Update repository at #{uri} is empty. Skipping...")
-        false
+      has_packages = !new_repository.empty?
+      if has_packages
+        repositories << new_repository
       else
-        @repositories << new_repository
-        true
+        log.info("Update repository at #{uri} is empty. Skipping...")
       end
+      has_packages
     rescue Installation::UpdateRepository::NotValidRepo
       log.warn("Update repository at #{uri} could not be found")
       raise NotValidRepo
@@ -110,6 +110,11 @@ module Installation
     def apply_all
       (repositories + driver_updates).each(&:apply)
       repositories.each(&:cleanup)
+    end
+
+    # Determines whether the manager has repositories with updates
+    def repositories?
+      !repositories.empty?
     end
   end
 end

--- a/src/lib/installation/updates_manager.rb
+++ b/src/lib/installation/updates_manager.rb
@@ -75,13 +75,19 @@ module Installation
     # information.
     #
     # @param uri [URI] URI where the repository lives
-    # @return [Array<UpdateRepository] Array of repositories to be applied
+    # @return [Boolean] true if the repository was added; false otherwise.
     #
     # @see Installation::UpdateRepository
     def add_repository(uri)
       new_repository = Installation::UpdateRepository.new(uri)
       new_repository.fetch
-      @repositories << new_repository
+      if new_repository.empty?
+        log.info("Update repository at #{uri} is empty. Skipping...")
+        false
+      else
+        @repositories << new_repository
+        true
+      end
     rescue Installation::UpdateRepository::NotValidRepo
       log.warn("Update repository at #{uri} could not be found")
       raise NotValidRepo

--- a/test/inst_update_installer_test.rb
+++ b/test/inst_update_installer_test.rb
@@ -9,13 +9,17 @@ describe Yast::InstUpdateInstaller do
   Yast.import "GetInstArgs"
   Yast.import "UI"
 
-  let(:manager) { double("update_manager", all_signed?: all_signed?, apply_all: true) }
+  let(:manager) do
+    double("update_manager", all_signed?: all_signed?, apply_all: true,
+      repositories?: has_repos)
+  end
   let(:url) { "http://update.opensuse.org/\$arch/update.dud" }
   let(:real_url) { "http://update.opensuse.org/#{arch}/update.dud" }
   let(:arch) { "x86_64" }
   let(:all_signed?) { true }
   let(:network_running) { true }
   let(:repo) { double("repo") }
+  let(:has_repos) { true }
 
   before do
     allow(Yast::Pkg).to receive(:GetArchitecture).and_return(arch)
@@ -79,6 +83,8 @@ describe Yast::InstUpdateInstaller do
       end
 
       context "when repository is empty" do
+        let(:has_repos) { false }
+
         it "does not restart YaST" do
           expect(manager).to receive(:add_repository)
             .and_return(false)

--- a/test/updates_manager_test.rb
+++ b/test/updates_manager_test.rb
@@ -23,9 +23,10 @@ describe Installation::UpdatesManager do
     end
 
     context "when repository is added successfully" do
-      it "returns true" do
+      it "returns true and add the repository" do
         allow(repo0).to receive(:fetch)
         expect(manager.add_repository(uri)).to eq(true)
+        expect(manager.repositories).to eq([repo0])
       end
     end
 
@@ -34,6 +35,7 @@ describe Installation::UpdatesManager do
         allow(repo0).to receive(:fetch)
         allow(repo0).to receive(:empty?).and_return(true)
         expect(manager.add_repository(uri)).to eq(false)
+        expect(manager.repositories).to be_empty
       end
     end
 

--- a/test/updates_manager_test.rb
+++ b/test/updates_manager_test.rb
@@ -12,8 +12,8 @@ describe Installation::UpdatesManager do
 
   let(:uri) { URI("http://updates.opensuse.org/sles12") }
 
-  let(:repo0) { double("repo0", apply: true, cleanup: true) }
-  let(:repo1) { double("repo1", apply: true, cleanup: true) }
+  let(:repo0) { double("repo0", apply: true, cleanup: true, :empty? => false) }
+  let(:repo1) { double("repo1", apply: true, cleanup: true, :empty? => false) }
   let(:dud0)  { double("dud0", apply: true) }
 
   describe "#add_repository" do
@@ -23,9 +23,17 @@ describe Installation::UpdatesManager do
     end
 
     context "when repository is added successfully" do
-      it "returns an array containing all repos" do
+      it "returns true" do
         allow(repo0).to receive(:fetch)
-        expect(manager.add_repository(uri)).to eq([repo0])
+        expect(manager.add_repository(uri)).to eq(true)
+      end
+    end
+
+    context "when repository is empty" do
+      it "returns false" do
+        allow(repo0).to receive(:fetch)
+        allow(repo0).to receive(:empty?).and_return(true)
+        expect(manager.add_repository(uri)).to eq(false)
       end
     end
 

--- a/test/updates_manager_test.rb
+++ b/test/updates_manager_test.rb
@@ -12,8 +12,8 @@ describe Installation::UpdatesManager do
 
   let(:uri) { URI("http://updates.opensuse.org/sles12") }
 
-  let(:repo0) { double("repo0", apply: true, cleanup: true, :empty? => false) }
-  let(:repo1) { double("repo1", apply: true, cleanup: true, :empty? => false) }
+  let(:repo0) { double("repo0", apply: true, cleanup: true, empty?: false) }
+  let(:repo1) { double("repo1", apply: true, cleanup: true, empty?: false) }
   let(:dud0)  { double("dud0", apply: true) }
 
   describe "#add_repository" do
@@ -122,6 +122,28 @@ describe Installation::UpdatesManager do
       it "also re-applies the driver updates" do
         expect(dud0).to receive(:apply)
         manager.apply_all
+      end
+    end
+  end
+
+  describe "#repositories?" do
+    context "when some repository was added" do
+      before do
+        allow(manager).to receive(:repositories).and_return([repo0])
+      end
+
+      it "returns true" do
+        expect(manager.repositories?).to eq(true)
+      end
+    end
+
+    context "when no repository was added" do
+      before do
+        allow(manager).to receive(:repositories).and_return([])
+      end
+
+      it "returns false" do
+        expect(manager.repositories?).to eq(false)
       end
     end
   end


### PR DESCRIPTION
Fixes [bsc#985113](https://bugzilla.suse.com/show_bug.cgi?id=985113).