### PR TITLE
[WIP] Fetch profile from update installer

### DIFF
--- a/test/inst_update_installer_test.rb
+++ b/test/inst_update_installer_test.rb
@@ -54,6 +54,7 @@ describe Yast::InstUpdateInstaller do
     allow(subject).to receive(:initialize_packager).and_return(true)
     allow(subject).to receive(:finish_packager)
     allow(subject).to receive(:fetch_profile).and_return(ay_profile)
+    allow(subject).to receive(:process_profile)
 
     # stub the Profile module to avoid dependency on autoyast2-installation
     stub_const("Yast::Profile", ay_profile)
@@ -408,8 +409,8 @@ describe Yast::InstUpdateInstaller do
             allow(::FileUtils).to receive(:touch)
           end
 
-          it "tries to fetch the profile from the given profile" do
-            expect(subject).to receive(:fetch_profile)
+          it "tries to process the profile from the given URL" do
+            expect(subject).to receive(:process_profile)
             expect(manager).to receive(:add_repository).with(URI(profile_url))
               .and_return(true)
 

--- a/test/inst_update_installer_test.rb
+++ b/test/inst_update_installer_test.rb
@@ -56,8 +56,6 @@ describe Yast::InstUpdateInstaller do
 
     # stub the Profile module to avoid dependency on autoyast2-installation
     stub_const("Yast::Profile", ay_profile)
-
-    stub_const("Yast::ProfileLocation", ay_profile_location)
   end
 
   describe "#main" do
@@ -360,6 +358,14 @@ describe Yast::InstUpdateInstaller do
           before do
             expect(Yast::Mode).to receive(:auto).at_least(1).and_return(true)
             allow(::FileUtils).to receive(:touch)
+          end
+
+          it "tries to fetch the profile from the given profile" do
+            expect(subject).to receive(:fetch_profile)
+            expect(manager).to receive(:add_repository).with(URI(profile_url))
+              .and_return(true)
+
+            subject.main
           end
 
           context "the profile defines the update URL" do

--- a/test/inst_update_installer_test.rb
+++ b/test/inst_update_installer_test.rb
@@ -35,6 +35,7 @@ describe Yast::InstUpdateInstaller do
   let(:restarting) { false }
   let(:profile) { {} }
   let(:ay_profile) { double("Yast::Profile", current: profile) }
+  let(:ay_profile_location) { double("Yast::ProfileLocation") }
 
   before do
     allow(Yast::Pkg).to receive(:GetArchitecture).and_return(arch)
@@ -51,9 +52,12 @@ describe Yast::InstUpdateInstaller do
     # skip the libzypp initialization globally, enable in the specific tests
     allow(subject).to receive(:initialize_packager).and_return(true)
     allow(subject).to receive(:finish_packager)
+    allow(subject).to receive(:fetch_profile).and_return(ay_profile)
 
     # stub the Profile module to avoid dependency on autoyast2-installation
     stub_const("Yast::Profile", ay_profile)
+
+    stub_const("Yast::ProfileLocation", ay_profile_location)
   end
 
   describe "#main" do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -33,6 +33,7 @@ module Yast
     # it is just namespace
     def SetSignatureHandling
     end
+
     def Import(profile)
     end
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -25,7 +25,19 @@ module Yast
     def second_stage
     end
   end
+
   AutoinstConfig = AutoinstConfigClass.new
+
+  class AutoinstGeneralClass
+    # we need at least one non-default methods, otherwise ruby-bindings thinks
+    # it is just namespace
+    def SetSignatureHandling
+    end
+    def Import(profile)
+    end
+  end
+
+  AutoinstGeneral = AutoinstGeneralClass.new
 
   # Faked Profile module
   class ProfileClass

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -33,6 +33,13 @@ module Yast
     end
   end
   Profile = ProfileClass.new
+
+  class ProfileLocationClass
+    def Process
+    end
+  end
+
+  ProfileLocation = ProfileLocationClass.new
 end
 
 if ENV["COVERAGE"]


### PR DESCRIPTION
I tried to do as minimal as possible not handling all the stuff that currently autoinit is handling, just enough to read the self_update_url.

So from here https://github.com/yast/yast-autoinstallation/blob/master/src/clients/inst_autoinit.rb#L196 to the end is not handled.