### PR TITLE
Use y2storage for hardware probing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ before_install:
     # disable rvm, use system Ruby
     - rvm reset
     - wget https://raw.githubusercontent.com/yast/yast-devtools/master/travis-tools/travis_setup.sh
-    - sh ./travis_setup.sh -p "rake yast2-devtools yast2-testsuite yast2-core-dev yast2 yast2-network yast2-transfer" -g "rspec:3.3.0 yast-rake gettext rubocop:0.41.2 simplecov coveralls cheetah"
+    - sh ./travis_setup.sh -p "rake yast2-devtools yast2-testsuite yast2-core-dev yast2 yast2-network yast2-transfer yast2-storage-ng" -g "rspec:3.3.0 yast-rake gettext rubocop:0.41.2 simplecov coveralls cheetah"
 script:
     - rake check:syntax
     - rake check:pot

--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Aug 10 11:51:08 UTC 2016 - ancor@suse.com
+
+- storage-ng: use the new library for storage hardware probing
+  (devicegraph) instead of the old one (targetmap)
+
+-------------------------------------------------------------------
 Tue Aug  9 14:51:06 UTC 2016 - ancor@suse.com
 
 - storage-ng: removed dependency from (old) yast2-storage, even

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -43,6 +43,10 @@ BuildRequires: yast2 >= 3.1.180
 # Yast::Remote
 BuildRequires: yast2-network
 
+# Y2Storage
+BuildRequires: yast2-storage-ng >= 0.1.1
+Requires:      yast2-storage-ng >= 0.1.1
+
 # AutoinstSoftware.SavePackageSelection()
 Requires:       autoyast2-installation >= 3.1.105
 

--- a/src/lib/installation/clients/inst_system_analysis.rb
+++ b/src/lib/installation/clients/inst_system_analysis.rb
@@ -32,7 +32,6 @@ require "y2storage"
 module Yast
   class InstSystemAnalysisClient < Client
     include Yast::Logger
-    using Y2Storage::Refinements::DevicegraphLists
 
     def main
       Yast.import "UI"
@@ -288,7 +287,7 @@ module Yast
         drivers_info = ""
       end
 
-      if devicegraph.disks.empty?
+      if devicegraph.empty?
         if @found_controllers || Arch.s390
           if !(Mode.autoinst || Mode.autoupgrade)
             # pop-up error report


### PR DESCRIPTION
To check it works, just run the installer and search for these lines in the logs after the system analysis step:

```
probed devicegraph begin
[...here is the information about your hardware as it's loaded in memory...]
probed devicegraph end
```

Tested in qemu-kvm with IDE & SCSI. Should work in real hardware and VirtualBox as well.

This goes together with https://github.com/yast/yast-storage-ng/pull/87