### PR TITLE
Remove old libstorage dependency

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Aug  9 14:51:06 UTC 2016 - ancor@suse.com
+
+- storage-ng: removed dependency from (old) yast2-storage, even
+  if it breaks some functionality.
+- 3.2.2
+
+-------------------------------------------------------------------
 Fri Jul 29 07:32:46 UTC 2016 - ancor@suse.com
 
 - If the user has skipped multipath activation, don't ask again

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -62,9 +62,6 @@ Conflicts:	yast2-mouse < 2.18.0
 # New API for ProductLicense
 Requires:	yast2-packager >= 3.1.96
 
-# Yast::Storage.multipath_off?
-Requires:	yast2-storage >= 3.1.97
-
 # use in startup scripts
 Requires:	initviocons
 

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation
-Version:        3.2.1
+Version:        3.2.2
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -62,6 +62,11 @@ Conflicts:	yast2-mouse < 2.18.0
 # New API for ProductLicense
 Requires:	yast2-packager >= 3.1.96
 
+# FIXME: some code present in this package still depends on the old yast2-storage
+# and will break without this dependency. That's acceptable at this point of the
+# migration to storage-ng. See installer-hacks.md in the yast-storage-ng repo.
+# Requires:  yast2-storage >= 3.1.97
+
 # use in startup scripts
 Requires:	initviocons
 

--- a/src/lib/installation/clients/inst_prepareprogress.rb
+++ b/src/lib/installation/clients/inst_prepareprogress.rb
@@ -37,7 +37,6 @@ module Yast
       Yast.import "Language"
       Yast.import "SlideShow"
       Yast.import "ImageInstallation"
-      Yast.import "StorageClients"
       Yast.import "PackageSlideShow"
       Yast.import "Wizard"
       Yast.import "InstData"

--- a/src/lib/installation/snapshots_finish.rb
+++ b/src/lib/installation/snapshots_finish.rb
@@ -11,7 +11,6 @@ module Installation
       textdomain "installation"
 
       Yast.import "Mode"
-      Yast.import "StorageSnapper"
       Yast.import "InstFunctions"
       Yast.include self, "installation/misc.rb"
     end


### PR DESCRIPTION
To make travis work again we need to be able to build and install some basic packages without bringing yast2-storage in. We don't need all the code to actually work, just the one executed in our installation (already fixed/commented in https://github.com/yast/yast-installation/pull/403).

This pull request removes the dependency from the spec file and cleanups some bits of code. Hopefully enough to get travis working again.