### PR TITLE
Fixed OOM killer setup

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Jul 14 08:10:16 UTC 2016 - lslezak@suse.cz
+
+- Properly adjust the OOM killer (oom_score_adj has a different
+  range than the original oom_adj) (bsc#974601)
+- 3.1.200
+
+-------------------------------------------------------------------
 Tue Jul 12 16:14:28 CEST 2016 - schubi@suse.de
 
 - Added AutoYaST schema file "ssh_import".

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation
-Version:        3.1.199
+Version:        3.1.200
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/installation/cio_ignore.rb
+++ b/src/lib/installation/cio_ignore.rb
@@ -82,18 +82,18 @@ module Installation
       enabled = CIOIgnore.instance.enabled
 
       text = if enabled
-               # TRANSLATORS: Installation overview
-               # IMPORTANT: Please, do not change the HTML link <a href="...">...</a>, only visible text
-               (_(
-                 "Blacklist devices enabled (<a href=\"%s\">disable</a>)."
-                 ) % CIO_DISABLE_LINK)
-             else
-               # TRANSLATORS: Installation overview
-               # IMPORTANT: Please, do not change the HTML link <a href="...">...</a>, only visible text
-               (_(
-                 "Blacklist devices disabled (<a href=\"%s\">enable</a>)."
-                 ) % CIO_ENABLE_LINK)
-             end
+        # TRANSLATORS: Installation overview
+        # IMPORTANT: Please, do not change the HTML link <a href="...">...</a>, only visible text
+        (_(
+          "Blacklist devices enabled (<a href=\"%s\">disable</a>)."
+          ) % CIO_DISABLE_LINK)
+      else
+        # TRANSLATORS: Installation overview
+        # IMPORTANT: Please, do not change the HTML link <a href="...">...</a>, only visible text
+        (_(
+          "Blacklist devices disabled (<a href=\"%s\">enable</a>)."
+          ) % CIO_ENABLE_LINK)
+      end
 
       {
         "preformatted_proposal" => Yast::HTML.List([text]),

--- a/src/lib/installation/clients/inst_disks_activate.rb
+++ b/src/lib/installation/clients/inst_disks_activate.rb
@@ -88,22 +88,22 @@ module Yast
       ]
 
       dasd_part = if @have_dasd
-                    button_with_spacing(:dasd, _("Configure &DASD Disks"))
-                  else
-                    missing_part
-                  end
+        button_with_spacing(:dasd, _("Configure &DASD Disks"))
+      else
+        missing_part
+      end
 
       zfcp_part = if @have_zfcp
-                    button_with_spacing(:zfcp, _("Configure &ZFCP Disks"))
-                  else
-                    missing_part
-                  end
+        button_with_spacing(:zfcp, _("Configure &ZFCP Disks"))
+      else
+        missing_part
+      end
 
       fcoe_part = if @want_fcoe
-                    button_with_spacing(:fcoe, _("Configure &FCoE Interfaces"))
-                  else
-                    missing_part
-                  end
+        button_with_spacing(:fcoe, _("Configure &FCoE Interfaces"))
+      else
+        missing_part
+      end
 
       @contents =
         VBox(

--- a/src/lib/installation/proposal_runner.rb
+++ b/src/lib/installation/proposal_runner.rb
@@ -261,10 +261,10 @@ module Installation
 
     def pre_continue_handling
       @skip = if Yast::UI.WidgetExists(Id(:skip))
-                Yast::UI.QueryWidget(Id(:skip), :Value)
-              else
-                true
-              end
+        Yast::UI.QueryWidget(Id(:skip), :Value)
+      else
+        true
+      end
       skip_blocker = Yast::UI.WidgetExists(Id(:skip)) && @skip
       if @have_blocker && !skip_blocker
         # error message is a popup
@@ -786,13 +786,13 @@ module Installation
     def html_header(submod)
       title = @store.title_for(submod)
       heading = if title.include?("<a")
-                  title
-                else
-                  Yast::HTML.Link(
-                    title,
-                    @store.id_for(submod)
-                  )
-                end
+        title
+      else
+        Yast::HTML.Link(
+          title,
+          @store.id_for(submod)
+        )
+      end
 
       Yast::HTML.Heading(heading)
     end

--- a/src/lib/installation/ssh_importer_presenter.rb
+++ b/src/lib/installation/ssh_importer_presenter.rb
@@ -42,22 +42,22 @@ module Installation
     def summary
       message =
         if importer.configurations.empty? && (Yast::Mode.installation || Yast::Mode.autoinst)
-          _("No previous Linux installation found")
-        elsif importer.device.nil?
-          _("No existing SSH host keys will be copied")
+        _("No previous Linux installation found")
+      elsif importer.device.nil?
+        _("No existing SSH host keys will be copied")
+      else
+        name = ssh_config.system_name if ssh_config
+        name ||= importer.device || "default"
+        if importer.copy_config?
+          # TRANSLATORS: %s is the name of a Linux system found in the hard
+          # disk, like 'openSUSE 13.2'
+          _("SSH host keys and configuration will be copied from %s") % name
         else
-          name = ssh_config.system_name if ssh_config
-          name ||= importer.device || "default"
-          if importer.copy_config?
-            # TRANSLATORS: %s is the name of a Linux system found in the hard
-            # disk, like 'openSUSE 13.2'
-            _("SSH host keys and configuration will be copied from %s") % name
-          else
-            # TRANSLATORS: %s is the name of a Linux system found in the hard
-            # disk, like 'openSUSE 13.2'
-            _("SSH host keys will be copied from %s") % name
-          end
+          # TRANSLATORS: %s is the name of a Linux system found in the hard
+          # disk, like 'openSUSE 13.2'
+          _("SSH host keys will be copied from %s") % name
         end
+      end
       Yast::HTML.List([message])
     end
 

--- a/startup/YaST2.call
+++ b/startup/YaST2.call
@@ -52,7 +52,7 @@ function wait_for_x11() {
 				continue
 			fi
 			# server is running, detach oom-killer from it
-			echo -n '-17' > /proc/$xserver_pid/oom_score_adj
+			echo -n '-1000' > /proc/$xserver_pid/oom_score_adj
 			server_running=1
 			# adjust video mode using xrandr, if requested
 			SETMODE=/usr/lib/YaST2/bin/set_videomode


### PR DESCRIPTION
This is a fix up for commit 65a6b6f0.

The `oom_score_adj` file has a different range than the original `oom_adj`, value `-1000` is the equivalent of the original `-17`.

See the [kernel proc documentation](https://www.kernel.org/doc/Documentation/filesystems/proc.txt), section 3.1.

*Note: the second commit is actually just an update for the Rubocop config (https://github.com/yast/yast-devtools/pull/107).*

- 3.1.200