### PR TITLE
CaaSP: Display the Beta product warning at start (bsc#1016887)

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Feb  8 11:57:14 UTC 2017 - lslezak@suse.cz
+
+- CaaSP: Display the Beta product warning at start when it is
+  present (bsc#1016887)
+- 3.1.217.19
+
+-------------------------------------------------------------------
 Wed Feb  1 14:20:43 UTC 2017 - jreidinger@suse.com
 
 - Enable CaaSP specific services on the installed system

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation
-Version:        3.1.217.18
+Version:        3.1.217.19
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/installation/clients/inst_casp_overview.rb
+++ b/src/lib/installation/clients/inst_casp_overview.rb
@@ -48,6 +48,7 @@ module Installation
       Yast.import "CWM"
       Yast.import "Popup"
       Yast.import "Pkg"
+      Yast.import "InstShowInfo"
 
       textdomain "installation"
 
@@ -58,6 +59,9 @@ module Installation
       # We do not need to create a wizard dialog in installation, but it's
       # helpful when testing all manually on a running system
       Yast::Wizard.CreateDialog if separate_wizard_needed?
+
+      # show the Beta warning if it exists
+      Yast::InstShowInfo.show_info_txt(INFO_FILE) if File.exist?(INFO_FILE)
 
       ret = nil
       loop do
@@ -101,6 +105,9 @@ module Installation
     end
 
   private
+
+    # location of the info.txt file (containing the Beta warning)
+    INFO_FILE = "/info.txt".freeze
 
     # Specific services that needs to be enabled on CAaSP see (FATE#321738)
     # It is additional services to the ones defined for role.

--- a/test/inst_casp_overview_test.rb
+++ b/test/inst_casp_overview_test.rb
@@ -69,6 +69,8 @@ describe ::Installation::InstCaspOverview do
       allow(Yast::WFM).to receive(:CallFunction).and_return({})
       allow(Yast::WFM).to receive(:CallFunction)
         .with("inst_doit", []).and_return(:next)
+      allow(File).to receive(:exist?).and_call_original
+      allow(File).to receive(:exist?).with("/info.txt").and_return(false)
     end
 
     it "sets package locale same as Language" do
@@ -113,6 +115,22 @@ describe ::Installation::InstCaspOverview do
       subject.run
 
       expect(::Installation::Services.enabled).to include("cloud-init")
+    end
+
+    it "displays the /info.txt file if it exists" do
+      expect(File).to receive(:exist?).with("/info.txt").and_return(true)
+      expect(Yast::InstShowInfo).to receive(:show_info_txt).with("/info.txt").and_return(true)
+      expect(Yast::CWM).to receive(:show).and_return(:next)
+
+      subject.run
+    end
+
+    it "does not try displaying the /info.txt file if it does not exist" do
+      expect(File).to receive(:exist?).with("/info.txt").and_return(false)
+      expect(Yast::InstShowInfo).to_not receive(:show_info_txt)
+      expect(Yast::CWM).to receive(:show).and_return(:next)
+
+      subject.run
     end
   end
 end


### PR DESCRIPTION
...when it is present

- Reuses the existing code, no change needed
- Unit tests included
- Tested manually (see the screenshots below)

## Screenshots

![casp_beta_qt](https://cloud.githubusercontent.com/assets/907998/22739011/16049c0e-ee0a-11e6-99ae-3e0a1958eaf6.png)

![casp_beta_ncurses](https://cloud.githubusercontent.com/assets/907998/22739025/24213572-ee0a-11e6-8068-dc758719759c.png)
