### PR TITLE
Set root subvolume read-only for CASP if configured (Fate#321755)

### DIFF
--- a/doc/control-file.md
+++ b/doc/control-file.md
@@ -1044,6 +1044,12 @@ should be an extra warning pop-up dialog when the user enters the expert
 partitioner dialog during installation, for example because the product has
 special requirements for partitioning (Btrfs to support snapshots etc.).
 
+*root_subvolume_read_only* (boolean, default _false_) specifies whether the
+root subvolume should be mounted read-only in /etc/fstab and its 'ro' Btrfs
+property should be set to _true_. This works only for Btrfs root
+filesystems. If another root filesystem type is chosen, this might fail
+silently.
+
 
 #### Subvolumes
 

--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Dec 14 10:46:21 CET 2016 - shundhammer@suse.de
+
+- Set root subvolume read-only if configured (Fate##321755)
+- Document new control.xml parameter root_subvolume_read_only
+- 3.1.217.7
+
+-------------------------------------------------------------------
 Tue Dec 13 14:09:54 UTC 2016 - jreidinger@suse.com
 
 - Add new installation dialog with keyboard layout and root

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation
-Version:        3.1.217.6
+Version:        3.1.217.7
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/installation/clients/umount_finish.rb
+++ b/src/lib/installation/clients/umount_finish.rb
@@ -173,6 +173,17 @@ module Yast
         # BNC #692799: Preserve the randomness state before umounting
         preserve_randomness_state
 
+
+        #
+        # !!! NO WRITE OPERATIONS TO THE TARGET AFTER THIS POINT !!!
+        #
+
+        # This must be done as long as the target root is still mounted
+        # (because the btrfs command requires that), but after the last write
+        # access to it (because it will be read only afterwards).
+        set_root_subvol_read_only
+
+
         @targetMap = Storage.GetTargetMap
 
         # first umount all file based crypto fs since they potentially
@@ -372,6 +383,41 @@ module Yast
       LocalCommand(Builtins.sformat("killproc -TERM %1", service_bin))
 
       nil
+    end
+
+    # Set the root subvolume to read-only and change the /etc/fstab entry
+    # accordingly
+    #
+    def set_root_subvol_read_only
+      return unless root_subvol_read_only_configured?
+      log.info("Setting root subvolume to read-only");
+      set_fstab_root_subvol_read_only
+      set_root_subvol_property_read_only
+    end
+
+    # Check the product configuration (control.xml) if the root subvolume
+    # should be set to read-only.
+    #
+    def root_subvol_read_only_configured?
+      true
+    end
+
+    # Change /etc/fstab on the target to mount the root subvolume read-only.
+    #
+    def set_fstab_root_subvol_read_only
+      cmd = "sed -i -e '/ \\/ btrfs/s/defaults/ro/' /etc/fstab"
+      log.info("Setting root subvol to read-only in /etc/fstab: \"#{cmd}\"")
+      SCR.Execute(path(".target.bash"), cmd)
+    end
+
+    # Set the "read-only" property for the root subvolume.
+    # This has to be done as long as the target root filesystem is still
+    # mounted.
+    #
+    def set_root_subvol_property_read_only
+      cmd = "btrfs property set /.snapshots/1/snapshot ro true"
+      log.info("Setting root subvol read-only property: \"#{cmd}\"")
+      SCR.Execute(path(".target.bash"), cmd)
     end
   end
 end

--- a/src/lib/installation/clients/umount_finish.rb
+++ b/src/lib/installation/clients/umount_finish.rb
@@ -45,6 +45,7 @@ module Yast
       Yast.import "Internet"
       Yast.import "FileUtils"
       Yast.import "Mode"
+      Yast.import "ProductFeatures"
 
       @ret = nil
       @func = ""
@@ -390,7 +391,7 @@ module Yast
     #
     def set_root_subvol_read_only
       return unless root_subvol_read_only_configured?
-      log.info("Setting root subvolume to read-only");
+      log.info("Setting root subvolume to read-only")
       set_fstab_root_subvol_read_only
       set_root_subvol_property_read_only
     end
@@ -399,7 +400,7 @@ module Yast
     # should be set to read-only.
     #
     def root_subvol_read_only_configured?
-      true
+      ProductFeatures.GetBooleanFeature("partitioning", "root_subvolume_read_only")
     end
 
     # Change /etc/fstab on the target to mount the root subvolume read-only.

--- a/src/lib/installation/clients/umount_finish.rb
+++ b/src/lib/installation/clients/umount_finish.rb
@@ -174,7 +174,6 @@ module Yast
         # BNC #692799: Preserve the randomness state before umounting
         preserve_randomness_state
 
-
         #
         # !!! NO WRITE OPERATIONS TO THE TARGET AFTER THIS POINT !!!
         #
@@ -183,7 +182,6 @@ module Yast
         # (because the btrfs command requires that), but after the last write
         # access to it (because it will be read only afterwards).
         set_root_subvol_read_only
-
 
         @targetMap = Storage.GetTargetMap
 


### PR DESCRIPTION
https://trello.com/c/sLkMAwRU/479-3-casp-321755-microos-switch-root-subvolume-to-read-only-s

This PR is the code and XML documentation part.
PR for the XML schema and the CASP control.xml (skelcd-CASP) will follow.

Please notice the PBI called for a simple solution. This approach will fail silently if the configuration parameter is set in control.xml, but the root filesystem type is something other than Btrfs.