### PR TITLE
Enable RO proposal in case of error

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Dec 19 13:23:12 UTC 2016 - mfilka@suse.com
+
+- Made user's interaction possible in case of error in read-only
+  proposal.
+- 3.1.217.9 
+
+-------------------------------------------------------------------
 Wed Dec 14 15:47:02 UTC 2016 - jreidinger@suse.com
 
 - Change layout of new installation dialog according to UX team

--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,8 +1,9 @@
 -------------------------------------------------------------------
 Mon Dec 19 13:23:12 UTC 2016 - mfilka@suse.com
 
-- Made user's interaction possible in case of error in read-only
-  proposal.
+- fate#321739
+  - Made user's interaction possible in case of error in read-only
+    proposal.
 - 3.1.217.9 
 
 -------------------------------------------------------------------

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation
-Version:        3.1.217.8
+Version:        3.1.217.9
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/installation/proposal_runner.rb
+++ b/src/lib/installation/proposal_runner.rb
@@ -807,7 +807,7 @@ module Installation
       title = @store.title_for(submod)
 
       # do not add a link if the module is read-only or link is already included
-      heading = if @store.read_only?(submod) || title.include?("<a")
+      heading = if @store.read_only_no_recovery?(submod) || title.include?("<a")
         title
       else
         Yast::HTML.Link(title, @store.id_for(submod))

--- a/src/lib/installation/proposal_runner.rb
+++ b/src/lib/installation/proposal_runner.rb
@@ -807,7 +807,7 @@ module Installation
       title = @store.title_for(submod)
 
       # do not add a link if the module is read-only or link is already included
-      heading = if @store.read_only_no_recovery?(submod) || title.include?("<a")
+      heading = if @store.hard_read_only?(submod) || title.include?("<a")
         title
       else
         Yast::HTML.Link(title, @store.id_for(submod))

--- a/src/lib/installation/proposal_runner.rb
+++ b/src/lib/installation/proposal_runner.rb
@@ -365,6 +365,11 @@ module Installation
       workflow_sequence
     end
 
+    # Checks if given proposal map contains an error report
+    #
+    # @param [Hash] proposal map as returned by make_proposal
+    # @return [Boolean] true if the map reports an issue in proposal
+    # @see ProposalClient#make_proposal
     def proposal_failed?(proposal)
       proposal && [:blocker, :fatal, :error].include?(proposal["warning_level"])
     end

--- a/src/lib/installation/proposal_runner.rb
+++ b/src/lib/installation/proposal_runner.rb
@@ -365,6 +365,10 @@ module Installation
       workflow_sequence
     end
 
+    def proposal_failed?(proposal)
+      proposal && [:blocker, :fatal, :error].include?(proposal["warning_level"])
+    end
+
     def make_proposal(force_reset, language_changed)
       tab_to_switch = 999
       current_tab_affected = false
@@ -404,14 +408,14 @@ module Installation
       make_proposal_callback = proc do |submod, prop_map|
         submodule_nr += 1
         Yast::UI.ChangeWidget(Id("pb_ip"), :Value, submodule_nr)
-        prop = html_header(submod)
+        force_rw = proposal_failed?(prop_map) && @store.soft_read_only?(submod)
+        prop = html_header(submod, force_rw: force_rw)
 
         # check if it is needed to switch to another tab
         # because of an error
         if Yast::Builtins.haskey(@mod2tab, submod)
           log.info "Mod2Tab: '#{@mod2tab[submod]}'"
-          warn_level = prop_map["warning_level"]
-          if [:blocker, :fatal, :error].include?(warn_level)
+          if proposal_failed?(prop_map)
             # bugzilla #237291
             # always switch to more detailed tab only
             # value 999 means to keep current tab, in case of error,
@@ -803,11 +807,11 @@ module Installation
     # Get the header for the specific proposal module
     # @param submod [String] the proposal module name
     # @return [String] richtext string with the proposal header
-    def html_header(submod)
+    def html_header(submod, force_rw: false)
       title = @store.title_for(submod)
 
       # do not add a link if the module is read-only or link is already included
-      heading = if @store.hard_read_only?(submod) || title.include?("<a")
+      heading = if (!force_rw && @store.read_only?(submod)) || title.include?("<a")
         title
       else
         Yast::HTML.Link(title, @store.id_for(submod))

--- a/src/lib/installation/proposal_store.rb
+++ b/src/lib/installation/proposal_store.rb
@@ -250,6 +250,14 @@ module Installation
       title.gsub(/<a.*?>(.*?)<\/a>/, "\\1")
     end
 
+    # Checks if the client's proposal is configured as "hard" or "soft" read-only
+    #
+    # "hard" read-only means that the proposal is always read-only
+    # "soft" read-only means that the proposal is made changeable when an error
+    #
+    # @return [Boolean] true if client is "hard" or "soft" read-only
+    # @see read_only_no_recovery
+    # @see read_only_with_recovery
     def read_only?(client)
       read_only_no_recovery?(client) || read_only_with_recovery?(client)
     end

--- a/src/lib/installation/proposal_store.rb
+++ b/src/lib/installation/proposal_store.rb
@@ -250,12 +250,32 @@ module Installation
       title.gsub(/<a.*?>(.*?)<\/a>/, "\\1")
     end
 
-    # Returns the read-only flag
+    def read_only?(client)
+      read_only_no_recovery?(client) || read_only_with_recovery?(client)
+    end
+
+    # Checks if the client's proposal is configured as "hard" read-only
+    #
+    # "hard" read-only means that the proposal is always read-only
+    # "soft" read-only means that the proposal is made changeable when an error
+    # in proposal is detected.
     #
     # @param [String] client
-    # @return [String] a title provided by the description API
-    def read_only?(client)
-      read_only_proposals.include?(client)
+    # @return [Boolean] if the client is marked as "hard" read only
+    def read_only_no_recovery?(client)
+      read_only_proposals[:hard].include?(client)
+    end
+
+    # Checks if the client's proposal is configured as "soft" read-only
+    #
+    # "hard" read-only means that the proposal is always read-only
+    # "soft" read-only means that the proposal is made changeable when an error
+    # in proposal is detected.
+    #
+    # @param [String] client
+    # @return [Boolean] if the client is marked as "soft" read only
+    def read_only_with_recovery?(client)
+      read_only_proposals[:soft].include?(client)
     end
 
     # Calls client('AskUser'), to change a setting interactively (if link is the
@@ -300,13 +320,19 @@ module Installation
     def read_only_proposals
       return @read_only_proposals if @read_only_proposals
 
-      @read_only_proposals = []
+      @read_only_proposals = { hard: [], soft: [] }
 
       properties.fetch("proposal_modules", []).each do |proposal|
         next unless proposal["read_only"]
 
         name = full_module_name(proposal["name"])
-        @read_only_proposals << name
+
+        case proposal["read_only"]
+        when "hard"
+          @read_only_proposals[:hard] << name
+        when "soft"
+          @read_only_proposals[:soft] << name
+        end
       end
 
       log.info "Found read-only proposals: #{@read_only_proposals}"

--- a/src/lib/installation/proposal_store.rb
+++ b/src/lib/installation/proposal_store.rb
@@ -335,11 +335,15 @@ module Installation
 
         name = full_module_name(proposal["name"])
 
-        case proposal["read_only"]
+        ro_type = proposal["read_only"]
+
+        case ro_type
         when "hard"
           @read_only_proposals[:hard] << name
         when "soft"
           @read_only_proposals[:soft] << name
+        else
+          log.info("Uknown value for read_only node: #{ro_type}")
         end
       end
 

--- a/src/lib/installation/proposal_store.rb
+++ b/src/lib/installation/proposal_store.rb
@@ -256,10 +256,10 @@ module Installation
     # "soft" read-only means that the proposal is made changeable when an error
     #
     # @return [Boolean] true if client is "hard" or "soft" read-only
-    # @see read_only_no_recovery
-    # @see read_only_with_recovery
+    # @see soft_read_only
+    # @see hard_read_only
     def read_only?(client)
-      read_only_no_recovery?(client) || read_only_with_recovery?(client)
+      hard_read_only?(client) || soft_read_only?(client)
     end
 
     # Checks if the client's proposal is configured as "hard" read-only
@@ -270,7 +270,7 @@ module Installation
     #
     # @param [String] client
     # @return [Boolean] if the client is marked as "hard" read only
-    def read_only_no_recovery?(client)
+    def hard_read_only?(client)
       read_only_proposals[:hard].include?(client)
     end
 
@@ -282,7 +282,7 @@ module Installation
     #
     # @param [String] client
     # @return [Boolean] if the client is marked as "soft" read only
-    def read_only_with_recovery?(client)
+    def soft_read_only?(client)
       read_only_proposals[:soft].include?(client)
     end
 

--- a/src/lib/installation/proposal_store.rb
+++ b/src/lib/installation/proposal_store.rb
@@ -325,6 +325,10 @@ module Installation
       matching_client.first
     end
 
+    # Reads read-only proposals from the control file
+    #
+    # @return [Hash] map with keys :hard and :soft. Values are names
+    # of proposals with "hard" or "soft" read_only flag set.
     def read_only_proposals
       return @read_only_proposals if @read_only_proposals
 

--- a/test/proposal_runner_test.rb
+++ b/test/proposal_runner_test.rb
@@ -75,6 +75,30 @@ describe ::Installation::ProposalRunner do
       expect(subject.run).to eq :auto
     end
 
+    describe "#html_header" do
+      it "returns clickable header when forced" do
+        allow(Yast::GetInstArgs).to receive(:proposal).and_return("software")
+
+        expect_any_instance_of(::Installation::ProposalRunner)
+          .to receive(:submod_descriptions_and_build_menu)
+          .and_return(false)
+        expect_any_instance_of(::Installation::ProposalStore)
+          .to receive(:title_for)
+          .and_return("Software")
+        expect_any_instance_of(::Installation::ProposalStore)
+          .to receive(:id_for)
+          .and_return("software")
+        expect_any_instance_of(::Installation::ProposalStore)
+          .not_to receive(:read_only?)
+          .and_return(true)
+
+        # initialization of internal state
+        expect(subject.run).to eq :auto
+
+        expect(subject.send(:html_header, "software", force_rw: true)).to eql Yast::HTML.Heading(Yast::HTML.Link("Software", "software"))
+      end
+    end
+
     context "when proposal contains tabs" do
       let(:properties) do
         PROPERTIES.merge(

--- a/test/proposal_store_test.rb
+++ b/test/proposal_store_test.rb
@@ -568,24 +568,51 @@ describe ::Installation::ProposalStore do
         # Proposals need to be cached first
         subject.make_proposals
 
-        expect(subject).to receive(:read_only?).with("proposal_a").and_return(true)
         allow(Yast::Report).to receive(:Warning)
       end
 
-      it "displays a warning" do
-        expect(Yast::Report).to receive(:Warning)
+      context "in case of hard read only proposal" do
+        before do
+          expect(subject).to receive(:hard_read_only?).with("proposal_a").and_return(true)
+        end
 
-        subject.handle_link("proposal_a")
+        it "displays a warning" do
+          expect(Yast::Report).to receive(:Warning)
+
+          subject.handle_link("proposal_a")
+        end
+
+        it "does not run the proposal client" do
+          expect(Yast::WFM).to_not receive(:CallFunction)
+
+          subject.handle_link("proposal_a")
+        end
+
+        it "returns nil" do
+          expect(subject.handle_link("proposal_a")).to eq(nil)
+        end
       end
 
-      it "does not run the proposal client" do
-        expect(Yast::WFM).to_not receive(:CallFunction)
+      context "in case of soft read only proposal" do
+        before do
+          expect(subject).to receive(:soft_read_only?).with("proposal_a").and_return(true)
+        end
 
-        subject.handle_link("proposal_a")
-      end
+        it "displays a warning" do
+          expect(Yast::Report).to receive(:Warning)
 
-      it "returns nil" do
-        expect(subject.handle_link("proposal_a")).to eq(nil)
+          subject.handle_link("proposal_a")
+        end
+
+        it "does not run the proposal client" do
+          expect(Yast::WFM).to_not receive(:CallFunction)
+
+          subject.handle_link("proposal_a")
+        end
+
+        it "returns nil" do
+          expect(subject.handle_link("proposal_a")).to eq(nil)
+        end
       end
     end
   end


### PR DESCRIPTION
https://trello.com/c/sEVjWKcJ/780-3-casp-read-only-software-selection

Proposals in control file currently have format:
```
<proposal_module>
  <name>software</name>
  <read_only config:type="boolean">true</read_only>
</proposal_module>
```
this PR changes this to
```
<proposal_module>
  <name>software</name>
  <!-- soft means that proposal becomes active when an error happens,
         hard means that proposal is always RO -->
  <read_only>soft</read_only>
</proposal_module>
```
