### PR TITLE
Merge SLE-12-SP2-Octopus into SLE-12-SP2-CASP

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -3,7 +3,6 @@ Thu Oct  6 12:55:58 CEST 2016 - schubi@suse.de
 
 - AutoYaST upgrade: Setting timeout for errors, messages, ...
   popup correctly (bnc#999895).
-- 3.1.217
 
 -------------------------------------------------------------------
 Thu Sep 29 08:09:28 UTC 2016 - igonzalezsosa@suse.com

--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Oct  6 12:55:58 CEST 2016 - schubi@suse.de
+
+- AutoYaST upgrade: Setting timeout for errors, messages, ...
+  popup correctly (bnc#999895).
+- 3.1.217
+
+-------------------------------------------------------------------
 Thu Sep 29 08:09:28 UTC 2016 - igonzalezsosa@suse.com
 
 - Translate description of Snapper snapshots (bsc#988700)

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation
-Version:        3.1.217
+Version:        3.1.216.1
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation
-Version:        3.1.216.1
+Version:        3.1.217
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/installation/clients/inst_system_analysis.rb
+++ b/src/lib/installation/clients/inst_system_analysis.rb
@@ -56,16 +56,6 @@ module Yast
       Yast.include self, "packager/storage_include.rb"
       Yast.include self, "packager/load_release_notes.rb"
 
-      if Mode.autoupgrade
-        Report.Import(
-
-          "messages" => { "timeout" => 10 },
-          "errors"   => { "timeout" => 10 },
-          "warnings" => { "timeout" => 10 }
-
-        )
-      end
-
       # This dialog in not interactive
       # always return `back when came from the previous dialog
       if GetInstArgs.going_back


### PR DESCRIPTION
Merge the Octopus branch into CASP to clean up the mess. Removed conflict in the version change.

(*Note: Ignore the Jenkins failure, the SP2 project is not yet available in the public OBS.*)