### PR TITLE
Fixed test-case after implementing lazy loading in ProductLicense

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -2,7 +2,7 @@
 Tue Aug 16 13:28:14 CEST 2016 - locilka@suse.com
 
 - Fixed testsuite for inst_complex_welcome after implementing lazy
-  loading in ProductLicense in yast2-packager
+  loading in ProductLicense in yast2-packager (bsc#993285)
 - 3.1.208
 
 -------------------------------------------------------------------

--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Aug 16 13:28:14 CEST 2016 - locilka@suse.com
+
+- Fixed testsuite for inst_complex_welcome after implementing lazy
+  loading in ProductLicense in yast2-packager
+- 3.1.208
+
+-------------------------------------------------------------------
 Fri Aug  5 07:22:59 UTC 2016 - igonzalezsosa@suse.com
 
 - Fix the registration screen initialization when SCC server

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -34,6 +34,7 @@ Source1:	YaST2-Second-Stage.service
 Source2:	YaST2-Firstboot.service
 
 BuildRequires:  docbook-xsl-stylesheets libxslt update-desktop-files yast2-core-devel
+BuildRequires:  yast2-packager >= 3.1.113
 BuildRequires:  yast2-devtools >= 3.1.10
 BuildRequires:  rubygem(rspec)
 
@@ -59,8 +60,8 @@ Requires:	yast2-pkg-bindings >= 3.1.33
 # Mouse-related scripts moved to yast2-mouse
 Conflicts:	yast2-mouse < 2.18.0
 
-# New API for ProductLicense
-Requires:	yast2-packager >= 3.1.96
+# Lazy loading in ProductLicense
+Conflicts:	yast2-packager < 3.1.113
 
 # Yast::Storage.multipath_off?
 Requires:	yast2-storage >= 3.1.97

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -61,7 +61,7 @@ Requires:	yast2-pkg-bindings >= 3.1.33
 Conflicts:	yast2-mouse < 2.18.0
 
 # Lazy loading in ProductLicense
-Conflicts:	yast2-packager < 3.1.113
+Requires:	yast2-packager >= 3.1.113
 
 # Yast::Storage.multipath_off?
 Requires:	yast2-storage >= 3.1.97

--- a/test/inst_complex_welcome_test.rb
+++ b/test/inst_complex_welcome_test.rb
@@ -101,6 +101,7 @@ describe Yast::InstComplexWelcomeClient do
             allow(Yast::Language).to receive(:CheckLanguagesSupport)
 
             allow(Yast::ProductLicense).to receive(:AcceptanceNeeded).and_return(license_needed)
+            allow(Yast::ProductLicense).to receive(:cache_license_acceptance_needed).and_return(nil)
             allow(subject).to receive(:license_accepted?).and_return(license_accepted)
           end
 


### PR DESCRIPTION
- The test actually tests behavior of the ProductLicense (a bit) instead of testing the client only
- That's something I can't and will not fix now
- See also https://build.opensuse.org/package/live_build_log/openSUSE:Factory:Staging:J/yast2-installation/standard/x86_64