### PR TITLE
UI and UX Optimizations in Welcome Screen

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Aug  3 17:06:46 CEST 2016 - locilka@suse.com
+
+- UI, UX and internal handling for the Welcome screen optimized to
+  prevent from not showing that the license needs to be accepted
+  (bsc#980374).
+- 3.1.205
+
+-------------------------------------------------------------------
 Fri Jul 29 07:32:46 UTC 2016 - ancor@suse.com
 
 - If the user has skipped multipath activation, don't ask again

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation
-Version:        3.1.204
+Version:        3.1.205
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/installation/clients/inst_complex_welcome.rb
+++ b/src/lib/installation/clients/inst_complex_welcome.rb
@@ -55,6 +55,8 @@ module Yast
       @language = Language.language
       @keyboard = ""
 
+      InstData.product_license_accepted ||= false
+
       # ----------------------------------------------------------------------
       # Build dialog
       # ----------------------------------------------------------------------
@@ -102,7 +104,6 @@ module Yast
           Keyboard.user_decision = true
         when :license_agreement
           read_ui_state
-          InstData.product_license_accepted = @license_accepted
         when :language
           next if Mode.config
           read_ui_state
@@ -142,12 +143,21 @@ module Yast
       end
     end
 
-    def initialize_widgets
-      Wizard.EnableAbortButton
+    def initialize_license
+      # Showing empty license to prevent from redrawing the dialog when
+      # the translated license is found and shown to the user
+      UI.ReplaceWidget(Id(:base_license_rp), RichText(""))
 
-      UI.ChangeWidget(Id(:language), :Value, @language)
-      UI.ChangeWidget(Id(:license_agreement), :Value, @license_accepted)
+      # If accepting the license is required, show the check-box
+      if license_required?
+        UI.ReplaceWidget(:license_checkbox_rp, license_agreement_checkbox)
+        UI.ChangeWidget(Id(:license_agreement), :Value, InstData.product_license_accepted)
+      end
 
+      log.info "Acceptance needed: #{@id} => #{license_required?}"
+    end
+
+    def initialize_keyboard_selection
       if Keyboard.user_decision
         UI.ChangeWidget(Id(:keyboard), :Value, Keyboard.current_kbd)
       else
@@ -155,6 +165,18 @@ module Yast
         UI.ChangeWidget(Id(:keyboard), :Value, kbd)
         Keyboard.Set(kbd)
       end
+    end
+
+    def initialize_widgets
+      UI.BusyCursor
+
+      initialize_license
+
+      Wizard.EnableAbortButton
+
+      UI.ChangeWidget(Id(:language), :Value, @language)
+
+      initialize_keyboard_selection
 
       # In case of going back, Release Notes button may be shown, retranslate it (bnc#886660)
       # Assure that relnotes have been downloaded first
@@ -162,7 +184,13 @@ module Yast
         Wizard.ShowReleaseNotesButton(_("Re&lease Notes..."), "rel_notes")
       end
 
+      # This also shows content of the info file if it exists, so it has to be
+      # called at the very end
+      ProductLicense.ShowLicenseInInstallation(:base_license_rp, @license_id)
+
       UI.SetFocus(Id(:language))
+
+      UI.NormalCursor
     end
 
     def help_text
@@ -271,7 +299,8 @@ module Yast
     #
     # @return [Boolean] true if license was accepted; false otherwise.
     def license_accepted?
-      license_required? ? UI.QueryWidget(Id(:license_agreement), :Value) : true
+      read_ui_state
+      InstData.product_license_accepted
     end
 
     # Determines whether the license is required or not
@@ -289,14 +318,15 @@ module Yast
     end
 
     def read_ui_state
-      @language         = UI.QueryWidget(Id(:language), :Value)
-      @keyboard         = UI.QueryWidget(Id(:keyboard), :Value)
-      @license_accepted = UI.QueryWidget(Id(:license_agreement), :Value)
+      @language = UI.QueryWidget(Id(:language), :Value)
+      @keyboard = UI.QueryWidget(Id(:keyboard), :Value)
+      InstData.product_license_accepted = UI.QueryWidget(Id(:license_agreement), :Value)
     end
 
     def retranslate_yast
       Console.SelectFont(@language)
       # no yast translation for nn_NO, use nb_NO as a backup
+      # FIXME: remove the hack, please
       if @language == "nn_NO"
         log.info "Nynorsk not translated, using Bokm\u00E5l"
         Language.WfmSetGivenLanguage("nb_NO")
@@ -325,7 +355,6 @@ module Yast
 
     def setup_final_choice
       Keyboard.Set(@keyboard)
-      InstData.product_license_accepted = @license_accepted
 
       # Language has been set already.
       # On first run store users decision as default.
@@ -364,7 +393,7 @@ module Yast
       data = {
         "language"         => @language,
         "keyboard"         => @keyboard,
-        "license_accepted" => @license_accepted
+        "license_accepted" => InstData.product_license_accepted
       }
 
       File.write(DATA_PATH, data.to_yaml)
@@ -372,9 +401,9 @@ module Yast
 
     def apply_data
       data = YAML.load(File.read(DATA_PATH))
-      @language         = data["language"]
-      @keyboard         = data["keyboard"]
-      @license_accepted = data["license_accepted"]
+      @language = data["language"]
+      @keyboard = data["keyboard"]
+      InstData.product_license_accepted = data["license_accepted"]
       ProductLicense.info_seen!(@license_id)
 
       change_language
@@ -428,7 +457,7 @@ module Yast
           HBox(
             HWeight(1, HStretch()),
             HSpacing(3),
-            HWeight(1, Left(TextEntry(Id(:keyboard_test), _("K&eyboard Test"))))
+            HWeight(1, Left(InputField(Id(:keyboard_test), Opt(:hstretch), _("K&eyboard Test"))))
           )
         ),
         VWeight(
@@ -445,7 +474,7 @@ module Yast
                   MinWidth(
                     # BNC #607135
                     text_mode? ? 85 : 106,
-                    Left(ReplacePoint(Id(:base_license_rp), Empty()))
+                    Left(ReplacePoint(Id(:base_license_rp), Opt(:hstretch), Empty()))
                   )
                 ),
                 VSpacing(text_mode? ? 0.5 : 1),
@@ -484,14 +513,6 @@ module Yast
       )
 
       initialize_widgets
-
-      ProductLicense.ShowLicenseInInstallation(:base_license_rp, @license_id)
-
-      # If accepting the license is required, show the check-box
-      if license_required?
-        UI.ReplaceWidget(:license_checkbox_rp, license_agreement_checkbox)
-      end
-      log.info "Acceptance needed: #{@id} => #{license_required?}"
     end
   end unless defined? Yast::InstComplexWelcomeClient
 end


### PR DESCRIPTION
- Code that handles license checkbox moved to prevent from warnings"No widget ID..."
- The License Text widget is now initialized ASAP
- Changing the License widget when its text is actually known
- The new code has been tested and optimized especially for the user (UI, UX), while keeping the actual openQA-related bug in mind as well (bsc#980374)
- The client has a good test case which does not need to be extended
- @license_accepted variable has been replaced by InstData.product_license_accepted because of conflicts in data duplication