### PR TITLE
Display a warning when using the fallback URL for self update (bsc#996179)

### DIFF
--- a/doc/SELF_UPDATE.md
+++ b/doc/SELF_UPDATE.md
@@ -43,10 +43,11 @@ Obviously, for downloading the installer updates YaST needs network.
 YaST by default tries using DHCP on all network interfaces. If there is
 a DHCP server in the network then network is configured automatically.
 
-If you need static IP setup in your network then use the `netsetup` and `hostip`
-boot options, e.g. `netsetup=hostip hostip=192.168.1.101/24`.
-If you need to set more options (gateway, nameserver,...) the see the
-[Linuxrc documentation](https://en.opensuse.org/SDB:Linuxrc#Network_Config).
+If you need static IP setup in your network then use the
+`ifcfg=<interface>=<ip_address>,<gateway>,<nameserver>` boot option, e.g.
+`ifcfg=eth0=192.168.1.101/24,192.168.1.1,192.168.1.2`.
+See the [Linuxrc documentation](https://en.opensuse.org/SDB:Linuxrc#Network_Config)
+for more details.
 
 ## Update Format
 

--- a/doc/SELF_UPDATE.md
+++ b/doc/SELF_UPDATE.md
@@ -43,10 +43,10 @@ Obviously, for downloading the installer updates YaST needs network.
 YaST by default tries using DHCP on all network interfaces. If there is
 a DHCP server in the network then network is configured automatically.
 
-If you need static IP setup in your network then use the `hostip` boot
-option, e.g. `hostip=192.168.1.101/24`. If you need to set more options
-(gateway, nameserver,...) the see the [Linuxrc documentation](
-https://en.opensuse.org/SDB:Linuxrc#Network_Config).
+If you need static IP setup in your network then use the `netsetup` and `hostip`
+boot options, e.g. `netsetup=hostip hostip=192.168.1.101/24`.
+If you need to set more options (gateway, nameserver,...) the see the
+[Linuxrc documentation](https://en.opensuse.org/SDB:Linuxrc#Network_Config).
 
 ## Update Format
 

--- a/doc/SELF_UPDATE.md
+++ b/doc/SELF_UPDATE.md
@@ -33,6 +33,20 @@ To use another language also for the self-update press `F2` in the DVD boot menu
 and select the language from the list. Or use the `language` boot option, e.g.
 `language=de_DE`.
 
+If you want to use a different keyboard layout for the console then use the
+[`keytable`](https://en.opensuse.org/SDB:Linuxrc#p_keytable) boot option.
+
+## Network Setup
+
+Obviously, for downloading the installer updates YaST needs network.
+
+YaST by default tries using DHCP on all network interfaces. If there is
+a DHCP server in the network then network is configured automatically.
+
+If you need static IP setup in your network then use the `hostip` boot
+option, e.g. `hostip=192.168.1.101/24`. If you need to set more options
+(gateway, nameserver,...) the see the [Linuxrc documentation](
+https://en.opensuse.org/SDB:Linuxrc#Network_Config).
 
 ## Update Format
 
@@ -44,8 +58,15 @@ handled in a different way:
   are executed.
 * No dependency checks are performed. RPMs are added in alphabetical order.
 
-The rpm-md repository is required by SMT as this is the only format which it
-supports for data mirroring.
+The rpm-md repository is required by SMT ([SUSE Subscription Management Tool](
+https://www.suse.com/products/subscription-management-tool))
+as this is the only format which it supports for data mirroring.
+
+The files from the packages override the files from the original inst-sys.
+That means the update packages might not need to contain all files,
+it is enough to include only the changed files which are different than
+in the original inst-sys. The unchanged files can be omitted to save memory
+and the download bandwidth.
 
 ## Where to Find the Updates
 
@@ -61,8 +82,10 @@ The URL of the update repository is evaluated in this order:
      <self_update_url>http://example.com/updates/$arch</self_update_url>
    </general>
    ```
-3. Registration server (SCC/SMT), not available in openSUSE. The URL of the
-   registration server which should be used is determined via:
+3. Registration server ([SCC](https://scc.suse.com) or
+   [SMT](https://www.suse.com/products/subscription-management-tool)), not
+   available in openSUSE. The URL of the registration server which should
+   be used is determined via:
    1. The `regurl` boot parameter
    2. AutoYaST profile ([reg_server element](https://www.suse.com/documentation/sles-12/singlehtml/book_autoyast/book_autoyast.html#CreateProfile.Register)).
    3. SLP lookup (this behavior applies to regular and AutoYaST installations):

--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Aug 30 06:55:13 UTC 2016 - lslezak@suse.cz
+
+- Display a warning popup when the installer self update uses
+  the fallback URL instead of selected SMT or the default SCC
+  server (bsc#996179)
+- 3.1.124
+
+-------------------------------------------------------------------
 Thu Aug 25 14:23:20 UTC 2016 - lslezak@suse.cz
 
 - Move the installer self update step earlier in the workflow

--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,9 +1,11 @@
 -------------------------------------------------------------------
 Tue Aug 30 06:55:13 UTC 2016 - lslezak@suse.cz
 
-- Display a warning popup when the installer self update uses
-  the fallback URL instead of selected SMT or the default SCC
+- Display a warning popup when the installer self-update uses
+  the fallback URL instead of the selected SMT or the default SCC
   server (bsc#996179)
+- Do not contact the registration server in self-update when
+  network is not running, skip self-update completely
 - 3.1.124
 
 -------------------------------------------------------------------

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation
-Version:        3.1.213
+Version:        3.1.214
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/installation/clients/inst_update_installer.rb
+++ b/src/lib/installation/clients/inst_update_installer.rb
@@ -210,7 +210,24 @@ module Yast
       # Set custom_url into installation options
       Registration::Storage::InstallationOptions.instance.custom_url = registration.url
       store_registration_url(url) if url != :scc
-      registration.get_updates_list.map { |u| URI(u.url) }
+      ret = registration.get_updates_list.map { |u| URI(u.url) }
+
+      if ret.empty?
+        # TRANSLATORS: error message
+        msg = _("<p>Cannot obtain the installer update repository URL\n" \
+          "from the registration server.</p>")
+
+        if self_update_url_from_control
+          # TRANSLATORS: part of an error message, %s is the default repository
+          # URL from control.xml
+          msg += _("<p>The default URL %s will be used.<p>") % self_update_url_from_control
+        end
+
+        # display the message in a RichText widget to wrap long lines
+        Report.LongWarning(msg)
+      end
+
+      ret
     end
 
     # Return the URL of the preferred registration server

--- a/src/lib/installation/clients/inst_update_installer.rb
+++ b/src/lib/installation/clients/inst_update_installer.rb
@@ -212,22 +212,27 @@ module Yast
       store_registration_url(url) if url != :scc
       ret = registration.get_updates_list.map { |u| URI(u.url) }
 
-      if ret.empty?
-        # TRANSLATORS: error message
-        msg = _("<p>Cannot obtain the installer update repository URL\n" \
-          "from the registration server.</p>")
-
-        if self_update_url_from_control
-          # TRANSLATORS: part of an error message, %s is the default repository
-          # URL from control.xml
-          msg += _("<p>The default URL %s will be used.<p>") % self_update_url_from_control
-        end
-
-        # display the message in a RichText widget to wrap long lines
-        Report.LongWarning(msg)
-      end
+      display_fallback_warning if ret.empty?
 
       ret
+    end
+
+    # Display a warning message about using the default update URL from
+    # control.xml when the registration server does not return any URL or fails.
+    # In AutoYaST mode the dialog is closed after a timeout.
+    def display_fallback_warning
+      # TRANSLATORS: error message
+      msg = _("<p>Cannot obtain the installer update repository URL\n" \
+        "from the registration server.</p>")
+
+      if self_update_url_from_control
+        # TRANSLATORS: part of an error message, %s is the default repository
+        # URL from control.xml
+        msg += _("<p>The default URL %s will be used.<p>") % self_update_url_from_control
+      end
+
+      # display the message in a RichText widget to wrap long lines
+      Report.LongWarning(msg)
     end
 
     # Return the URL of the preferred registration server

--- a/src/lib/installation/clients/inst_update_installer.rb
+++ b/src/lib/installation/clients/inst_update_installer.rb
@@ -57,8 +57,8 @@ module Yast
         Installation.finish_restarting!
       end
 
-      # shortcut - already updated or disabled via boot option
-      if installer_updated? || disabled_in_linuxrc?
+      # shortcut - already updated, disabled via boot option or network not running
+      if installer_updated? || disabled_in_linuxrc? || !NetworkService.isNetworkRunning
         log.info "Self update not needed, skipping"
         return :next
       end
@@ -72,7 +72,7 @@ module Yast
 
       initialize_packager
 
-      # self update disabled or not possible
+      # self-update not possible, the repo URL is not defined
       return :next unless try_to_update?
 
       log.info("Trying installer update")
@@ -437,9 +437,9 @@ module Yast
     #
     # The update should be performed when these requeriments are met:
     #
-    # * Installer is not updated yet.
-    # * Self-update feature is enabled.
     # * Network is up.
+    # * Installer is not updated yet.
+    # * Self-update feature is enabled and the repository URL is defined
     #
     # @return [Boolean] true if the update should be performed; false otherwise.
     #
@@ -447,7 +447,7 @@ module Yast
     # @see #self_update_enabled?
     # @see NetworkService.isNetworkRunning
     def try_to_update?
-      !installer_updated? && self_update_enabled? && NetworkService.isNetworkRunning
+      NetworkService.isNetworkRunning && !installer_updated? && self_update_enabled?
     end
 
     # Determines whether the given URL is equal to the default one

--- a/test/inst_update_installer_test.rb
+++ b/test/inst_update_installer_test.rb
@@ -316,6 +316,18 @@ describe Yast::InstUpdateInstaller do
             expect(subject.main).to eq(:restart_yast)
           end
 
+          context "when the registration server returns empty URL list or fails" do
+            before do
+              allow(registration).to receive(:get_updates_list).and_return([])
+            end
+
+            it "displays a warning about using the default URL from control.xml" do
+              expect(Yast::Report).to receive(:LongWarning)
+                .with(/#{Regexp.escape("http://update.opensuse.org/x86_64/update.dud")}/)
+              subject.main
+            end
+          end
+
           context "when more than one SMT server exist" do
             before do
               allow(url_helpers).to receive(:slp_discovery).and_return([smt0, smt1])


### PR DESCRIPTION
## Description

When the registration server fails or returns empty URL then the fallback URL from `control.xml` was silently used. This might be a bit misleading because users might think the SMT server is still used after confirming the error popup. It's not clear which URL is used in the end.

This fixes [bug#996179](https://bugzilla.suse.com/show_bug.cgi?id=996179).

## Original Behavior

*Click the screenshots to display them in full size.*

Note the default `https://updates.suse.com/` URL in the progress after confirming the error. If you do not look carefully you might still think the originally selected SMT is used, that's not true.

![self_update_fallback](https://cloud.githubusercontent.com/assets/907998/18058328/1af55094-6e14-11e6-84e6-19b4e1e087c0.gif)

## Fixed

There is a popup warning displayed when the fallback URL is used.

*(The SSL import dialog is not displayed because this was tested it in the same installation instance, the certificate has been already imported.)*

![self_update_fallback_popup](https://cloud.githubusercontent.com/assets/907998/18058978/1e492308-6e17-11e6-8df6-2d817cf016c9.gif)

## Notes

- The `Report.LongWarning` call is used to print the message in a RichText widget to wrap long lines in ncurses UI: 
![warning_ncurses](https://cloud.githubusercontent.com/assets/907998/18078945/8aa51f1c-6e8e-11e6-8cb1-dbb8e7329b0d.png)
-  `Report.LongWarning` does not block in AutoYaST mode, the default URL is used automatically after a timeout.
- Additionaly the registration server is not contacted when network is not configured. In that case whole self-update is skipped.