### PR TITLE
[WIP] Move self-update and software manager initialization

### DIFF
--- a/src/lib/installation/clients/inst_system_analysis.rb
+++ b/src/lib/installation/clients/inst_system_analysis.rb
@@ -96,6 +96,10 @@ module Yast
       actions_doing = []
       actions_functions = []
 
+      actions_todo      << _("Initialize software manager")
+      actions_doing     << _("Initializing software manager...")
+      actions_functions << fun_ref(method(:InitInstallationRepositories), "boolean ()")
+
       Builtins.y2milestone("Probing done: %1", Installation.probing_done)
       # skip part of probes as it doesn't change, but some parts (mostly disks
       # that can be activated) need rerun see BNC#865579
@@ -134,10 +138,6 @@ module Yast
       actions_todo      << _("Search for system files")
       actions_doing     << _("Searching for system files...")
       actions_functions << fun_ref(method(:FilesFromOlderSystems), "boolean ()")
-
-      actions_todo      << _("Initialize software manager")
-      actions_doing     << _("Initializing software manager...")
-      actions_functions << fun_ref(method(:InitInstallationRepositories), "boolean ()")
 
       Progress.New(
         # TRANSLATORS: dialog caption
@@ -339,6 +339,7 @@ module Yast
         ret = false
       else
         @packager_initialized = true
+        return :restart_yast if update_installer == :restart_yast
         Packages.InitializeAddOnProducts
 
         # bnc#886608: Adjusting product name (for &product; macro) right after we
@@ -352,6 +353,13 @@ module Yast
       PackageCallbacks.RestorePreviousProgressCallbacks
 
       ret
+    end
+
+    # Runs installer's self-update
+    #
+    # @see inst_update_installer client
+    def update_installer
+      WFM.CallFunction("inst_update_installer", [])
     end
 
     def FilesFromOlderSystems


### PR DESCRIPTION
The intention of this PR is just to discuss what's the best approach to move the self-update feature earlier during the installation. I'm showing some code which works although I think that the final solution could be different.

My first instinct was just to move the `InitInstallationRepositories` to the beginning of this client and adding a new step:

```ruby
  actions_todo      << _("Installer update")
  actions_doing     << _("Searching for installer updates...")
  actions_functions << fun_ref(method(:update_installer), "boolean ()")
```

But at this point, the add-ons initialization (`add_on_products.xml`) are already processed and I would like to do the update in a even earlier step. So that's the reason to call the "client" right after the real initialization. Anyway, the code needs some refactoring (it looks ugly).

On the other hand, we should remove references to `update_installer` in control files and that leads me to another possible approach: maybe we could move the software initialization to its own client (including calling the self-update).

Finally, I don't know why the progress is messed up after the software initialization step finishes.