### PR TITLE
Replace unicode bullet char by asterisk for ncurses (bsc#995082)

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Aug 24 14:51:45 UTC 2016 - cwh@suse.com
+
+- Replace unicode bullet char by asterisk for ncurses (bsc#995082)
+- 3.1.211
+
+-------------------------------------------------------------------
 Wed Aug 17 15:02:02 UTC 2016 - jreidinger@suse.com
 
 - filter out same repositories from extraurls if they differ only

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation
-Version:        3.1.210
+Version:        3.1.211
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/installation/select_system_role.rb
+++ b/src/lib/installation/select_system_role.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 # Copyright (c) 2016 SUSE LLC.
 #  All Rights Reserved.
 
@@ -94,10 +95,12 @@ module Installation
 
     def role_buttons
       ui_roles = role_attributes.each_with_object(VBox()) do |r, vbox|
+        # bsc#995082: System role descriptions use a character that is missing in console font
+        description = Yast::UI.TextMode ? r[:description].gsub('•', '*') : r[:description]
         vbox << Left(RadioButton(Id(r[:id]), r[:label]))
         vbox << HBox(
           HSpacing(Yast::UI.TextMode ? 4 : 2),
-          Left(Label(r[:description]))
+          Left(Label(description))
         )
         vbox << VSpacing(2)
       end

--- a/src/lib/installation/select_system_role.rb
+++ b/src/lib/installation/select_system_role.rb
@@ -96,7 +96,7 @@ module Installation
     def role_buttons
       ui_roles = role_attributes.each_with_object(VBox()) do |r, vbox|
         # bsc#995082: System role descriptions use a character that is missing in console font
-        description = Yast::UI.TextMode ? r[:description].gsub('•', '*') : r[:description]
+        description = Yast::UI.TextMode ? r[:description].tr("•", "*") : r[:description]
         vbox << Left(RadioButton(Id(r[:id]), r[:label]))
         vbox << HBox(
           HSpacing(Yast::UI.TextMode ? 4 : 2),


### PR DESCRIPTION
More like a hack, but it fixes the issue without big overhead.
![roles-ncurses](https://cloud.githubusercontent.com/assets/336868/17935474/c051916c-6a1b-11e6-8f0e-9261212f6874.png)
![roles-qt](https://cloud.githubusercontent.com/assets/336868/17935475/c0524698-6a1b-11e6-853a-b0b7fd407f58.png)
