### PR TITLE
Don't save custom_url when SCC is used during self-update

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Aug  5 07:22:59 UTC 2016 - igonzalezsosa@suse.com
+
+- Fix the registration screen initialization when SCC server
+  is used during self-update (FATE#319716)
+- 3.1.207
+
+-------------------------------------------------------------------
 Thu Aug  4 10:02:28 UTC 2016 - igonzalezsosa@suse.com
 
 - Retrieve the self-update URL from the registration

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation
-Version:        3.1.206
+Version:        3.1.207
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/installation/clients/inst_update_installer.rb
+++ b/src/lib/installation/clients/inst_update_installer.rb
@@ -168,7 +168,7 @@ module Yast
       registration = Registration::Registration.new(url == :scc ? nil : url.to_s)
       # Set custom_url into installation options
       Registration::Storage::InstallationOptions.instance.custom_url = registration.url
-      store_registration_url(url) if url.is_a?(URI)
+      store_registration_url(url) unless url == :scc
       registration.get_updates_list.map { |u| URI(u.url) }
     end
 

--- a/src/lib/installation/clients/inst_update_installer.rb
+++ b/src/lib/installation/clients/inst_update_installer.rb
@@ -168,7 +168,7 @@ module Yast
       registration = Registration::Registration.new(url == :scc ? nil : url.to_s)
       # Set custom_url into installation options
       Registration::Storage::InstallationOptions.instance.custom_url = registration.url
-      store_registration_url(registration.url)
+      store_registration_url(url) if url.is_a?(URI)
       registration.get_updates_list.map { |u| URI(u.url) }
     end
 

--- a/src/lib/installation/clients/inst_update_installer.rb
+++ b/src/lib/installation/clients/inst_update_installer.rb
@@ -168,7 +168,7 @@ module Yast
       registration = Registration::Registration.new(url == :scc ? nil : url.to_s)
       # Set custom_url into installation options
       Registration::Storage::InstallationOptions.instance.custom_url = registration.url
-      store_registration_url(url) unless url == :scc
+      store_registration_url(url) if url != :scc
       registration.get_updates_list.map { |u| URI(u.url) }
     end
 

--- a/test/inst_update_installer_test.rb
+++ b/test/inst_update_installer_test.rb
@@ -273,8 +273,8 @@ describe Yast::InstUpdateInstaller do
 
               it "saves the registration URL to be used later" do
                 allow(manager).to receive(:add_repository)
-                expect(FakeInstallationOptions.instance).to_not receive(:custom_url=).with(nil)
-                expect(File).to receive(:write).with(/inst_update_installer.yaml/,
+                expect(FakeInstallationOptions.instance).to receive(:custom_url=).with(smt0.slp_url)
+                expect(File).to receive(:write).with(/\/inst_update_installer.yaml\z/,
                   { "custom_url" => smt0.slp_url }.to_yaml)
                 subject.main
               end
@@ -306,7 +306,8 @@ describe Yast::InstUpdateInstaller do
 
               it "does not save the registration URL to be used later" do
                 allow(manager).to receive(:add_repository)
-                expect(FakeInstallationOptions.instance).to_not receive(:custom_url=).with(nil)
+                allow(registration).to receive(:url).and_return(nil)
+                expect(FakeInstallationOptions.instance).to receive(:custom_url=).with(nil)
                 expect(File).to_not receive(:write).with(/inst_update_installer.yaml/, anything)
                 subject.main
               end
@@ -338,7 +339,7 @@ describe Yast::InstUpdateInstaller do
             it "saves the registration URL to be used later" do
               allow(manager).to receive(:add_repository)
               expect(FakeInstallationOptions.instance).to receive(:custom_url=).with(smt0.slp_url)
-              expect(File).to receive(:write).with(/inst_update_installer.yaml/,
+              expect(File).to receive(:write).with(/\/inst_update_installer.yaml\z/,
                 { "custom_url" => smt0.slp_url }.to_yaml)
               subject.main
             end
@@ -460,7 +461,7 @@ describe Yast::InstUpdateInstaller do
 
       before do
         allow(File).to receive(:exist?)
-        allow(File).to receive(:exist?).with(/inst_update_installer.yaml/)
+        allow(File).to receive(:exist?).with(/\/inst_update_installer.yaml\z/)
           .and_return(data_file_exists)
         allow(subject).to receive(:require_registration_libraries)
           .and_return(registration_libs)

--- a/test/inst_update_installer_test.rb
+++ b/test/inst_update_installer_test.rb
@@ -254,24 +254,30 @@ describe Yast::InstUpdateInstaller do
             expect(subject.main).to eq(:restart_yast)
           end
 
-          it "saves the registration URL to be used later" do
-            allow(manager).to receive(:add_repository)
-            expect(FakeInstallationOptions.instance).to receive(:custom_url=).with(smt0.slp_url)
-            expect(File).to receive(:write).with(/inst_update_installer.yaml/,
-              { "custom_url" => smt0.slp_url }.to_yaml)
-            subject.main
-          end
-
           context "when more than one SMT server exist" do
             before do
               allow(url_helpers).to receive(:slp_discovery).and_return([smt0, smt1])
             end
 
-            it "ask the user to choose one of them" do
-              expect(regservice_selection).to receive(:run).and_return(smt0)
-              expect(registration_class).to receive(:new).with(smt0.slp_url)
-                .and_return(registration)
-              expect(subject.main).to eq(:restart_yast)
+            context "if the user selects a SMT server" do
+              before do
+                allow(regservice_selection).to receive(:run).and_return(smt0)
+              end
+
+              it "asks that SMT server for the updates URLs" do
+                expect(registration_class).to receive(:new).with(smt0.slp_url)
+                  .and_return(registration)
+                allow(manager).to receive(:add_repository)
+                subject.main
+              end
+
+              it "saves the registration URL to be used later" do
+                allow(manager).to receive(:add_repository)
+                expect(FakeInstallationOptions.instance).to_not receive(:custom_url=).with(nil)
+                expect(File).to receive(:write).with(/inst_update_installer.yaml/,
+                  { "custom_url" => smt0.slp_url }.to_yaml)
+                subject.main
+              end
             end
 
             context "if user cancels the dialog" do
@@ -291,10 +297,17 @@ describe Yast::InstUpdateInstaller do
                 allow(regservice_selection).to receive(:run).and_return(:scc)
               end
 
-              it "asks the SCC server" do
+              it "asks the SCC server for the updates URLs" do
                 expect(registration_class).to receive(:new).with(nil)
                   .and_return(registration)
                 allow(manager).to receive(:add_repository)
+                subject.main
+              end
+
+              it "does not save the registration URL to be used later" do
+                allow(manager).to receive(:add_repository)
+                expect(FakeInstallationOptions.instance).to_not receive(:custom_url=).with(nil)
+                expect(File).to_not receive(:write).with(/inst_update_installer.yaml/, anything)
                 subject.main
               end
             end
@@ -319,6 +332,14 @@ describe Yast::InstUpdateInstaller do
               expect(regservice_selection).to_not receive(:run)
               expect(registration_class).to receive(:new).with(smt0.slp_url)
                 .and_return(registration)
+              subject.main
+            end
+
+            it "saves the registration URL to be used later" do
+              allow(manager).to receive(:add_repository)
+              expect(FakeInstallationOptions.instance).to receive(:custom_url=).with(smt0.slp_url)
+              expect(File).to receive(:write).with(/inst_update_installer.yaml/,
+                { "custom_url" => smt0.slp_url }.to_yaml)
               subject.main
             end
           end


### PR DESCRIPTION
Fixes a problem introduced [here](https://github.com/yast/yast-installation/pull/401/commits/e27cc92d5d5f45d48808b4e1fcb54499778e6c50#diff-8aa15970732082407af8655c128f0913R168).

The registration URL used during self-update is stored to be the default option in the registration screen. However, due to the change mentioned above, it was stored accidentally converted from `nil` to `""` if SCC was used.

This patch just skip writing the URL if not needed.