### PR TITLE
[RFC] Proposal error popup

### DIFF
--- a/src/lib/installation/proposal_errors.rb
+++ b/src/lib/installation/proposal_errors.rb
@@ -1,0 +1,51 @@
+require "yast"
+
+Yast.import "UI"
+Yast.import "Label"
+Yast.import "Mode"
+Yast.import "Popup"
+
+module Installation
+  class ProposalErrors
+    include Yast::I18n
+    include Yast::Logger
+
+    ERROR_PROPOSAL_TIMEOUT = 60
+
+    def initialize
+      textdomain "installation"
+      @errors = []
+    end
+
+    # clears previously stored errros
+    def clear
+      @errors = []
+    end
+
+    # appends new error with given message
+    def append(message)
+      @errors << message
+    end
+
+    # returns true if there is no error or user approved stored errors
+    def approved?
+      return true if @errors.empty?
+
+      headline = _("Error Found in Installation Settings")
+      text = _("The following errors were found in the configuration proposal.\n" \
+        "If you continue with the installation it may not be successful.\n" \
+        "Errors:\n")
+      sep = Yast::UI.TextMode ? "-" : "•"
+      text += "#{sep} " + @errors.join("\n#{sep} ")
+
+      if Yast::Mode.auto
+        !Yast::Popup.TimedErrorAnyQuestion(headline, text,
+          Yast::Label.BackButton, Yast::Label.ContinueButton, :focus_yes,
+          ERROR_PROPOSAL_TIMEOUT)
+      else
+        !Yast::Popup.ErrorAnyQuestion(headline, text,
+          Yast::Label.BackButton, Yast::Label.ContinueButton, :focus_yes)
+      end
+    end
+  end
+end

--- a/test/proposal_errors_test.rb
+++ b/test/proposal_errors_test.rb
@@ -1,0 +1,33 @@
+#! /usr/bin/env rspec
+
+require_relative "./test_helper"
+
+require "installation/proposal_errors"
+
+describe ::Installation::ProposalErrors do
+  describe "#approved?" do
+    it "returns true if there is no error stored" do
+      expect(Yast::Popup).to_not receive(:ErrorAnyQuestion)
+      expect(subject.approved?).to eq true
+    end
+
+    it "asks user to approve errors and returns true if approved" do
+      subject.append("test")
+
+      expect(Yast::Popup).to receive(:ErrorAnyQuestion).and_return(false)
+      expect(subject.approved?).to eq true
+
+      expect(Yast::Popup).to receive(:ErrorAnyQuestion).and_return(true)
+      expect(subject.approved?).to eq false
+    end
+
+    it "in autoyast ask with timeout and return true if timeout exceed" do
+      subject.append("test")
+      allow(Yast::Mode).to receive(:auto).and_return(true)
+
+      # timed error return false when timeout exceed
+      expect(Yast::Popup).to receive(:TimedErrorAnyQuestion).and_return(false)
+      expect(subject.approved?).to eq true
+    end
+  end
+end


### PR DESCRIPTION
I will add changes, when it is final and also create sr against CASP first.

glob content:

Some errors in proposal is non-blocking, but is serious and often lead to problems later in installation. In past it happen that people overlook such errors. So to even more high-light it, we decided to require one more confirmation when such situation happen. You can see how it will look like in following screenshots:
![error_proposal_qt](https://cloud.githubusercontent.com/assets/478871/20304122/f340d96c-ab2e-11e6-9fc7-5b83c8dc0350.png)
![error_proposal_ncurses](https://cloud.githubusercontent.com/assets/478871/20304129/f8693006-ab2e-11e6-81d2-0176bad41b63.png)

