### PR TITLE
Set theme for ncurses

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Oct 13 14:15:23 UTC 2016 - igonzalezsosa@suse.com
+
+- Set libyui-ncurses environment before starting the installer
+  (related to bsc#780621)
+- 3.2.4
+
+-------------------------------------------------------------------
 Thu Oct 13 13:55:33 UTC 2016 - igonzalezsosa@suse.com
 
 - Bump version number to release fixes for bnc#999895,

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation
-Version:        3.2.3
+Version:        3.2.4
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -46,8 +46,8 @@ BuildRequires: yast2 >= 3.1.180
 # AutoinstSoftware.SavePackageSelection()
 Requires:       autoyast2-installation >= 3.1.105
 
-# Moved proc_modules.scr
-Requires:       yast2 >= 3.1.186
+# Needs set_inst_ncurses_env
+Requires:       yast2 >= 3.2.0
 
 # Language::GetLanguageItems and other API
 # Language::Set (handles downloading the translation extensions)

--- a/startup/YaST2.call
+++ b/startup/YaST2.call
@@ -128,6 +128,7 @@ function prepare_for_ncurses () {
 	#---------------------------------------------
 	check_run_fbiterm
 	log "\tCheck for FB-I-terminal: RUN_FBITERM = $RUN_FBITERM"
+	set_inst_ncurses_env
 }
 
 #----[ prepare_for_ssh ]----#


### PR DESCRIPTION
Set theme for ncurses in order to honor the `Y2COLORMODE` setting. I've decided to add a `set_inst_ncurses_env` in make it symmetric to the Qt scenario.

Depends on https://github.com/yast/yast-yast2/pull/501 and it's related to https://github.com/libyui/libyui-qt/pull/60 and https://github.com/libyui/libyui-qt/pull/61.