### PR TITLE
Get self-update URL from SMT through SUSEconnect

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Jul  4 08:05:53 UTC 2016 - igonzalezsosa@suse.com
+
+- Retrieve self-update URL from SMT (FATE#319716)
+- 3.1.199
+
+-------------------------------------------------------------------
 Mon Jun 27 13:00:24 UTC 2016 - jreidinger@suse.com
 
 - Make writing of bootloader settings the last step so that other

--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,7 +1,8 @@
 -------------------------------------------------------------------
 Mon Jul  4 08:05:53 UTC 2016 - igonzalezsosa@suse.com
 
-- Retrieve self-update URL from SMT (FATE#319716)
+- Retrieve the self-update URL from the registration
+  server (SCC/SMT) (FATE#319716)
 - 3.1.199
 
 -------------------------------------------------------------------

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation
-Version:        3.1.198
+Version:        3.1.199
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/installation/clients/inst_update_installer.rb
+++ b/src/lib/installation/clients/inst_update_installer.rb
@@ -103,10 +103,12 @@ module Yast
     # @return [URI,nil] self-update URL. nil if no URL was found.
     def self_update_url_from_connect
       require "registration/sw_mgmt"
+      require "registration/url_helpers"
       require "suse/connect"
       base_product = Registration::SwMgmt.base_product_to_register
       product = Registration::SwMgmt.remote_product(base_product)
-      update = SUSE::Connect::YaST.list_installer_updates(product).first
+      update = SUSE::Connect::YaST.list_installer_updates(product,
+        url: Registration::UrlHelpers.registration_url).first
       log.info("self-update repository for product '#{base_product}' is #{update}")
       update ? URI(update.url) : nil
     rescue LoadError

--- a/src/lib/installation/clients/inst_update_installer.rb
+++ b/src/lib/installation/clients/inst_update_installer.rb
@@ -86,11 +86,32 @@ module Yast
     # @see #self_update_url_from_linuxrc
     # @see #self_update_url_from_control
     # @see #self_update_url_from_profile
+    # @see #self_update_url_from_connect
     def self_update_url
-      url = self_update_url_from_linuxrc || self_update_url_from_profile ||
-        self_update_url_from_control
-      log.info("self-update URL is #{url}")
-      url
+      return @url unless @url.nil?
+      @url = self_update_url_from_linuxrc || self_update_url_from_profile ||
+        self_update_url_from_connect || self_update_url_from_control
+      log.info("self-update URL is #{@url}")
+      @url
+    end
+
+    # Return the self-update URL from SMT servers
+    #
+    # Return nil if yast2-registration or SUSEConnect are not available
+    # (for instance in openSUSE).
+    #
+    # @return [URI,nil] self-update URL. nil if no URL was found.
+    def self_update_url_from_connect
+      require "registration/sw_mgmt"
+      require "suse/connect"
+      base_product = Registration::SwMgmt.base_product_to_register
+      product = Registration::SwMgmt.remote_product(base_product)
+      update = SUSE::Connect::YaST.list_installer_updates(product).first
+      log.info("self-update repository for product '#{base_product}' is #{update}")
+      update ? URI(update.url) : nil
+    rescue LoadError
+      log.info "yast2-registration or SUSEConnect are not available"
+      nil
     end
 
     # Return the self-update URL according to Linuxrc

--- a/test/inst_update_installer_test.rb
+++ b/test/inst_update_installer_test.rb
@@ -169,9 +169,9 @@ describe Yast::InstUpdateInstaller do
 
           let(:base_product) do
             {
-              "arch" => "x86_64",
-              "name" => "SLES",
-              "version" => "12-2",
+              "arch"         => "x86_64",
+              "name"         => "SLES",
+              "version"      => "12-2",
               "release_type" => ""
             }
           end
@@ -189,7 +189,7 @@ describe Yast::InstUpdateInstaller do
 
           let(:sw_mgmt) do
             double("sw_mgmt", base_product_to_register: base_product,
-              remote_product: product)
+                              remote_product:           product)
           end
 
           let(:suse_connect) do

--- a/test/inst_update_installer_test.rb
+++ b/test/inst_update_installer_test.rb
@@ -164,7 +164,8 @@ describe Yast::InstUpdateInstaller do
         end
 
         context "when SMT defines the URL" do
-          let(:smt_url) { "http://update.suse.com/sle12/12.2" }
+          let(:update_url) { "http://update.suse.com/sle12/12.2" }
+          let(:smt_url) { "http://update.suse.com" }
 
           let(:base_product) do
             {
@@ -184,7 +185,7 @@ describe Yast::InstUpdateInstaller do
             )
           end
 
-          let(:update) { OpenStruct.new(name: "SLES-12-Installer-Updates", url: smt_url) }
+          let(:update) { OpenStruct.new(name: "SLES-12-Installer-Updates", url: update_url) }
 
           let(:sw_mgmt) do
             double("sw_mgmt", base_product_to_register: base_product,
@@ -195,21 +196,25 @@ describe Yast::InstUpdateInstaller do
             double("suse_connect", list_installer_updates: [update])
           end
 
+          let(:url_helpers) { double("url_helpers", registration_url: smt_url) }
+
           before do
             allow(subject).to receive(:require).with("registration/sw_mgmt").and_return(true)
+            allow(subject).to receive(:require).with("registration/url_helpers").and_return(true)
             allow(subject).to receive(:require).with("suse/connect").and_return(true)
             stub_const("Registration::SwMgmt", sw_mgmt)
+            stub_const("Registration::UrlHelpers", url_helpers)
             stub_const("SUSE::Connect::YaST", suse_connect)
-            allow(suse_connect).to receive(:list_installer_updates)
-              .and_return([update])
             allow(::FileUtils).to receive(:touch)
           end
 
           it "tries to update the installer using the given URL" do
             expect(sw_mgmt).to receive(:remote_product).with(base_product)
               .and_return(product)
-            expect(manager).to receive(:add_repository).with(URI(smt_url))
+            expect(manager).to receive(:add_repository).with(URI(update_url))
               .and_return(true)
+            expect(suse_connect).to receive(:list_installer_updates).with(product, url: smt_url)
+              .and_return([update])
             expect(subject.main).to eq(:restart_yast)
           end
         end

--- a/test/inst_update_installer_test.rb
+++ b/test/inst_update_installer_test.rb
@@ -28,6 +28,7 @@ describe Yast::InstUpdateInstaller do
     allow(::Installation::UpdatesManager).to receive(:new).and_return(manager)
     allow(Yast::Installation).to receive(:restarting?)
     allow(Yast::Installation).to receive(:restart!) { :restart_yast }
+    allow(subject).to receive(:require).with("registration/sw_mgmt").and_raise(LoadError)
 
     # stub the Profile module to avoid dependency on autoyast2-installation
     ay_profile = double("Yast::Profile")
@@ -159,6 +160,57 @@ describe Yast::InstUpdateInstaller do
             it "does not update the installer" do
               expect(subject).to_not receive(:update_installer)
             end
+          end
+        end
+
+        context "when SMT defines the URL" do
+          let(:smt_url) { "http://update.suse.com/sle12/12.2" }
+
+          let(:base_product) do
+            {
+              "arch" => "x86_64",
+              "name" => "SLES",
+              "version" => "12-2",
+              "release_type" => ""
+            }
+          end
+
+          let(:product) do
+            OpenStruct.new(
+              arch:         base_product["arch"],
+              identifier:   base_product["name"],
+              version:      base_product["version"],
+              release_type: base_product["release_type"]
+            )
+          end
+
+          let(:update) { OpenStruct.new(name: "SLES-12-Installer-Updates", url: smt_url) }
+
+          let(:sw_mgmt) do
+            double("sw_mgmt", base_product_to_register: base_product,
+              remote_product: product)
+          end
+
+          let(:suse_connect) do
+            double("suse_connect", list_installer_updates: [update])
+          end
+
+          before do
+            allow(subject).to receive(:require).with("registration/sw_mgmt").and_return(true)
+            allow(subject).to receive(:require).with("suse/connect").and_return(true)
+            stub_const("Registration::SwMgmt", sw_mgmt)
+            stub_const("SUSE::Connect::YaST", suse_connect)
+            allow(suse_connect).to receive(:list_installer_updates)
+              .and_return([update])
+            allow(::FileUtils).to receive(:touch)
+          end
+
+          it "tries to update the installer using the given URL" do
+            expect(sw_mgmt).to receive(:remote_product).with(base_product)
+              .and_return(product)
+            expect(manager).to receive(:add_repository).with(URI(smt_url))
+              .and_return(true)
+            expect(subject.main).to eq(:restart_yast)
           end
         end
 


### PR DESCRIPTION
Add SMT integration in [FATE#319716](https://fate.suse.com/319716).

Only 1 URL is currently supported, but `list_installer_updates` will return an `Array` anyway. If we want to support multiple URLs, we should also answer some additional questions:

* Should we support multiple self-update values in control.xml and AutoYaST profiles?
* Should we add support to add a self-update URL (not replace) in Linuxrc?