### PR TITLE
Disable self update via AutoYaST profile

### DIFF
--- a/doc/SELF_UPDATE.md
+++ b/doc/SELF_UPDATE.md
@@ -9,14 +9,17 @@ installation even after the media has been released. Check
 
 Starting in SUSE Linux Enterprise 12 SP3, self-update is enabled by default.
 However, it can be disabled by setting `self_update=0` boot option. If you're
-using AutoYaST, is also possible to disable this feature using the `self_update`
-element in `general` section of the profile:
+using AutoYaST, it is also possible to disable this feature using the
+`self_update` element in the `general` section of the profile:
 
    ```xml
    <general>
      <self_update config:type="boolean">false</self_update>
    </general>
    ```
+
+Please, take into account that self-update will be disabled if any of those
+values is set.
 
 During the rest of this document it is assumed that self-update is enabled.
 

--- a/doc/SELF_UPDATE.md
+++ b/doc/SELF_UPDATE.md
@@ -7,9 +7,18 @@ installation even after the media has been released. Check
 
 ## Disabling Updates
 
-Self-update is enabled by default. However, it can be disabled by setting
-`self_update=0` boot option. In the following sections it is assumed that this
-feature is enabled.
+Starting in SUSE Linux Enterprise 12 SP3, self-update is enabled by default.
+However, it can be disabled by setting `self_update=0` boot option. If you're
+using AutoYaST, is also possible to disable this feature using the `self_update`
+element in `general` section of the profile:
+
+   ```xml
+   <general>
+     <self_update config:type="boolean">false</self_update>
+   </general>
+   ```
+
+During the rest of this document it is assumed that self-update is enabled.
 
 ## Basic Workflow
 

--- a/doc/SELF_UPDATE.md
+++ b/doc/SELF_UPDATE.md
@@ -18,8 +18,8 @@ using AutoYaST, it is also possible to disable this feature using the
    </general>
    ```
 
-Please, take into account that self-update will be disabled if any of those
-values is set.
+Please, take into account that self-update will be skipped if any option
+disables it (boot parameter *or* AutoYaST profile).
 
 During the rest of this document it is assumed that self-update is enabled.
 

--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -2,7 +2,7 @@
 Wed Jan 25 10:41:33 UTC 2017 - igonzalezsosa@suse.com
 
 - Add an option to disable the self-update feature through the
-  AutoYaST profile
+  AutoYaST profile (FATE#319716)
 - 3.2.17
 
 -------------------------------------------------------------------

--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Jan 25 10:41:33 UTC 2017 - igonzalezsosa@suse.com
+
+- Add an option to disable the self-update feature through the
+  AutoYaST profile
+- 3.2.17
+
+-------------------------------------------------------------------
 Fri Jan 20 08:44:28 UTC 2017 - mfilka@suse.com
 
 - bnc#1017752

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation
-Version:        3.2.16
+Version:        3.2.17
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/installation/clients/inst_update_installer.rb
+++ b/src/lib/installation/clients/inst_update_installer.rb
@@ -148,12 +148,10 @@ module Yast
       Linuxrc.InstallInf("SelfUpdate") == "0"
     end
 
-    # Determines whether self-update feature is disable via AutoYaST profile
+    # Determines whether self-update feature is disabled via AutoYaST profile
     #
     # @return [Boolean] true if self update has been disabled by AutoYaST profile
     def disabled_in_profile?
-      return false unless Mode.auto
-
       profile = Yast::Profile.current
       !profile.fetch("general", {}).fetch("self_update", true)
     end

--- a/src/lib/installation/clients/inst_update_installer.rb
+++ b/src/lib/installation/clients/inst_update_installer.rb
@@ -63,13 +63,12 @@ module Yast
         return :next
       end
 
-      initialize_progress
-
       if Mode.auto
         process_profile
-        Yast::Progress.NextStage
+        return :next if disabled_in_profile?
       end
 
+      initialize_progress
       initialize_packager
 
       # self-update not possible, the repo URL is not defined
@@ -134,8 +133,8 @@ module Yast
     #
     # @return [Boolean] True if it's enabled; false otherwise.
     def self_update_enabled?
-      if disabled_in_linuxrc? || disabled_in_profile?
-        log.info("self-update was disabled by the user")
+      if disabled_in_linuxrc?
+        log.info("self-update was disabled through Linuxrc")
         false
       else
         !self_update_urls.empty?
@@ -591,8 +590,6 @@ module Yast
         _("Apply the Packages"),
         _("Restart")
       ]
-
-      stages.unshift(_("Fetching AutoYast Profile")) if Mode.auto
 
       # open a new wizard dialog with title on the top
       # (the default dialog with title on the left looks ugly with the

--- a/src/lib/installation/clients/inst_update_installer.rb
+++ b/src/lib/installation/clients/inst_update_installer.rb
@@ -134,8 +134,8 @@ module Yast
     #
     # @return [Boolean] True if it's enabled; false otherwise.
     def self_update_enabled?
-      if disabled_in_linuxrc?
-        log.info("self-update was disabled through Linuxrc")
+      if disabled_in_linuxrc? || disabled_in_profile?
+        log.info("self-update was disabled by the user")
         false
       else
         !self_update_urls.empty?
@@ -147,6 +147,16 @@ module Yast
     #   boot option
     def disabled_in_linuxrc?
       Linuxrc.InstallInf("SelfUpdate") == "0"
+    end
+
+    # Determines whether self-update feature is disable via AutoYaST profile
+    #
+    # @return [Boolean] true if self update has been disabled by AutoYaST profile
+    def disabled_in_profile?
+      return false unless Mode.auto
+
+      profile = Yast::Profile.current
+      !profile.fetch("general", {}).fetch("self_update", true)
     end
 
     # Return the self-update URLs

--- a/test/inst_update_installer_test.rb
+++ b/test/inst_update_installer_test.rb
@@ -484,6 +484,15 @@ describe Yast::InstUpdateInstaller do
               end
             end
           end
+
+          context "when update is disabled through the profile" do
+            let(:profile) { { "general" => { "self_update" => false } } }
+
+            it "does not update the installer" do
+              expect(subject).to_not receive(:update_installer)
+              expect(subject.main).to eq(:next)
+            end
+          end
         end
       end
 


### PR DESCRIPTION
Using the following snippet allows to disable the self-update using an AutoYaST profile:

```xml
<general>
  <self_update config:type="boolean">false</self_update>
</general>
```

I'm also removing the step `Fetching AutoYaST Profile`. Why? Because I think that we should show the same UI if you disable the self-update via Linuxrc (no progress is shown) or via a profile. It can be confusing to see the `Updating Installer` screen (although for 1 sec) if you explicitly has disabled it.