### PR TITLE
Use storage-ng for hardware probing

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Aug  1 07:51:08 UTC 2016 - ancor@suse.com
+
+- storage-ng: use the new library for storage hardware probing
+  (devicegraph) instead of the old one (targetmap)
+- 3.2.2
+
+-------------------------------------------------------------------
 Fri Jul 29 07:32:46 UTC 2016 - ancor@suse.com
 
 - If the user has skipped multipath activation, don't ask again

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation
-Version:        3.2.1
+Version:        3.2.2
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -43,6 +43,10 @@ BuildRequires: yast2 >= 3.1.180
 # Yast::Remote
 BuildRequires: yast2-network
 
+# Y2Storage
+BuildRequires: yast2-storage-ng >= 0.1.1
+Requires:      yast2-storage-ng >= 0.1.1
+
 # AutoinstSoftware.SavePackageSelection()
 Requires:       autoyast2-installation >= 3.1.105
 


### PR DESCRIPTION
To check it works, just run the installer and search for these lines in the logs after the system analysis step:

```
probed devicegraph begin
[...here is the information about your hardware as it's loaded in memory...]
probed devicegraph end
```

Tested in qemu-kvm with IDE & SCSI. Should work in real hardware and VirtualBox as well.

This goes together with https://github.com/yast/yast-storage-ng/pull/87