### PR TITLE
Add readonly_timezone element documentation

### DIFF
--- a/doc/control-file.md
+++ b/doc/control-file.md
@@ -397,6 +397,11 @@ These options usually enable or disable some installation feature.
 -   (boolean) *require\_registration* - Require registration of add-on
     product (ignored in the base product).
 
+-   (boolean) *readonly\_timezone* - Timezone cannot be changed by the
+    user during installation or upgrade. The default value is
+    determined using the *timezone* element in the *globals* section.
+    If it's not specified, *UTC* will be used.
+
 ### Installation Helpers
 
 In the *globals* section, there are also helper variables for the


### PR DESCRIPTION
Adding documentation about the readonly_timezone feature. I think that releasing a new `yast2-installation` package is not needed.