### PR TITLE
Support for read-only proposal modules (FATE#321739)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ YaST Installation Framework
 
 [![Travis Build](https://travis-ci.org/yast/yast-installation.svg?branch=master)](https://travis-ci.org/yast/yast-installation)
 [![Jenkins Build](http://img.shields.io/jenkins/s/https/ci.opensuse.org/yast-installation-master.svg)](https://ci.opensuse.org/view/Yast/job/yast-installation-master/)
-
+[![Coverage Status](https://coveralls.io/repos/github/yast/yast-installation/badge.svg?branch=SLE-12-SP2-Octopus)](https://coveralls.io/github/yast/yast-installation?branch=SLE-12-SP2-Octopus)
 
 Description
 ============

--- a/doc/installation_clients.md
+++ b/doc/installation_clients.md
@@ -33,9 +33,18 @@ section)[TODO link].
 
 The actions can be:
 
-- `"MakeProposal"` that creates a proposal for the module. It can have parameter `"force_reset"`
-  that can force reset and create a new one from scratch. Response is a `Hash` with proposal text,
-  optional link definitions and a help text. **TODO specify exactly format.**
+- `"MakeProposal"` that creates a proposal for the module. The optional `Hash`
+  then has this structure:
+  ```ruby
+  {
+    "force_reset"      => true/false,
+    "language_changed" => true/false,
+    "read_only"        => true/false
+  }
+  ```
+
+  See more details [in the generic `ProposalClient` class](
+    https://github.com/yast/yast-yast2/blob/5762181d62762816a73fc040362c1efb5d97deed/library/general/src/lib/installation/proposal_client.rb#L100)
 - `"AskUser"` for automatic or manual user request to change the proposed configuration. Parameter is
   `"chosen_id"` which specify action. It can be `"id"` from `"Description"` action
   which should open dialog to modify values or links specified in `"MakeProposal"`

--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Oct 31 13:23:38 UTC 2016 - lslezak@suse.cz
+
+- Added support for read-only proposal modules (FATE#321739)
+- 3.1.216.1.2
+
+-------------------------------------------------------------------
 Thu Oct 27 15:09:58 CEST 2016 - shundhammer@suse.de
 
 - Documentation for subvolumes in control.xml (fate#321737)

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation
-Version:        3.1.216.1.1
+Version:        3.1.216.1.2
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/installation/proposal_runner.rb
+++ b/src/lib/installation/proposal_runner.rb
@@ -54,7 +54,6 @@ module Installation
       Yast.import "GetInstArgs"
       Yast.import "ProductControl"
       Yast.import "HTML"
-      Yast.import "Report"
 
       # values used in defined functions
 

--- a/src/lib/installation/proposal_runner.rb
+++ b/src/lib/installation/proposal_runner.rb
@@ -54,6 +54,7 @@ module Installation
       Yast.import "GetInstArgs"
       Yast.import "ProductControl"
       Yast.import "HTML"
+      Yast.import "Report"
 
       # values used in defined functions
 
@@ -321,9 +322,18 @@ module Installation
     #
     # @param [String] submodule	name of the submodule's proposal dispatcher
     # @param  has_next		force a "next" button even if the submodule would otherwise rename it
-    # @return workflow_sequence see proposal-API.txt
-    #
+    # @return workflow_sequence see proposal-API.txt, or nil if the link cannot be handled
+    #   (is read-only)
     def submod_ask_user(input)
+      client = @store.client_for_link(input)
+      if @store.read_only?(client)
+        log.warn "Proposal client #{client.inspect} is read-only, ignoring the user action"
+        # TRANSLATORS: Warning message, can be split to more lines if needed
+        Yast::Report.Warning(_("This proposed setting is marked as read-only\n" \
+          "and cannot be changed."))
+        return nil
+      end
+
       # Call the AskUser() function
       ask_user_result = @store.handle_link(input)
 

--- a/src/lib/installation/proposal_store.rb
+++ b/src/lib/installation/proposal_store.rb
@@ -454,6 +454,7 @@ module Installation
         [
           "MakeProposal",
           {
+            "read_only"        => read_only?(client),
             "force_reset"      => force_reset,
             "language_changed" => language_changed
           }

--- a/src/lib/installation/proposal_store.rb
+++ b/src/lib/installation/proposal_store.rb
@@ -298,16 +298,14 @@ module Installation
     end
 
     def read_only_proposals
-      return @read_only_proposals unless @read_only_proposals.nil?
+      return @read_only_proposals if @read_only_proposals
 
       @read_only_proposals = []
-      log.info "all proposals: #{properties["proposal_modules"]}"
 
       properties.fetch("proposal_modules", []).each do |proposal|
         next unless proposal["read_only"]
 
-        name = proposal["name"]
-        name += "_proposal" unless name.end_with?("_proposal")
+        name = full_module_name(proposal["name"])
         @read_only_proposals << name
       end
 
@@ -545,12 +543,20 @@ module Installation
       @modules_order.map! { |m| m["proposal_modules"] }
 
       @modules_order.each do |module_tab|
-        module_tab.map! do |mod|
-          mod.include?("_proposal") ? mod : mod + "_proposal"
-        end
+        module_tab.map! { |mod| full_module_name(mod) }
       end
 
       @modules_order
+    end
+
+    # Build the full proposal module name including the "_proposal" suffix.
+    # The sufix is not added when it is already present.
+    # @param [String] full or short proposal module name
+    # @return [String] full proposal module name
+    def full_module_name(name)
+      # already a full name?
+      return name if name.end_with?("_proposal")
+      name + "_proposal"
     end
 
     def order_without_tabs

--- a/src/lib/installation/proposal_store.rb
+++ b/src/lib/installation/proposal_store.rb
@@ -242,6 +242,14 @@ module Installation
         client
     end
 
+    # Returns the read-only flag
+    #
+    # @param [String] client
+    # @return [String] a title provided by the description API
+    def read_only?(client)
+      read_only_proposals.include?(client)
+    end
+
     # Calls client('AskUser'), to change a setting interactively (if link is the
     # heading for the part) or noninteractively (if it is a "shortcut")
     def handle_link(link)
@@ -271,6 +279,24 @@ module Installation
       raise "Unknown user request #{link}. Broken proposal client?" if matching_client.nil?
 
       matching_client.first
+    end
+
+    def read_only_proposals
+      return @read_only_proposals unless @read_only_proposals.nil?
+
+      @read_only_proposals = []
+      log.info "all proposals: #{properties["proposal_modules"]}"
+
+      properties.fetch("proposal_modules", []).each do |proposal|
+        if proposal["read_only"]
+          name = proposal["name"]
+          name += "_proposal" unless name.end_with?("_proposal")
+          @read_only_proposals << name
+        end
+      end
+
+      log.info "Found read-only proposals: #{@read_only_proposals}"
+      @read_only_proposals
     end
 
   private

--- a/src/lib/installation/proposal_store.rb
+++ b/src/lib/installation/proposal_store.rb
@@ -304,11 +304,11 @@ module Installation
       log.info "all proposals: #{properties["proposal_modules"]}"
 
       properties.fetch("proposal_modules", []).each do |proposal|
-        if proposal["read_only"]
-          name = proposal["name"]
-          name += "_proposal" unless name.end_with?("_proposal")
-          @read_only_proposals << name
-        end
+        next unless proposal["read_only"]
+
+        name = proposal["name"]
+        name += "_proposal" unless name.end_with?("_proposal")
+        @read_only_proposals << name
       end
 
       log.info "Found read-only proposals: #{@read_only_proposals}"

--- a/test/proposal_store_test.rb
+++ b/test/proposal_store_test.rb
@@ -542,5 +542,10 @@ describe ::Installation::ProposalStore do
         end
       end
     end
+
+    context "when the proposal is marked as read-only" do
+      it "displays a warning and does not run the proposal client" do
+      end
+    end
   end
 end

--- a/test/proposal_store_test.rb
+++ b/test/proposal_store_test.rb
@@ -452,6 +452,14 @@ describe ::Installation::ProposalStore do
     }
   end
 
+  let(:client_description_with_link) do
+    {
+      "rich_text_title" => "<a href=\"software_link\">Software</a>",
+      "menu_title"      => "&Software",
+      "id"              => "software"
+    }
+  end
+
   let(:client_name) { "software_proposal" }
 
   describe "#description_for" do
@@ -490,6 +498,18 @@ describe ::Installation::ProposalStore do
       allow(subject).to receive(:description_for).with(client_name).and_return(client_description)
 
       expect(subject.title_for(client_name)).to eq(client_description["rich_text_title"])
+    end
+
+    context "when the proposal is marked as read-only" do
+      before do
+        expect(subject).to receive(:read_only?).with(client_name).and_return(true)
+      end
+
+      it "removes all <a> tags from the title" do
+        allow(subject).to receive(:description_for).with(client_name).and_return(client_description_with_link)
+        # compare with the client description without the link
+        expect(subject.title_for(client_name)).to eq(client_description["rich_text_title"])
+      end
     end
   end
 
@@ -544,7 +564,28 @@ describe ::Installation::ProposalStore do
     end
 
     context "when the proposal is marked as read-only" do
-      it "displays a warning and does not run the proposal client" do
+      before do
+        # Proposals need to be cached first
+        subject.make_proposals
+
+        expect(subject).to receive(:read_only?).with("proposal_a").and_return(true)
+        allow(Yast::Report).to receive(:Warning)
+      end
+
+      it "displays a warning" do
+        expect(Yast::Report).to receive(:Warning)
+
+        subject.handle_link("proposal_a")
+      end
+
+      it "does not run the proposal client" do
+        expect(Yast::WFM).to_not receive(:CallFunction)
+
+        subject.handle_link("proposal_a")
+      end
+
+      it "returns nil" do
+        expect(subject.handle_link("proposal_a")).to eq(nil)
       end
     end
   end


### PR DESCRIPTION
This implements the support for the read-only proposal modules, [FATE#321739](https://fate.suse.com/321739).

# Manual Testing

## Control File Example

The code has been tested with software and firewall proposal modules set to read-only mode:

```xml
<proposal_module>
  <name>software</name>
  <presentation_order>35</presentation_order>
  <read_only config:type="boolean">true</read_only>
</proposal_module>
<proposal_module>
  <name>firewall_stage1</name>
  <presentation_order>50</presentation_order>
  <read_only config:type="boolean">true</read_only>
</proposal_module>
```

## The Displayed Proposal

The software and firewall proposal modules then do not display the links in the section header (note the different color), the modules are not reachable:

![read_only_proposal](https://cloud.githubusercontent.com/assets/907998/19859299/0ea86f22-9f85-11e6-964f-b6df5f58fdb5.png)

However the links returned in the proposal summary are still displayed. But clicking them results in a warning popup and the click is ignored:

![read_only_proposal_link](https://cloud.githubusercontent.com/assets/907998/19859307/13d3c97e-9f85-11e6-9684-0058da198647.png)

### Text Mode

The same situation in text mode, the title cannot be activated:

![read_only_proposal_text](https://cloud.githubusercontent.com/assets/907998/19860145/f686c6ca-9f87-11e6-8f6b-3f55fb53f430.png)

And the activating the links also displays the warning popup:
![read_only_proposal_link_text](https://cloud.githubusercontent.com/assets/907998/19860153/fe78dd82-9f87-11e6-94e4-4869ab35a3bb.png)


Additionaly in the text mode the *Change...* menu button does not contain the read-only modules, the software and the firewall setting are omitted:

![read_only_proposal_menu_text](https://cloud.githubusercontent.com/assets/907998/19860197/2db36838-9f88-11e6-9bb9-3278790e1fae.png)

## Disadvantages of the Current Implementation

- Users cannot enter the read-only proposals to see the details. e.g. if the package proposal is read-only the user cannot see which exact packages will be installed.
- Some modules might ask the user to run the module (e.g. when the software selection is too big and does not fit the available space it asks for deselecting some packages), but that's not possible.
- Clicking the links in the proposal does not look nice (they should be rather hidden instead of displaying the warning popup after clicking them).

## Future Enhancements

The proposal handler now sends a new `read_only` flag to the proposal clients.

We could use this feature later to improve the disadvantages mentioned above, the clients would know that they are running in the read-only mode and should not return clickable links and adjust the displayed text accordingly.