### PR TITLE
Don't halt AutoYaST installation on self-update problem

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Jul 22 13:48:12 UTC 2016 - igonzalezsosa@suse.com
+
+- Don't halt the installation if installer updates server
+  cannot be reached when using AutoYaST (bsc#988949)
+- 3.1.203
+
+-------------------------------------------------------------------
 Thu Jul 21 11:52:59 UTC 2016 - jreidinger@suse.com
 
 - simplify and speed up inst_finish client (bnc#986649)

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation
-Version:        3.1.202
+Version:        3.1.203
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/installation/clients/inst_update_installer.rb
+++ b/src/lib/installation/clients/inst_update_installer.rb
@@ -196,8 +196,8 @@ module Yast
     rescue ::Installation::UpdatesManager::CouldNotProbeRepo
       if Mode.auto
         Report.Warning(could_not_probe_repo_msg)
-      else
-        retry if remote_self_update_url? && configure_network?
+      elsif remote_self_update_url? && configure_network?
+        retry
       end
       false
     end
@@ -217,9 +217,9 @@ module Yast
     # @return [Boolean] true if the network configuration client was launched;
     #                   false if the network is not configured.
     def configure_network?
-      msg = could_not_probe_repo_msg + "\n" \
-        "Would you like to check your network configuration\n" \
-        "and try installing the updates again?"
+      msg = could_not_probe_repo_msg +
+        _("\nWould you like to check your network configuration\n" \
+        "and try installing the updates again?")
 
       if Popup.YesNo(msg)
         Yast::WFM.CallFunction("inst_lan", [{ "skip_detection" => true }])
@@ -270,6 +270,5 @@ module Yast
         "If you need a proxy server to access the update repository\n" \
         "then use the \"proxy\" boot parameter.\n"), self_update_url)
     end
-
   end
 end

--- a/src/lib/installation/clients/inst_update_installer.rb
+++ b/src/lib/installation/clients/inst_update_installer.rb
@@ -195,7 +195,7 @@ module Yast
 
     rescue ::Installation::UpdatesManager::CouldNotProbeRepo
       if Mode.auto
-        Report.Error(could_not_probe_repo_msg)
+        Report.Warning(could_not_probe_repo_msg)
       else
         retry if remote_self_update_url? && configure_network?
       end

--- a/src/lib/installation/clients/inst_update_installer.rb
+++ b/src/lib/installation/clients/inst_update_installer.rb
@@ -194,7 +194,11 @@ module Yast
       false
 
     rescue ::Installation::UpdatesManager::CouldNotProbeRepo
-      retry if remote_self_update_url? && configure_network?
+      if Mode.auto
+        Report.Error(could_not_probe_repo_msg)
+      else
+        retry if remote_self_update_url? && configure_network?
+      end
       false
     end
 
@@ -213,21 +217,11 @@ module Yast
     # @return [Boolean] true if the network configuration client was launched;
     #                   false if the network is not configured.
     def configure_network?
-      if Popup.YesNo(
-        # Note: the proxy cannot be configured in the YaST installer yet,
-        # it needs to be set via the "proxy" boot option.
-        # TRANSLATORS: %s is an URL
-        format(_("Downloading the optional installer updates from \n%s\nfailed.\n" \
-                 "\n" \
-                 "You can continue the installation without applying the updates.\n" \
-                 "However, some potentially important bug fixes might be missing.\n" \
-                 "\n" \
-                 "If you need a proxy server to access the update repository\n" \
-                 "then use the \"proxy\" boot parameter.\n" \
-                 "\n" \
-                 "Would you like to check your network configuration\n" \
-                 "and try installing the updates again?"), self_update_url)
-      )
+      msg = could_not_probe_repo_msg + "\n" \
+        "Would you like to check your network configuration\n" \
+        "and try installing the updates again?"
+
+      if Popup.YesNo(msg)
         Yast::WFM.CallFunction("inst_lan", [{ "skip_detection" => true }])
         true
       else
@@ -258,5 +252,24 @@ module Yast
     def using_default_url?
       self_update_url_from_control == self_update_url
     end
+
+    # Return a message to be shown when the updates repo could not be probed
+    #
+    # @return [String] Message including the repository URL
+    #
+    # @see #self_update_url
+    def could_not_probe_repo_msg
+      # Note: the proxy cannot be configured in the YaST installer yet,
+      # it needs to be set via the "proxy" boot option.
+      # TRANSLATORS: %s is an URL
+      format(_("Downloading the optional installer updates from \n%s\nfailed.\n" \
+        "\n" \
+        "You can continue the installation without applying the updates.\n" \
+        "However, some potentially important bug fixes might be missing.\n" \
+        "\n" \
+        "If you need a proxy server to access the update repository\n" \
+        "then use the \"proxy\" boot parameter.\n"), self_update_url)
+    end
+
   end
 end

--- a/test/inst_update_installer_test.rb
+++ b/test/inst_update_installer_test.rb
@@ -111,7 +111,7 @@ describe Yast::InstUpdateInstaller do
             end
 
             it "shows an error" do
-              expect(Yast::Report).to receive(:Error)
+              expect(Yast::Report).to receive(:Warning)
               expect(subject.main).to eq(:next)
             end
           end


### PR DESCRIPTION
It should fix [bsc#988949](https://bugzilla.suse.com/show_bug.cgi?id=988949). When running AutoYaST, if the self-update repo cannot be probed, it just show a error and don't halt the installation (unless the profile is configured to stop on errors).