### PR TITLE
More information in the self update error popup (bsc#986091)

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Jun 23 08:17:24 UTC 2016 - lslezak@suse.cz
+
+- Display more information in the error popup when downloading
+  the optional installer updates fails (bsc#986091)
+- 3.1.197
+
+-------------------------------------------------------------------
 Thu Jun 16 13:31:16 UTC 2016 - igonzalezsosa@suse.com
 
 - Avoid restarting YaST when self-update repository exists but

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation
-Version:        3.1.196
+Version:        3.1.197
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/installation/clients/inst_update_installer.rb
+++ b/src/lib/installation/clients/inst_update_installer.rb
@@ -214,9 +214,19 @@ module Yast
     #                   false if the network is not configured.
     def configure_network?
       if Popup.YesNo(
+        # Note: the proxy cannot be configured in the YaST installer yet,
+        # it needs to be set via the "proxy" boot option.
         # TRANSLATORS: %s is an URL
-        format(_("Downloading installer updates from \n%s\nfailed.\n\n" \
-                 "Would you like to check your network configuration?"), self_update_url))
+        format(_("Downloading the optional installer updates from \n%s\nfailed.\n" \
+                 "\n" \
+                 "You can continue the installation without applying the updates.\n" \
+                 "However, some potentially important bug fixes might be missing.\n" \
+                 "\n" \
+                 "If you need a proxy server to access the update repository\n" \
+                 "then use the \"proxy\" boot parameter.\n" \
+                 "\n" \
+                 "Would you like to check your network configuration\n" \
+                 "and try installing the updates again?"), self_update_url))
         Yast::WFM.CallFunction("inst_lan", [{ "skip_detection" => true }])
         true
       else


### PR DESCRIPTION
The current error message is a bit scary for the customers, we need to tell them that the installer updates are optional and it is OK to continue without them.

See [bug #986091](https://bugzilla.suse.com/show_bug.cgi?id=986091) for more details.

- 3.1.197

## Screenshots

#### The Original Message
![self_update_error_old](https://cloud.githubusercontent.com/assets/907998/16297125/bdcffdba-392f-11e6-9093-7eb4a957039b.png)

#### The Improved Message

![self_update_error](https://cloud.githubusercontent.com/assets/907998/16297006/13e8708e-392f-11e6-9ece-150504d72a21.png)
