### PR TITLE
Declare textdomain to fix untranslated texts

### DIFF
--- a/src/lib/installation/clients/ssh_import_auto.rb
+++ b/src/lib/installation/clients/ssh_import_auto.rb
@@ -15,6 +15,10 @@ module Installation
       attr_accessor :changed
     end
 
+    def initialize
+      textdomain "installation"
+    end
+
     def run
       progress_orig = Yast::Progress.set(false)
       ret = super


### PR DESCRIPTION
found by y2tool y2makepot

IMHO the messages occur in [fairly rare cases](https://github.com/search?utf8=%E2%9C%93&q=translators+sense+path%3Asrc%2Flib%2Finstallation%2Fclients&type=Code&ref=advsearch&l=&l=) so I am not making a bug for this.