### PR TITLE
 Get self-update URL from SMT through SUSEconnect (with multiple URLs support)

### DIFF
--- a/doc/SELF_UPDATE.md
+++ b/doc/SELF_UPDATE.md
@@ -36,7 +36,7 @@ handled in a different way:
 The URL of the update repository is evaluated in this order:
 
 1. The `SelfUpdate` boot option
-2. The AutoYaST control file - in AutoYaST installation only, use the
+2. The AutoYaST profile - in AutoYaST installation only, use the
    `/general/self_update_url` XML node:
 
    ```xml
@@ -44,6 +44,14 @@ The URL of the update repository is evaluated in this order:
      <self_update_url>http://example.com/updates/$arch</self_update_url>
    </general>
    ```
+3. Registration server (SCC/SMT), not available in openSUSE. The URL of the
+   registration server which should be used is determined via:
+   1. AutoYaST profile ([reg_server element](https://www.suse.com/documentation/sles-12/singlehtml/book_autoyast/book_autoyast.html#CreateProfile.Register)).
+   2. The `regurl` boot parameter
+   3. SLP lookup:
+      * If one server is found, it will be used automatically.
+      * If more than one server is found, it will ask the user to choose one.
+   4. Default SUSE Customer Center API (`https://scc.suse.com/`).
 3. Hard-coded in the `control.xml` file on the installation medium (thus it
    depends on the base product):
 
@@ -62,7 +70,7 @@ in the [Arch module](http://www.rubydoc.info/github/yast/yast-yast2/Yast/ArchCla
 
 ### Actual URLs
 
-The regular update URLs have the form
+Whe using registration servers, the regular update URLs have the form
 `https://updates.suse.com/SUSE/Updates/$PRODUCT/$VERSION/$ARCH/update` where
 - PRODUCT is like OpenStack-Cloud, SLE-DESKTOP, SLE-SDK, SLE-SERVER,
 - VERSION (for SLE-SERVER) is like 12, 12-SP1,

--- a/doc/SELF_UPDATE.md
+++ b/doc/SELF_UPDATE.md
@@ -48,7 +48,7 @@ The URL of the update repository is evaluated in this order:
    registration server which should be used is determined via:
    1. AutoYaST profile ([reg_server element](https://www.suse.com/documentation/sles-12/singlehtml/book_autoyast/book_autoyast.html#CreateProfile.Register)).
    2. The `regurl` boot parameter
-   3. SLP lookup:
+   3. SLP lookup (this behavior applies to regular and AutoYaST installations):
       * If one server is found, it will be used automatically.
       * If more than one server is found, it will ask the user to choose one.
    4. Default SUSE Customer Center API (`https://scc.suse.com/`).
@@ -109,3 +109,22 @@ Currently there is no API available for remembering the client states. The easie
 way is to store the configuration into an YAML file and load it when restarting the
 installer. See the [example](https://github.com/yast/yast-installation/pull/367/files#diff-4c91d6424e08c9bef9237f7d959fc0c2R48)
 in the `inst_complex_welcome` client.
+
+## Error handling
+
+Errors during the installer update are handled as described below:
+
+* If network is not available, the installer update will be skipped.
+* If the network is configured but the installer updates repository or the
+  registration server are not reachable:
+  * in a regular installation/upgrade, YaST2 will offer the possibility
+    to check/adjust the network configuration.
+  * in an AutoYaST installation/upgrade, a warning will be shown.
+* If the updates repository is found but it is empty or not valid:
+  * in the case that the URL was specified by the user (using the *SelfUpdate* boot
+    option or through the *self_update_url* element in an AutoYaST profile), an
+    error message will be shown.
+  * if the URL was not specified by the user, the installer will skip the update
+    process (it will assume that no updates are available).
+* If something goes wrong trying to fetch and apply the update, the user will be
+  notified.

--- a/doc/SELF_UPDATE.md
+++ b/doc/SELF_UPDATE.md
@@ -52,7 +52,7 @@ The URL of the update repository is evaluated in this order:
       * If one server is found, it will be used automatically.
       * If more than one server is found, it will ask the user to choose one.
    4. Default SUSE Customer Center API (`https://scc.suse.com/`).
-3. Hard-coded in the `control.xml` file on the installation medium (thus it
+4. Hard-coded in the `control.xml` file on the installation medium (thus it
    depends on the base product):
 
    ```xml
@@ -61,8 +61,10 @@ The URL of the update repository is evaluated in this order:
    </globals>
    ```
 
-The first found option is used. If no update URL is found then the self update
-is skipped.
+The first suitable URL will be used. There are two exceptions:
+
+* Of course, if no update URL is found then the self update is skipped.
+* If SCC/SMT provides multiple URLs, they will be all used.
 
 The URL can contain a variable `$arch` that will be replaced by the system's
 architecture, such as `x86_64`, `s390x`, etc. You can find more information
@@ -70,7 +72,7 @@ in the [Arch module](http://www.rubydoc.info/github/yast/yast-yast2/Yast/ArchCla
 
 ### Actual URLs
 
-Whe using registration servers, the regular update URLs have the form
+When using registration servers, the regular update URLs have the form
 `https://updates.suse.com/SUSE/Updates/$PRODUCT/$VERSION/$ARCH/update` where
 - PRODUCT is like OpenStack-Cloud, SLE-DESKTOP, SLE-SDK, SLE-SERVER,
 - VERSION (for SLE-SERVER) is like 12, 12-SP1,

--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Jul  4 08:05:53 UTC 2016 - igonzalezsosa@suse.com
+
+- Retrieve self-update URL from SMT (FATE#319716)
+- 3.1.204
+
+-------------------------------------------------------------------
 Fri Jul 22 13:48:12 UTC 2016 - igonzalezsosa@suse.com
 
 - Don't halt the installation if installer updates server

--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,7 +1,8 @@
 -------------------------------------------------------------------
-Mon Jul  4 08:05:53 UTC 2016 - igonzalezsosa@suse.com
+Mon Jul 25 15:07:19 UTC 2016 - igonzalezsosa@suse.com
 
-- Retrieve self-update URL from SMT (FATE#319716)
+- Retrieve the self-update URL from the registration
+  server (SCC/SMT) (FATE#319716)
 - 3.1.204
 
 -------------------------------------------------------------------

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -130,8 +130,6 @@ Recommends:	curl
 Recommends:	yast2-update
 Recommends:	yast2-add-on
 
-Conflicts: yast2-registration < 3.1.177
-
 PreReq:		%fillup_prereq
 
 BuildArch: noarch

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation
-Version:        3.1.203
+Version:        3.1.204
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -127,6 +127,8 @@ Recommends:	curl
 Recommends:	yast2-update
 Recommends:	yast2-add-on
 
+Conflicts: yast2-registration < 3.1.177
+
 PreReq:		%fillup_prereq
 
 BuildArch: noarch

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -97,6 +97,9 @@ Conflicts:	yast2-core < 2.17.10
 # Top bar with logo
 Conflicts:	yast2-ycp-ui-bindings < 3.1.7
 
+# RegserviceSelectionDialog
+Conflicts:  yast2-registration < 3.1.179
+
 Obsoletes:	yast2-installation-devel-doc
 
 # tar-gzip some system files and untar-ungzip them after the installation (FATE #300421, #120103)

--- a/src/lib/installation/clients/inst_update_installer.rb
+++ b/src/lib/installation/clients/inst_update_installer.rb
@@ -103,10 +103,12 @@ module Yast
     # @return [URI,nil] self-update URL. nil if no URL was found.
     def self_update_url_from_connect
       require "registration/sw_mgmt"
+      require "registration/url_helpers"
       require "suse/connect"
       base_product = Registration::SwMgmt.base_product_to_register
       product = Registration::SwMgmt.remote_product(base_product)
-      update = SUSE::Connect::YaST.list_installer_updates(product).first
+      update = SUSE::Connect::YaST.list_installer_updates(product,
+        url: Registration::UrlHelpers.registration_url).first
       log.info("self-update repository for product '#{base_product}' is #{update}")
       update ? URI(update.url) : nil
     rescue LoadError

--- a/src/lib/installation/clients/inst_update_installer.rb
+++ b/src/lib/installation/clients/inst_update_installer.rb
@@ -268,22 +268,22 @@ module Yast
       log.info("Adding update from #{url}")
       updates_manager.add_repository(url)
 
-    rescue ::Installation::UpdatesManager::NotValidRepo => e
-      if !default_url?(e.uri)
+    rescue ::Installation::UpdatesManager::NotValidRepo
+      if !default_url?(url)
         # TRANSLATORS: %s is an URL
-        Report.Error(format(_("A valid update could not be found at\n%s.\n\n"), e.uri))
+        Report.Error(format(_("A valid update could not be found at\n%s.\n\n"), url))
       end
       false
 
-    rescue ::Installation::UpdatesManager::CouldNotFetchUpdateFromRepo => e
+    rescue ::Installation::UpdatesManager::CouldNotFetchUpdateFromRepo
       # TRANSLATORS: %s is an URL
-      Report.Error(format(_("Could not fetch update from\n%s.\n\n"), e.uri))
+      Report.Error(format(_("Could not fetch update from\n%s.\n\n"), url))
       false
 
     rescue ::Installation::UpdatesManager::CouldNotProbeRepo
       if Mode.auto
-        Report.Warning(could_not_probe_repo_msg)
-      elsif remote_url?(e.uri) && configure_network?(e.uri)
+        Report.Warning(could_not_probe_repo_msg(url))
+      elsif remote_url?(url) && configure_network?(url)
         retry
       end
       false

--- a/src/lib/installation/clients/inst_update_installer.rb
+++ b/src/lib/installation/clients/inst_update_installer.rb
@@ -164,6 +164,7 @@ module Yast
       return [] if url == :cancel
 
       log.info("Using registration URL: #{url}")
+      import_registration_ayconfig if Mode.auto
       registration = Registration::Registration.new(url == :scc ? nil : url)
       # Set custom_url into installation options
       Registration::Storage::InstallationOptions.instance.custom_url = registration.url
@@ -421,6 +422,17 @@ module Yast
       Registration::Storage::InstallationOptions.instance.custom_url = data["custom_url"]
       ::FileUtils.rm_rf(REGISTRATION_DATA_PATH)
       true
+    end
+
+    # Load registration configuration from AutoYaST profile
+    #
+    # This data will be used by Registration::ConnectHelpers.catch_registration_errors.
+    #
+    # @see Yast::Profile.current
+    def import_registration_ayconfig
+      ::Registration::Storage::Config.instance.import(
+        Yast::Profile.current.fetch("suse_register", {})
+      )
     end
   end
 end

--- a/src/lib/installation/clients/inst_update_installer.rb
+++ b/src/lib/installation/clients/inst_update_installer.rb
@@ -165,7 +165,7 @@ module Yast
 
       log.info("Using registration URL: #{url}")
       import_registration_ayconfig if Mode.auto
-      registration = Registration::Registration.new(url == :scc ? nil : url)
+      registration = Registration::Registration.new(url == :scc ? nil : url.to_s)
       # Set custom_url into installation options
       Registration::Storage::InstallationOptions.instance.custom_url = registration.url
       store_registration_url(registration.url)
@@ -182,15 +182,15 @@ module Yast
     #   * If there's only 1 SMT server, it will be chosen automatically.
     #   * If there's more than 1 SMT server, it will ask the user to choose one
     #
-    # @return [String,Symbol] Registration URL; :scc if SCC server was selected;
-    #                         :cancel if dialog was dismissed.
+    # @return [URI,:scc,:cancel] Registration URL; :scc if SCC server was selected;
+    #                            :cancel if dialog was dismissed.
     #
     # @see #registration_server_from_user
     def registration_url
       url = registration_url_from_profile || ::Registration::UrlHelpers.boot_reg_url
-      return url.to_s if url
+      return URI(url) if url
       services = ::Registration::UrlHelpers.slp_discovery
-      return nil if services.empty?
+      return :scc if services.empty?
       service =
         if services.size > 1
           registration_service_from_user(services)
@@ -198,7 +198,7 @@ module Yast
           services.first
         end
       return service unless service.respond_to?(:slp_url)
-      ::Registration::UrlHelpers.service_url(service.slp_url)
+      URI(::Registration::UrlHelpers.service_url(service.slp_url))
     end
 
     # Return the registration server URL from the AutoYaST profile

--- a/src/lib/installation/clients/inst_update_installer.rb
+++ b/src/lib/installation/clients/inst_update_installer.rb
@@ -163,6 +163,7 @@ module Yast
       url = registration_url
       return [] if url == :cancel
 
+      log.info("Using registration URL: #{url}")
       registration = Registration::Registration.new(url == :scc ? nil : url)
       # Set custom_url into installation options
       Registration::Storage::InstallationOptions.instance.custom_url = registration.url
@@ -186,7 +187,7 @@ module Yast
     # @see #registration_server_from_user
     def registration_url
       url = registration_url_from_profile || ::Registration::UrlHelpers.boot_reg_url
-      return url if url
+      return url.to_s if url
       services = ::Registration::UrlHelpers.slp_discovery
       return nil if services.empty?
       service =
@@ -405,9 +406,9 @@ module Yast
 
     # Store URL of registration server to be used by inst_scc client
     #
-    # @params [String] Registration server URL.
+    # @params [URI] Registration server URL.
     def store_registration_url(url)
-      data = { "custom_url" => url }
+      data = { "custom_url" => url.to_s }
       File.write(REGISTRATION_DATA_PATH, data.to_yaml)
     end
 

--- a/src/lib/installation/clients/inst_update_installer.rb
+++ b/src/lib/installation/clients/inst_update_installer.rb
@@ -86,11 +86,32 @@ module Yast
     # @see #self_update_url_from_linuxrc
     # @see #self_update_url_from_control
     # @see #self_update_url_from_profile
+    # @see #self_update_url_from_connect
     def self_update_url
-      url = self_update_url_from_linuxrc || self_update_url_from_profile ||
-        self_update_url_from_control
-      log.info("self-update URL is #{url}")
-      url
+      return @url unless @url.nil?
+      @url = self_update_url_from_linuxrc || self_update_url_from_profile ||
+        self_update_url_from_connect || self_update_url_from_control
+      log.info("self-update URL is #{@url}")
+      @url
+    end
+
+    # Return the self-update URL from SMT servers
+    #
+    # Return nil if yast2-registration or SUSEConnect are not available
+    # (for instance in openSUSE).
+    #
+    # @return [URI,nil] self-update URL. nil if no URL was found.
+    def self_update_url_from_connect
+      require "registration/sw_mgmt"
+      require "suse/connect"
+      base_product = Registration::SwMgmt.base_product_to_register
+      product = Registration::SwMgmt.remote_product(base_product)
+      update = SUSE::Connect::YaST.list_installer_updates(product).first
+      log.info("self-update repository for product '#{base_product}' is #{update}")
+      update ? URI(update.url) : nil
+    rescue LoadError
+      log.info "yast2-registration or SUSEConnect are not available"
+      nil
     end
 
     # Return the self-update URL according to Linuxrc

--- a/src/lib/installation/clients/inst_update_installer.rb
+++ b/src/lib/installation/clients/inst_update_installer.rb
@@ -109,10 +109,10 @@ module Yast
     #
     # @return [Array<URI>] self-update URLs
     #
-    # @see #custom_self_update_url
     # @see #default_self_update_url
+    # @see #custom_self_update_url
     def self_update_urls
-      return @self_update_urls unless @self_update_urls.nil?
+      return @self_update_urls if @self_update_urls
       @self_update_urls = Array(custom_self_update_url)
       @self_update_urls = default_self_update_urls if @self_update_urls.empty?
       log.info("self-update URLs are #{@self_update_urls}")
@@ -125,7 +125,7 @@ module Yast
     #
     # @return [Array<URI>] self-update URLs
     def default_self_update_urls
-      return @default_self_update_urls unless @default_self_update_urls.nil?
+      return @default_self_update_urls if @default_self_update_urls
       @default_self_update_urls = self_update_url_from_connect
       return @default_self_update_urls unless @default_self_update_urls.empty?
       @default_self_update_urls = Array(self_update_url_from_control)
@@ -146,9 +146,10 @@ module Yast
     # Return the self-update URLs from SCC/SMT server
     #
     # Return an empty array if yast2-registration or SUSEConnect are not
-    # available (for instance in openSUSE). More than 1 URLs can be specified.
+    # available (for instance in openSUSE). More than 1 URLs can be found.
     #
-    # As a side effect, it stores the URL of the registration server used.
+    # As a side effect, it stores the URL of the registration server used
+    # in the installation options.
     #
     # @return [Array<URI>] self-update URLs.
     def self_update_url_from_connect
@@ -165,7 +166,7 @@ module Yast
                "for product '#{base_product}' are #{updates}")
       updates.map { |u| URI(u.url) }
     rescue SocketError => e
-      log.warn("Registration server could not be reached (URL: #{options.custom_url})")
+      log.warn("Registration server (URL #{options.custom_url}) could not be reached (#{e.message})")
       if configure_network?(could_not_find_updates_msg)
         retry
       else
@@ -204,7 +205,7 @@ module Yast
     #                                           :cancel if the dialog was dismissed.
     def registration_service_from_user(services)
       ::Registration::UI::RegserviceSelectionDialog.run(
-        services: services,
+        services:    services,
         description: _("Select a detected registration server from the list\n" \
           "to search for installer updates.")
       )

--- a/src/lib/installation/update_repository.rb
+++ b/src/lib/installation/update_repository.rb
@@ -49,7 +49,7 @@ module Installation
     # @return [Array<Pathname>] local paths of updates fetched from the repo
     attr_reader :update_files
 
-    # A valid repository was not found (altough the URL exists,
+    # A valid repository was not found (although the URL exists,
     # repository type cannot be determined).
     class NotValidRepo < StandardError; end
 

--- a/src/lib/installation/updates_manager.rb
+++ b/src/lib/installation/updates_manager.rb
@@ -104,13 +104,13 @@ module Installation
       has_packages
     rescue Installation::UpdateRepository::NotValidRepo
       log.warn("Update repository at #{uri} could not be found")
-      raise NotValidRepo.new(uri)
+      raise NotValidRepo, uri
     rescue Installation::UpdateRepository::FetchError
       log.error("Update repository at #{uri} was found but update could not be fetched")
-      raise CouldNotFetchUpdateFromRepo.new(uri)
+      raise CouldNotFetchUpdateFromRepo, uri
     rescue Installation::UpdateRepository::CouldNotProbeRepo
       log.error("Update repository at #{uri} could not be read")
-      raise CouldNotProbeRepo.new(uri)
+      raise CouldNotProbeRepo, uri
     end
 
     # Applies all the updates

--- a/src/lib/installation/updates_manager.rb
+++ b/src/lib/installation/updates_manager.rb
@@ -43,18 +43,7 @@ module Installation
     attr_reader :driver_updates
 
     # Base exception to be used for repository problems
-    class RepoError < StandardError
-      # @return [URI] Repository URI
-      attr_reader :uri
-
-      # Constructor
-      #
-      # @param uri [URI] Repository URI
-      def initialize(uri)
-        super()
-        @uri = uri
-      end
-    end
+    class RepoError < StandardError; end
 
     # The URL was found but a valid repo is not there.
     class NotValidRepo < RepoError; end
@@ -104,13 +93,13 @@ module Installation
       has_packages
     rescue Installation::UpdateRepository::NotValidRepo
       log.warn("Update repository at #{uri} could not be found")
-      raise NotValidRepo, uri
+      raise NotValidRepo
     rescue Installation::UpdateRepository::FetchError
       log.error("Update repository at #{uri} was found but update could not be fetched")
-      raise CouldNotFetchUpdateFromRepo, uri
+      raise CouldNotFetchUpdateFromRepo
     rescue Installation::UpdateRepository::CouldNotProbeRepo
       log.error("Update repository at #{uri} could not be read")
-      raise CouldNotProbeRepo, uri
+      raise CouldNotProbeRepo
     end
 
     # Applies all the updates

--- a/test/inst_update_installer_test.rb
+++ b/test/inst_update_installer_test.rb
@@ -85,7 +85,7 @@ describe Yast::InstUpdateInstaller do
         it "shows an error and returns :next" do
           expect(Yast::Popup).to receive(:Error)
           expect(manager).to receive(:add_repository)
-            .and_raise(::Installation::UpdatesManager::CouldNotFetchUpdateFromRepo.new(url))
+            .and_raise(::Installation::UpdatesManager::CouldNotFetchUpdateFromRepo)
           expect(subject.main).to eq(:next)
         end
       end
@@ -110,7 +110,7 @@ describe Yast::InstUpdateInstaller do
           it "shows a dialog suggesting to check the network configuration" do
             expect(Yast::Popup).to receive(:YesNo)
             expect(manager).to receive(:add_repository)
-              .and_raise(::Installation::UpdatesManager::CouldNotProbeRepo.new(URI(url)))
+              .and_raise(::Installation::UpdatesManager::CouldNotProbeRepo)
             expect(subject.main).to eq(:next)
           end
 
@@ -133,7 +133,7 @@ describe Yast::InstUpdateInstaller do
           it "shows a dialog suggesting to check the network configuration" do
             expect(Yast::Popup).to_not receive(:YesNo)
             expect(manager).to receive(:add_repository)
-              .and_raise(::Installation::UpdatesManager::CouldNotProbeRepo.new(URI(url)))
+              .and_raise(::Installation::UpdatesManager::CouldNotProbeRepo)
             expect(subject.main).to eq(:next)
           end
         end
@@ -156,7 +156,7 @@ describe Yast::InstUpdateInstaller do
         it "shows an error if update is not found" do
           expect(Yast::Popup).to receive(:Error)
           expect(manager).to receive(:add_repository).with(URI(custom_url))
-            .and_raise(::Installation::UpdatesManager::NotValidRepo.new(URI(custom_url)))
+            .and_raise(::Installation::UpdatesManager::NotValidRepo)
           expect(subject.main).to eq(:next)
         end
       end
@@ -176,7 +176,7 @@ describe Yast::InstUpdateInstaller do
           it "does not show an error if update is not found" do
             expect(Yast::Popup).to_not receive(:Error)
             expect(manager).to receive(:add_repository).with(URI(real_url))
-              .and_raise(::Installation::UpdatesManager::NotValidRepo.new(URI(real_url)))
+              .and_raise(::Installation::UpdatesManager::NotValidRepo)
             expect(subject.main).to eq(:next)
           end
 
@@ -284,7 +284,7 @@ describe Yast::InstUpdateInstaller do
             it "shows an error and returns :next if update fails" do
               expect(Yast::Report).to receive(:Error)
               expect(manager).to receive(:add_repository)
-                .and_raise(::Installation::UpdatesManager::CouldNotFetchUpdateFromRepo.new(url))
+                .and_raise(::Installation::UpdatesManager::CouldNotFetchUpdateFromRepo)
               expect(subject.main).to eq(:next)
             end
           end
@@ -301,7 +301,7 @@ describe Yast::InstUpdateInstaller do
             it "does not show an error if update is not found" do
               expect(Yast::Report).to_not receive(:Error)
               expect(manager).to receive(:add_repository).with(URI(real_url))
-                .and_raise(::Installation::UpdatesManager::NotValidRepo.new(URI(real_url)))
+                .and_raise(::Installation::UpdatesManager::NotValidRepo)
               expect(subject.main).to eq(:next)
             end
 

--- a/test/inst_update_installer_test.rb
+++ b/test/inst_update_installer_test.rb
@@ -184,9 +184,9 @@ describe Yast::InstUpdateInstaller do
 
           let(:base_product) do
             {
-              "arch" => "x86_64",
-              "name" => "SLES",
-              "version" => "12-2",
+              "arch"         => "x86_64",
+              "name"         => "SLES",
+              "version"      => "12-2",
               "release_type" => ""
             }
           end
@@ -204,7 +204,7 @@ describe Yast::InstUpdateInstaller do
 
           let(:sw_mgmt) do
             double("sw_mgmt", base_product_to_register: base_product,
-              remote_product: product)
+                              remote_product:           product)
           end
 
           let(:suse_connect) do

--- a/test/inst_update_installer_test.rb
+++ b/test/inst_update_installer_test.rb
@@ -343,6 +343,24 @@ describe Yast::InstUpdateInstaller do
               subject.main
             end
           end
+
+          context "when a registration server was specified via AutoYaST profile" do
+            let(:reg_server_url) { "http://ay.test.example.com/update" }
+
+            before do
+              allow(Yast::Mode).to receive(:auto).at_least(1).and_return(true)
+              allow(Yast::Profile).to receive(:current)
+                .and_return("suse_register" => { "reg_server" => reg_server_url })
+            end
+
+            it "uses the given server" do
+              expect(suse_connect).to receive(:list_installer_updates).with(product, url: URI(reg_server_url))
+                .and_return([update0])
+              expect(manager).to receive(:add_repository).with(URI(update0_url))
+                .and_return(true)
+              subject.main
+            end
+          end
         end
 
         context "in AutoYaST installation or upgrade" do

--- a/test/inst_update_installer_test.rb
+++ b/test/inst_update_installer_test.rb
@@ -224,12 +224,13 @@ describe Yast::InstUpdateInstaller do
             double("suse_connect", list_installer_updates: [update0, update1])
           end
 
-          let(:url_helpers) { double("url_helpers", registration_url: smt_url) }
+          let(:url_helpers) { double("url_helpers", registration_url: smt_url, slp_discovery_feedback: []) }
 
           before do
             allow(subject).to receive(:require).with("registration/sw_mgmt").and_return(true)
             allow(subject).to receive(:require).with("registration/url_helpers").and_return(true)
             allow(subject).to receive(:require).with("registration/storage").and_return(true)
+            allow(subject).to receive(:require).with("registration/ui/regservice_selection_dialog").and_return(true)
             allow(subject).to receive(:require).with("suse/connect").and_return(true)
             stub_const("Registration::SwMgmt", sw_mgmt)
             stub_const("Registration::UrlHelpers", url_helpers)
@@ -245,14 +246,14 @@ describe Yast::InstUpdateInstaller do
               .and_return(true)
             expect(manager).to receive(:add_repository).with(URI(update1_url))
               .and_return(true)
-            expect(suse_connect).to receive(:list_installer_updates).with(product, url: smt_url)
+            expect(suse_connect).to receive(:list_installer_updates).with(product, url: nil)
               .and_return([update0, update1])
             expect(subject.main).to eq(:restart_yast)
           end
 
           it "saves the registration URL" do
             expect(manager).to receive(:add_repository).twice
-            expect(FakeInstallationOptions.instance).to receive(:custom_url=).with(smt_url)
+            expect(FakeInstallationOptions.instance).to receive(:custom_url=).with(nil)
             subject.main
           end
         end

--- a/test/inst_update_installer_test.rb
+++ b/test/inst_update_installer_test.rb
@@ -42,6 +42,7 @@ describe Yast::InstUpdateInstaller do
     allow(Yast::NetworkService).to receive(:isNetworkRunning).and_return(network_running)
     allow(::Installation::UpdatesManager).to receive(:new).and_return(manager)
     allow(Yast::Installation).to receive(:restarting?).and_return(restarting)
+    allow(Yast::Installation).to receive(:finish_restarting!)
     allow(Yast::Installation).to receive(:restart!) { :restart_yast }
     allow(subject).to receive(:require).with("registration/url_helpers").and_raise(LoadError)
     allow(::FileUtils).to receive(:touch)

--- a/test/inst_update_installer_test.rb
+++ b/test/inst_update_installer_test.rb
@@ -206,7 +206,7 @@ describe Yast::InstUpdateInstaller do
           let(:update1) do
             OpenStruct.new(
               name: "SLES-12-Installer-Updates-1",
-              url: "http://update.suse.com/updates/sles12/12.2"
+              url:  "http://update.suse.com/updates/sles12/12.2"
             )
           end
 

--- a/test/inst_update_installer_test.rb
+++ b/test/inst_update_installer_test.rb
@@ -326,7 +326,7 @@ describe Yast::InstUpdateInstaller do
             end
 
             it "uses the given server" do
-              expect(registration_class).to receive(:new).with(URI(reg_server_url))
+              expect(registration_class).to receive(:new).with(reg_server_url)
                 .and_return(registration)
               subject.main
             end


### PR DESCRIPTION
Improved version of #400 to support multiple URLs coming from SCC/SMT.

It depends on https://github.com/yast/yast-registration/pull/263 (merged).