### PR TITLE
Self-update refactoring

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Feb 14 14:55:08 UTC 2017 - igonzalezsosa@suse.com
+
+- Self-Update only shows errors when a custom URL is used
+  (bsc#1025251)
+- 3.2.22
+
+-------------------------------------------------------------------
 Wed Feb  8 16:42:29 UTC 2017 - kanderssen@suse.com
 
 - CaaSP all-in-one-dialog: added validation to the controller node

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -107,8 +107,8 @@ Conflicts:	yast2-core < 2.17.10
 # Top bar with logo
 Conflicts:	yast2-ycp-ui-bindings < 3.1.7
 
-# new registration widget
-Conflicts:  yast2-registration <= 3.2.1
+# Registration#get_updates_list does not handle exceptions
+Conflicts:  yast2-registration < 3.2.3
 
 Obsoletes:	yast2-installation-devel-doc
 

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation
-Version:        3.2.21
+Version:        3.2.22
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/installation/clients/inst_update_installer.rb
+++ b/src/lib/installation/clients/inst_update_installer.rb
@@ -231,7 +231,7 @@ module Yast
 
     rescue ::Installation::UpdatesManager::CouldNotFetchUpdateFromRepo
       if repo.user_defined?
-      # TRANSLATORS: %s is an URL
+        # TRANSLATORS: %s is an URL
         Report.Error(format(_("Could not fetch update from\n%s.\n\n"), repo.uri))
       end
       false

--- a/src/lib/installation/clients/inst_update_installer.rb
+++ b/src/lib/installation/clients/inst_update_installer.rb
@@ -24,7 +24,6 @@ module Yast
     include Yast::I18n
 
     UPDATED_FLAG_FILENAME = "installer_updated".freeze
-    REMOTE_SCHEMES = ["http", "https", "ftp", "tftp", "sftp", "nfs", "nfs4", "cifs", "smb"].freeze
     PROFILE_FORBIDDEN_SCHEMES = ["label"].freeze
     REGISTRATION_DATA_PATH = "/var/lib/YaST2/inst_update_installer.yaml".freeze
 
@@ -106,7 +105,7 @@ module Yast
     # * Could not fetch update from repository: report the user about
     #   this error.
     # * Repository could not be probed: suggest checking network
-    #   configuration if URL has a REMOTE_SCHEME.
+    #   configuration if URL is remote.
     #
     # @return [Boolean] true if installer was updated; false otherwise.
     def update_installer
@@ -239,19 +238,10 @@ module Yast
       msg = could_not_probe_repo_msg(repo.uri)
       if Mode.auto
         Report.Warning(msg)
-      elsif remote_url?(repo.uri) && configure_network?(msg)
-        # TODO: repo#remote?
+      elsif repo.remote? && configure_network?(msg)
         retry
       end
       false
-    end
-
-    # Determine whether the URL is remote
-    #
-    # @param url [URI] URL to check
-    # @return [Boolean] true if it's considered remote; false otherwise.
-    def remote_url?(url)
-      REMOTE_SCHEMES.include?(url.scheme)
     end
 
     # Launch the network configuration client on users' demand

--- a/src/lib/installation/clients/inst_update_installer.rb
+++ b/src/lib/installation/clients/inst_update_installer.rb
@@ -216,7 +216,7 @@ module Yast
 
     # Add a repository to the updates manager
     #
-    # @param repository [UpdateRepository] Update repository to add
+    # @param repo [UpdateRepository] Update repository to add
     # @return [Boolean] true if the repository was added; false otherwise.
     def add_repository(repo)
       log.info("Adding update from #{repo.inspect}")
@@ -230,11 +230,14 @@ module Yast
       false
 
     rescue ::Installation::UpdatesManager::CouldNotFetchUpdateFromRepo
+      if repo.user_defined?
       # TRANSLATORS: %s is an URL
-      Report.Error(format(_("Could not fetch update from\n%s.\n\n"), repo.uri))
+        Report.Error(format(_("Could not fetch update from\n%s.\n\n"), repo.uri))
+      end
       false
 
     rescue ::Installation::UpdatesManager::CouldNotProbeRepo
+      return false unless repo.user_defined?
       msg = could_not_probe_repo_msg(repo.uri)
       if Mode.auto
         Report.Warning(msg)

--- a/src/lib/installation/update_repositories_finder.rb
+++ b/src/lib/installation/update_repositories_finder.rb
@@ -1,0 +1,270 @@
+# encoding: utf-8
+
+# ------------------------------------------------------------------------------
+# Copyright (c) 2017 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of version 2 of the GNU General Public License as published by the
+# Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# ------------------------------------------------------------------------------
+
+require "yast"
+require "installation/update_repository"
+require "uri"
+
+Yast.import "Pkg"
+Yast.import "Packages"
+Yast.import "PackageCallbacks"
+Yast.import "InstURL"
+Yast.import "Linuxrc"
+Yast.import "Mode"
+Yast.import "Profile"
+Yast.import "ProductFeatures"
+Yast.import "Report"
+
+module Installation
+  # This class find repositories to be used by the self-update feature.
+  class UpdateRepositoriesFinder
+    include Yast::Logger
+    include Yast::I18n
+
+    # Return the update source
+    def updates
+      return @updates if @updates
+
+      @updates = Array(custom_update)
+      return @updates unless @updates.empty?
+      default_updates
+    end
+
+    private
+
+    # Return the self-update repository if defined by the user
+    #
+    # It tries to find an URL in Linuxrc boot parameters and
+    # AutoYaST profile.
+    #
+    # @return [UpdateRepository] self-update repository
+    #
+    # @see update_url_from_linuxrc
+    # @see update_url_from_profile
+    def custom_update
+      url = update_url_from_linuxrc || update_url_from_profile
+      url ? UpdateRepository.new(url, :user) : nil
+    end
+
+    def default_updates
+      urls = default_urls
+      urls.map { |u| UpdateRepository.new(u, :default) }
+    end
+
+    # Return the default self-update URLs
+    #
+    # A default URL can be specified via SCC/SMT servers or in the control.xml file.
+    #
+    # @return [Array<URI>] self-update URLs
+    def default_urls
+      # load the base product from the installation medium,
+      # the registration server needs it for evaluating the self update URL
+      # TODO: not needed in opensuse (should we move it to update_urls_from_connect)
+      add_installation_repo
+      urls = update_urls_from_connect
+      return urls unless urls.empty?
+      [update_url_from_control].compact
+    end
+
+    # Return the self-update URL according to Linuxrc
+    #
+    # @return [URI,nil] self-update URL. nil if no URL was set in Linuxrc.
+    def update_url_from_linuxrc
+      get_url_from(Yast::Linuxrc.InstallInf("SelfUpdate"))
+    end
+
+    # Return the self-update URL from the AutoYaST profile
+    #
+    # @return [URI,nil] the self-update URL, nil if not running in AutoYaST mode
+    #   or when the URL is not defined in the profile
+    def update_url_from_profile
+      return nil unless Yast::Mode.auto
+
+      profile = Yast::Profile.current
+      profile_url = profile.fetch("general", {})["self_update_url"]
+
+      get_url_from(profile_url)
+    end
+
+    # Return the self-update URL according to product's control file
+    #
+    # @return [URI,nil] self-update URL. nil if no URL was set in control file.
+    def update_url_from_control
+      get_url_from(Yast::ProductFeatures.GetStringFeature("globals", "self_update_url"))
+    end
+
+    # Return the self-update URLs from SCC/SMT server
+    #
+    # Return an empty array if yast2-registration or SUSEConnect are not
+    # available (for instance in openSUSE). More than 1 URLs can be found.
+    #
+    # As a side effect, it stores the URL of the registration server used
+    # in the installation options.
+    #
+    # @return [Array<URI>] self-update URLs.
+    def update_urls_from_connect
+      return [] unless defined?(::Registration::UrlHelpers)
+      url = registration_url
+      return [] if url == :cancel
+
+      log.info("Using registration URL: #{url}")
+      import_registration_ayconfig if Yast::Mode.auto
+      registration = Registration::Registration.new(url == :scc ? nil : url.to_s)
+      # Set custom_url into installation options
+      Registration::Storage::InstallationOptions.instance.custom_url = registration.url
+      ret = registration.get_updates_list.map { |u| URI(u.url) }
+
+      # avoid unless using a custom registration server
+      display_fallback_warning if ret.empty?
+
+      ret
+    end
+
+
+    # Converts the string into an URI if it's valid
+    #
+    # It substitutes $arch pattern with the architecture of the current system.
+    #
+    # @return [URI,nil] The string converted into a URL; nil if it's
+    #                   not a valid URL.
+    #
+    # @see URI.regexp
+    def get_url_from(url)
+      return nil unless url.is_a?(::String)
+      real_url = url.gsub(/\$arch\b/, Yast::Pkg.GetArchitecture)
+      URI.regexp.match(real_url) ? URI(real_url) : nil
+    end
+
+    def add_installation_repo
+      base_url = Yast::InstURL.installInf2Url("")
+      initial_repository = Yast::Pkg.SourceCreateBase(base_url, "")
+
+      until initial_repository
+        log.error "Adding the installation repository failed"
+        # ask user to retry
+        base_url = Packages.UpdateSourceURL(base_url)
+
+        # aborted by user
+        return false if base_url == ""
+
+        initial_repository = Yast::Pkg.SourceCreateBase(base_url, "")
+      end
+    end
+
+    # Return the URL of the preferred registration server
+    #
+    # Determined in the following order:
+    #
+    # * "regurl" boot parameter
+    # * From AutoYaST profile
+    # * SLP look up
+    #   * In AutoYaST mode the SLP needs to be explicitly enabled in the profile,
+    #     if the scan finds *exactly* one SLP service then it is used. If more
+    #     than one service is found then an interactive popup is displayed.
+    #     (This breaks the AY unattended concept but basically more services
+    #     is treated as an error, AytoYaST cannot know which one to use.)
+    #   * In non-AutoYaST mode it will ask the user to choose the found SLP
+    #     servise or the SCC default.
+    #  * Fallbacks to SCC if no SLP service is found.
+    #
+    # @return [URI,:scc,:cancel] Registration URL; :scc if SCC server was selected;
+    #                            :cancel if dialog was dismissed.
+    #
+    # @see #registration_service_from_user
+    def registration_url
+      url = ::Registration::UrlHelpers.boot_reg_url || registration_url_from_profile
+      return URI(url) if url
+
+      # do the SLP scan in AutoYast mode only when allowed in the profile
+      return :scc if Yast::Mode.auto && registration_profile["slp_discovery"] != true
+
+      services = ::Registration::UrlHelpers.slp_discovery
+      log.info "SLP discovery result: #{services.inspect}"
+      return :scc if services.empty?
+
+      service =
+        if Yast::Mode.auto && services.size == 1
+          services.first
+        else
+          registration_service_from_user(services)
+        end
+
+      log.info "Selected SLP service: #{service.inspect}"
+
+      return service unless service.respond_to?(:slp_url)
+      URI(::Registration::UrlHelpers.service_url(service.slp_url))
+    end
+
+    # Return the registration server URL from the AutoYaST profile
+    #
+    # @return [URI,nil] the self-update URL, nil if not running in AutoYaST mode
+    #   or when the URL is not defined in the profile
+    def registration_url_from_profile
+      return nil unless Yast::Mode.auto
+
+      get_url_from(registration_profile["reg_server"])
+    end
+
+    # return the registration settings from the loaded AutoYaST profile
+    # @return [Hash] the current settings, returns empty Hash if the
+    #   registration section is missing in the profile
+    def registration_profile
+      profile = Yast::Profile.current
+      profile.fetch("suse_register", {})
+    end
+
+    # Ask the user to chose a registration server
+    #
+    # @param services [Array<SlpServiceClass::Service>] Array of registration servers
+    # @return [SlpServiceClass::Service,Symbol] Registration service to use; :scc if SCC is selected;
+    #                                           :cancel if the dialog was dismissed.
+    def registration_service_from_user(services)
+      ::Registration::UI::RegserviceSelectionDialog.run(
+        services:    services,
+        description: _("Select a detected registration server from the list\n" \
+          "to search for installer updates.")
+      )
+    end
+
+    # Load registration configuration from AutoYaST profile
+    #
+    # This data will be used by Registration::ConnectHelpers.catch_registration_errors.
+    #
+    # @see Yast::Profile.current
+    def import_registration_ayconfig
+      ::Registration::Storage::Config.instance.import(
+        Yast::Profile.current.fetch("suse_register", {})
+      )
+    end
+
+    # Display a warning message about using the default update URL from
+    # control.xml when the registration server does not return any URL or fails.
+    # In AutoYaST mode the dialog is closed after a timeout.
+    def display_fallback_warning
+      # TRANSLATORS: error message
+      msg = _("<p>Cannot obtain the installer update repository URL\n" \
+        "from the registration server.</p>")
+
+      if update_url_from_control
+        # TRANSLATORS: part of an error message, %s is the default repository
+        # URL from control.xml
+        msg += _("<p>The default URL %s will be used.<p>") % update_url_from_control
+      end
+
+      # display the message in a RichText widget to wrap long lines
+      Yast::Report.LongWarning(msg)
+    end
+  end
+end

--- a/src/lib/installation/update_repositories_finder.rb
+++ b/src/lib/installation/update_repositories_finder.rb
@@ -37,9 +37,13 @@ module Installation
     def updates
       return @updates if @updates
 
-      @updates = Array(custom_update)
+      @updates = Array(custom_update) # Custom URL
       return @updates unless @updates.empty?
-      default_updates
+
+      @updates = updates_from_connect
+      return @updates unless @updates.empty?
+
+      @updates = Array(update_from_control)
     end
 
     private
@@ -49,33 +53,33 @@ module Installation
     # It tries to find an URL in Linuxrc boot parameters and
     # AutoYaST profile.
     #
-    # @return [UpdateRepository] self-update repository
+    # @return [UpdateRepository,nil] self-update repository or nil if not defined
     #
     # @see update_url_from_linuxrc
     # @see update_url_from_profile
     def custom_update
       url = update_url_from_linuxrc || update_url_from_profile
-      url ? UpdateRepository.new(url, :user) : nil
+      url && UpdateRepository.new(url, :user)
     end
 
-    def default_updates
-      urls = default_urls
-      urls.map { |u| UpdateRepository.new(u, :default) }
+    # Return the self-update repository defined in the control file
+    #
+    # @return [UpdateRepository,nil] self-update repository or nil if not defined
+    def update_from_control
+      url = update_url_from_control
+      url && UpdateRepository.new(url, :default)
     end
 
-    # Return the default self-update URLs
+    # Return the self-update repository defined in the registration server
     #
-    # A default URL can be specified via SCC/SMT servers or in the control.xml file.
-    #
-    # @return [Array<URI>] self-update URLs
-    def default_urls
+    # @return [Array<UpdateRepository>] self-update repositories
+    def updates_from_connect
+      return [] unless defined?(::Registration::UrlHelpers)
       # load the base product from the installation medium,
       # the registration server needs it for evaluating the self update URL
-      # TODO: not needed in opensuse (should we move it to update_urls_from_connect)
       add_installation_repo
       urls = update_urls_from_connect
-      return urls unless urls.empty?
-      [update_url_from_control].compact
+      urls ? urls.map { |u| UpdateRepository.new(u, :default) } : []
     end
 
     # Return the self-update URL according to Linuxrc
@@ -113,23 +117,21 @@ module Installation
     # As a side effect, it stores the URL of the registration server used
     # in the installation options.
     #
-    # @return [Array<URI>] self-update URLs.
+    # @return [Array<URI>,false] self-update URLs or false in case of error
     def update_urls_from_connect
-      return [] unless defined?(::Registration::UrlHelpers)
       url = registration_url
       return [] if url == :cancel
 
+      custom_regserver = url != :scc
       log.info("Using registration URL: #{url}")
       import_registration_ayconfig if Yast::Mode.auto
-      registration = Registration::Registration.new(url == :scc ? nil : url.to_s)
+      registration = Registration::Registration.new(custom_regserver ? url.to_s : nil)
       # Set custom_url into installation options
       Registration::Storage::InstallationOptions.instance.custom_url = registration.url
-      ret = registration.get_updates_list.map { |u| URI(u.url) }
 
-      # avoid unless using a custom registration server
-      display_fallback_warning if ret.empty?
-
-      ret
+      handle_registration_errors(custom_regserver) do
+        registration.get_updates_list.map { |u| URI(u.url) }
+      end
     end
 
     # Converts the string into an URI if it's valid
@@ -146,6 +148,7 @@ module Installation
       URI.regexp.match(real_url) ? URI(real_url) : nil
     end
 
+    # Loads the base product from the installation medium
     def add_installation_repo
       base_url = Yast::InstURL.installInf2Url("")
       initial_repository = Yast::Pkg.SourceCreateBase(base_url, "")
@@ -264,6 +267,35 @@ module Installation
 
       # display the message in a RichText widget to wrap long lines
       Yast::Report.LongWarning(msg)
+    end
+
+    # Runs a block of code handling errors
+    #
+    # If errors should be shown, the helper {catch_registration_errors}
+    # from Registration::ConnectHelpers will be used.
+    #
+    # Otherwise, errors will be logged and the method will return +false+.
+    #
+    # @param [Boolean] show_errors True if errors should be shown to the user. False otherwise.
+    # @return [false, Object] The value returned by the block itself. False
+    #                         if the block failed.
+    #
+    # @see Registration::ConnectHelpers.catch_registration_errors
+    def handle_registration_errors(show_errors)
+      if show_errors
+        require "registration/connect_helpers"
+        ret = nil
+        success = ::Registration::ConnectHelpers.catch_registration_errors { ret = yield }
+        success && ret
+      else
+        begin
+          yield
+        rescue StandardError => e
+          log.warn("Could not determine update repositories through the registration server: " \
+            "#{e.class}: #{e}, #{e.backtrace}")
+          false
+        end
+      end
     end
   end
 end

--- a/src/lib/installation/update_repositories_finder.rb
+++ b/src/lib/installation/update_repositories_finder.rb
@@ -51,7 +51,7 @@ module Installation
       @updates = Array(update_from_control)
     end
 
-    private
+  private
 
     # Return the self-update repository if defined by the user
     #

--- a/src/lib/installation/update_repositories_finder.rb
+++ b/src/lib/installation/update_repositories_finder.rb
@@ -132,7 +132,6 @@ module Installation
       ret
     end
 
-
     # Converts the string into an URI if it's valid
     #
     # It substitutes $arch pattern with the architecture of the current system.

--- a/src/lib/installation/update_repositories_finder.rb
+++ b/src/lib/installation/update_repositories_finder.rb
@@ -33,6 +33,11 @@ module Installation
     include Yast::Logger
     include Yast::I18n
 
+    # Constructor
+    def initialize
+      textdomain "installation"
+    end
+
     # Return the update source
     def updates
       return @updates if @updates

--- a/src/lib/installation/update_repository.rb
+++ b/src/lib/installation/update_repository.rb
@@ -49,10 +49,9 @@ module Installation
     #
     # * :default: Default
     # * :user:    User defined
-    ORIGINS = [:default, :user]
+    ORIGINS = [:default, :user].freeze
     # Path to instsys.parts registry
     INSTSYS_PARTS_PATH = Pathname("/etc/instsys.parts")
-
 
     # @return [URI] URI of the repository
     attr_reader :uri

--- a/src/lib/installation/update_repository.rb
+++ b/src/lib/installation/update_repository.rb
@@ -124,7 +124,8 @@ module Installation
 
     # @return [Fixnum] yast2-pkg-bindings ID of the repository
     def repo_id
-      @repo_id ||= add_repo
+      return @repo_id unless @repo_id.nil?
+      add_repo
     end
 
     # Retrieves the list of packages to install
@@ -137,6 +138,7 @@ module Installation
     # @see Yast::Pkg.ResolvableProperties
     def packages
       return @packages unless @packages.nil?
+      add_repo if repo_id.nil?
       candidates = Yast::Pkg.ResolvableProperties("", :package, "")
       @packages = candidates.select { |p| p["source"] == repo_id }.sort_by! { |a| a["name"] }
       log.info "Considering #{@packages.size} packages: #{@packages}"

--- a/src/lib/installation/update_repository.rb
+++ b/src/lib/installation/update_repository.rb
@@ -245,6 +245,16 @@ module Installation
       origin == :user
     end
 
+    # Determines whether the URI of the repository is remote or not
+    #
+    # @return [Boolean] true if the repository is using a 'remote URI';
+    #                   false otherwise.
+    #
+    # @see Pkg.UrlSchemeIsRemote
+    def remote?
+      Yast::Pkg.UrlSchemeIsRemote(uri.scheme)
+    end
+
   private
 
     # Fetch and build a squashfs filesytem for a given package

--- a/src/lib/installation/update_repository.rb
+++ b/src/lib/installation/update_repository.rb
@@ -47,7 +47,7 @@ module Installation
     # * :user:    User defined
     ORIGINS = [:default, :user]
     # Path to instsys.parts registry
-    INSTSYS_PARTS_PATH = Pathname("/etc/instsys.parts").freeze
+    INSTSYS_PARTS_PATH = Pathname("/etc/instsys.parts")
 
 
     # @return [URI] URI of the repository

--- a/src/lib/installation/update_repository.rb
+++ b/src/lib/installation/update_repository.rb
@@ -269,8 +269,7 @@ module Installation
     #
     # @return [String] Debugging information
     def inspect
-      safe_url = Yast::URL.HidePassword(uri.to_s)
-      "#<Installation::UpdateRepository> @uri=\"#{safe_url}\" @origin=#{@origin.inspect}"
+      "#<Installation::UpdateRepository> @uri=\"#{safe_uri}\" @origin=#{@origin.inspect}"
     end
 
   private
@@ -458,6 +457,15 @@ module Installation
     # @param [Fixnum] percent the current progress in range 0..100
     def update_progress(percent)
       Yast::Progress.Step(percent)
+    end
+
+    # Returns the URI removing sensitive information
+    #
+    # @return [String] URI without the password (if present)
+    #
+    # @see Yast::URL.HidePassword
+    def safe_uri
+      @safe_uri ||= Yast::URL.HidePassword(uri.to_s)
     end
   end
 end

--- a/src/lib/installation/update_repository.rb
+++ b/src/lib/installation/update_repository.rb
@@ -46,11 +46,12 @@ module Installation
     # * :default: Default
     # * :user:    User defined
     ORIGINS = [:default, :user]
+    # Path to instsys.parts registry
+    INSTSYS_PARTS_PATH = Pathname("/etc/instsys.parts").freeze
+
 
     # @return [URI] URI of the repository
     attr_reader :uri
-    # @return [Pathname] Registry of inst-sys updated parts
-    attr_reader :instsys_parts_path
     # @return [Array<Pathname>] local paths of updates fetched from the repo
     attr_reader :update_files
     # @return [Symbol] Repository origin. @see ORIGINS
@@ -104,11 +105,7 @@ module Installation
     #
     # @param uri                [URI]      Repository URI
     # @param origin             [Symbol]   Repository origin (@see ORIGINS)
-    # @param instsys_parts_path [Pathname] Path to instsys.parts registry
-    # TODO: instsys_parts_path should not be a constructor's parameter.
-    #       It should be passed directly to the apply method with a default
-    #       value defined as a constant.
-    def initialize(uri, origin = :default, instsys_parts_path = Pathname("/etc/instsys.parts"))
+    def initialize(uri, origin = :default)
       Yast.import "Pkg"
       Yast.import "Progress"
 
@@ -117,7 +114,6 @@ module Installation
       @uri = uri
       @update_files = []
       @packages = nil
-      @instsys_parts_path = instsys_parts_path
       raise UnknownOrigin unless ORIGINS.include?(origin)
       @origin = origin
     end
@@ -413,9 +409,9 @@ module Installation
     # @param path       [Pathname] Filesystem to mount
     # @param mountpoint [Pathname] Mountpoint
     #
-    # @see instsys_parts_path
+    # @see INSTSYS_PARTS_PATH
     def update_instsys_parts(path, mountpoint)
-      instsys_parts_path.open("a") do |f|
+      INSTSYS_PARTS_PATH.open("a") do |f|
         f.puts "#{path.relative_path_from(Pathname("/"))} #{mountpoint}"
       end
     end

--- a/test/inst_update_installer_test.rb
+++ b/test/inst_update_installer_test.rb
@@ -1,20 +1,11 @@
 #!/usr/bin/env rspec
 
 require_relative "test_helper"
+require_relative "./support/fake_registration"
 require "installation/clients/inst_update_installer"
 require "singleton"
 
 describe Yast::InstUpdateInstaller do
-  # Registration::Storage::InstallationOptions fake
-  class FakeInstallationOptions
-    include Singleton
-    attr_accessor :custom_url
-  end
-
-  class FakeRegConfig
-    include Singleton
-    def import(_args); end
-  end
 
   Yast.import "Linuxrc"
   Yast.import "ProductFeatures"
@@ -37,27 +28,27 @@ describe Yast::InstUpdateInstaller do
   let(:ay_profile) { double("Yast::Profile", current: profile) }
   let(:ay_profile_location) { double("Yast::ProfileLocation") }
   let(:finder) { ::Installation::UpdateRepositoriesFinder.new }
+  let(:update) { double("update", uri: URI(real_url)) }
+  let(:updates) { [update] }
 
   before do
     allow(::Installation::UpdateRepositoriesFinder).to receive(:new).and_return(finder)
     allow(Yast::GetInstArgs).to receive(:going_back).and_return(false)
-    allow(Yast::Pkg).to receive(:GetArchitecture).and_return(arch)
-    allow(Yast::Mode).to receive(:auto).and_return(false)
     allow(Yast::NetworkService).to receive(:isNetworkRunning).and_return(network_running)
     allow(::Installation::UpdatesManager).to receive(:new).and_return(manager)
     allow(Yast::Installation).to receive(:restarting?).and_return(restarting)
-    allow(Yast::Installation).to receive(:finish_restarting!)
     allow(Yast::Installation).to receive(:restart!) { :restart_yast }
+    allow(finder).to receive(:updates).and_return(updates)
     allow(subject).to receive(:require).with("registration/url_helpers").and_raise(LoadError)
-    allow(::FileUtils).to receive(:touch)
     stub_const("Registration::Storage::InstallationOptions", FakeInstallationOptions)
     stub_const("Registration::Storage::Config", FakeRegConfig)
+
     # skip the libzypp initialization globally, enable in the specific tests
     allow(subject).to receive(:initialize_packager).and_return(true)
     allow(subject).to receive(:finish_packager)
-    allow(finder).to receive(:add_installation_repo)
     allow(subject).to receive(:fetch_profile).and_return(ay_profile)
     allow(subject).to receive(:process_profile)
+    allow(finder).to receive(:add_installation_repo)
 
     # stub the Profile module to avoid dependency on autoyast2-installation
     stub_const("Yast::Profile", ay_profile)
@@ -114,7 +105,7 @@ describe Yast::InstUpdateInstaller do
       subject.main
     end
 
-    context "when update URL is configured in control.xml" do
+    context "when some update is available" do
       before do
         allow(Yast::ProductFeatures).to receive(:GetStringFeature).and_return(url)
       end
@@ -188,315 +179,13 @@ describe Yast::InstUpdateInstaller do
         end
 
         context "and self-update URL is not remote" do
-          let(:url) { "cd:/?device=sr0" }
+          let(:real_url) { "cd:/?device=sr0" }
 
           it "shows a dialog suggesting to check the network configuration" do
             expect(Yast::Popup).to_not receive(:YesNo)
             expect(manager).to receive(:add_repository)
               .and_raise(::Installation::UpdatesManager::CouldNotProbeRepo)
             expect(subject.main).to eq(:next)
-          end
-        end
-      end
-
-      context "when an URL is specified through Linuxrc" do
-        let(:custom_url) { "http://example.net/sles12/" }
-
-        before do
-          allow(Yast::Linuxrc).to receive(:InstallInf).with("SelfUpdate").and_return(custom_url)
-        end
-
-        it "tries to update the installer using the given URL" do
-          expect(manager).to receive(:add_repository).with(URI(custom_url)).and_return(true)
-          expect(manager).to receive(:apply_all)
-          allow(::FileUtils).to receive(:touch)
-          expect(subject.main).to eq(:restart_yast)
-        end
-
-        it "shows an error if update is not found" do
-          expect(Yast::Popup).to receive(:Error)
-          expect(manager).to receive(:add_repository).with(URI(custom_url))
-            .and_raise(::Installation::UpdatesManager::NotValidRepo)
-          expect(subject.main).to eq(:next)
-        end
-      end
-
-      context "when no URL is specified through Linuxrc" do
-        before do
-          allow(Yast::ProductFeatures).to receive(:GetStringFeature).and_return(url)
-        end
-
-        context "in standard installation" do
-          it "gets URL from control file" do
-            allow(::FileUtils).to receive(:touch)
-            expect(manager).to receive(:add_repository).with(URI(real_url)).and_return(true)
-            expect(subject.main).to eq(:restart_yast)
-          end
-
-          it "does not show an error if update is not found" do
-            expect(Yast::Popup).to_not receive(:Error)
-            expect(manager).to receive(:add_repository).with(URI(real_url))
-              .and_raise(::Installation::UpdatesManager::NotValidRepo)
-            expect(subject.main).to eq(:next)
-          end
-
-          context "and control file doesn't have an URL" do
-            let(:url) { "" }
-
-            it "does not update the installer" do
-              expect(subject).to_not receive(:update_installer)
-            end
-          end
-        end
-
-        context "when a SCC/SMT server defines the URL" do
-          let(:smt0) { double("service", slp_url: "http://update.suse.com") }
-          let(:smt1) { double("service", slp_url: "http://update.example.net") }
-
-          let(:update0) do
-            OpenStruct.new(
-              name: "SLES-12-Installer-Updates-0",
-              url:  "http://update.suse.com/updates/sle12/12.2"
-            )
-          end
-
-          let(:update1) do
-            OpenStruct.new(
-              name: "SLES-12-Installer-Updates-1",
-              url:  "http://update.suse.com/updates/sles12/12.2"
-            )
-          end
-
-          let(:regservice_selection) { Class.new }
-
-          let(:url_helpers) { double("url_helpers", registration_url: smt0.slp_url, slp_discovery: []) }
-          let(:regurl) { nil }
-
-          let(:registration) { double("registration", url: smt0.slp_url) }
-          let(:registration_class) { double("registration_class", new: registration) }
-
-          let(:updates) { [update0, update1] }
-
-          before do
-            # Load registration libraries
-            allow(subject).to receive(:require).with("registration/url_helpers")
-              .and_return(true)
-            allow(subject).to receive(:require).with("registration/registration")
-              .and_return(true)
-            allow(subject).to receive(:require).with("registration/ui/regservice_selection_dialog")
-              .and_return(true)
-            stub_const("Registration::Registration", registration_class)
-            stub_const("Registration::UrlHelpers", url_helpers)
-            stub_const("Registration::UI::RegserviceSelectionDialog", regservice_selection)
-
-            allow(url_helpers).to receive(:service_url) { |u| u }
-            allow(url_helpers).to receive(:boot_reg_url).and_return(regurl)
-            allow(registration).to receive(:get_updates_list).and_return(updates)
-            allow(manager).to receive(:add_repository).and_return(true)
-            allow(File).to receive(:write)
-          end
-
-          it "initializes the package management" do
-            # override the global stubs
-            expect(subject).to receive(:initialize_packager).and_call_original
-            expect(finder).to receive(:add_installation_repo).and_call_original
-
-            url = "cd:///"
-            expect(Yast::Pkg).to receive(:SetTextLocale)
-            expect(Yast::Pkg).to receive(:TargetInitialize).with("/")
-            expect(Yast::Packages).to receive(:ImportGPGKeys)
-            expect(Yast::InstURL).to receive(:installInf2Url).and_return(url)
-            expect(Yast::Pkg).to receive(:SourceCreateBase).with(url, "").and_return(0)
-
-            # just a shortcut to avoid mocking the whole update
-            allow(subject).to receive(:update_installer).and_return(false)
-            subject.main
-          end
-
-          it "tries to update the installer using the given URL" do
-            expect(manager).to receive(:add_repository).with(URI(update0.url))
-              .and_return(true)
-            expect(manager).to receive(:add_repository).with(URI(update1.url))
-              .and_return(true)
-            expect(subject.main).to eq(:restart_yast)
-          end
-
-          context "when the registration server returns empty URL list or fails" do
-            before do
-              allow(registration).to receive(:get_updates_list).and_return([])
-            end
-
-            it "displays a warning about using the default URL from control.xml" do
-              expect(Yast::Report).to receive(:LongWarning)
-                .with(/#{Regexp.escape("http://update.opensuse.org/x86_64/update.dud")}/)
-              subject.main
-            end
-          end
-
-          context "when more than one SMT server exist" do
-            before do
-              allow(url_helpers).to receive(:slp_discovery).and_return([smt0, smt1])
-            end
-
-            context "if the user selects a SMT server" do
-              before do
-                allow(regservice_selection).to receive(:run).and_return(smt0)
-              end
-
-              it "asks that SMT server for the updates URLs" do
-                expect(registration_class).to receive(:new).with(smt0.slp_url)
-                  .and_return(registration)
-                allow(manager).to receive(:add_repository)
-                subject.main
-              end
-
-              it "saves the registration URL to be used later" do
-                allow(manager).to receive(:add_repository)
-                expect(FakeInstallationOptions.instance).to receive(:custom_url=).with(smt0.slp_url)
-                  .and_call_original
-                expect(File).to receive(:write).with(/\/inst_update_installer.yaml\z/,
-                  { "custom_url" => smt0.slp_url }.to_yaml)
-                subject.main
-              end
-            end
-
-            context "if user cancels the dialog" do
-              before do
-                allow(regservice_selection).to receive(:run).and_return(:cancel)
-                allow(manager).to receive(:add_repository) # it will use the default URL
-              end
-
-              it "does not search for updates" do
-                expect(registration).to_not receive(:get_updates_list)
-                subject.main
-              end
-            end
-
-            context "if users selects the SCC server" do
-              before do
-                allow(regservice_selection).to receive(:run).and_return(:scc)
-              end
-
-              it "asks the SCC server for the updates URLs" do
-                expect(registration_class).to receive(:new).with(nil)
-                  .and_return(registration)
-                allow(manager).to receive(:add_repository)
-                subject.main
-              end
-
-              it "does not save the registration URL to be used later" do
-                allow(manager).to receive(:add_repository)
-                allow(registration).to receive(:url).and_return(nil)
-                expect(FakeInstallationOptions.instance).to receive(:custom_url=).with(nil)
-                expect(File).to_not receive(:write).with(/inst_update_installer.yaml/, anything)
-                subject.main
-              end
-            end
-
-            context "when a regurl was specified via Linuxrc" do
-              let(:regurl) { "http://regserver.example.net" }
-
-              it "uses the given server" do
-                expect(registration_class).to receive(:new).with(regurl)
-                  .and_return(registration)
-                subject.main
-              end
-            end
-          end
-
-          context "when a registration configuration is specified via AutoYaST profile" do
-            let(:reg_server_url) { "http://ay.test.example.com/update" }
-            let(:profile) { { "suse_register" => { "reg_server" => reg_server_url } } }
-
-            before do
-              allow(Yast::Mode).to receive(:auto).at_least(1).and_return(true)
-            end
-
-            it "uses the given server" do
-              expect(registration_class).to receive(:new).with(reg_server_url)
-                .and_return(registration)
-              subject.main
-            end
-
-            it "imports profile settings into registration configuration" do
-              allow(manager).to receive(:add_repository)
-              expect(FakeRegConfig.instance).to receive(:import).with(profile["suse_register"])
-              subject.main
-            end
-          end
-        end
-
-        context "in AutoYaST installation or upgrade" do
-          let(:profile_url) { "http://ay.test.example.com/update" }
-          let(:profile) { { "general" => { "self_update_url" => profile_url } } }
-
-          before do
-            expect(Yast::Mode).to receive(:auto).at_least(1).and_return(true)
-            allow(::FileUtils).to receive(:touch)
-          end
-
-          it "tries to process the profile from the given URL" do
-            expect(subject).to receive(:process_profile)
-            expect(manager).to receive(:add_repository).with(URI(profile_url))
-              .and_return(true)
-
-            subject.main
-          end
-
-          context "the profile defines the update URL" do
-            it "gets the URL from AutoYaST profile" do
-              expect(manager).to receive(:add_repository).with(URI(profile_url))
-                .and_return(true)
-              subject.main
-            end
-
-            it "returns :restart_yast" do
-              allow(manager).to receive(:add_repository).with(URI(profile_url))
-                .and_return(true)
-              expect(subject.main).to eq(:restart_yast)
-            end
-
-            it "shows an error and returns :next if update fails" do
-              expect(Yast::Report).to receive(:Error)
-              expect(manager).to receive(:add_repository)
-                .and_raise(::Installation::UpdatesManager::CouldNotFetchUpdateFromRepo)
-              expect(subject.main).to eq(:next)
-            end
-          end
-
-          context "the profile does not define the update URL" do
-            let(:profile_url) { nil }
-
-            it "gets URL from control file" do
-              expect(manager).to receive(:add_repository).with(URI(real_url))
-                .and_return(true)
-              expect(subject.main).to eq(:restart_yast)
-            end
-
-            it "does not show an error if update is not found" do
-              expect(Yast::Report).to_not receive(:Error)
-              expect(manager).to receive(:add_repository).with(URI(real_url))
-                .and_raise(::Installation::UpdatesManager::NotValidRepo)
-              expect(subject.main).to eq(:next)
-            end
-
-            context "and control file doesn't have an URL" do
-              let(:url) { "" }
-
-              it "does not update the installer" do
-                expect(subject).to_not receive(:update_installer)
-                expect(subject.main).to eq(:next)
-              end
-            end
-          end
-
-          context "when update is disabled through the profile" do
-            let(:profile) { { "general" => { "self_update" => false } } }
-
-            it "does not update the installer" do
-              expect(subject).to_not receive(:update_installer)
-              expect(subject.main).to eq(:next)
-            end
           end
         end
       end
@@ -531,7 +220,7 @@ describe Yast::InstUpdateInstaller do
 
     context "when restarting YaST2" do
       let(:restarting) { true }
-      let(:data_file_exists) { true }
+      let(:data_file_exists) { false }
       let(:smt_url) { "https://smt.example.net" }
       let(:registration_libs) { true }
 
@@ -542,9 +231,12 @@ describe Yast::InstUpdateInstaller do
         allow(subject).to receive(:require_registration_libraries)
           .and_return(registration_libs)
         allow(File).to receive(:exist?).with(/installer_updated/).and_return(true)
+        allow(Yast::Installation).to receive(:restart!)
       end
 
       context "and data file is available" do
+        let(:data_file_exists) { true }
+
         it "sets custom_url" do
           allow(File).to receive(:read).and_return("---\ncustom_url: #{smt_url}\n")
           expect(FakeInstallationOptions.instance).to receive(:custom_url=)
@@ -554,8 +246,6 @@ describe Yast::InstUpdateInstaller do
       end
 
       context "and data file is not available" do
-        let(:data_file_exists) { false }
-
         it "does not set custom_url" do
           expect(FakeInstallationOptions.instance).to_not receive(:custom_url=)
           subject.main
@@ -564,11 +254,17 @@ describe Yast::InstUpdateInstaller do
 
       context "and yast2-registration is not available" do
         let(:registration_libs) { false }
+        let(:data_file_exists) { true }
 
         it "does not load custom_url" do
           expect(FakeInstallationOptions.instance).to_not receive(:custom_url=)
           subject.main
         end
+      end
+
+      it "finishes the restarting process" do
+        expect(Yast::Installation).to receive(:finish_restarting!)
+        subject.main
       end
     end
   end
@@ -579,8 +275,7 @@ describe Yast::InstUpdateInstaller do
 
     before do
       allow(Yast::Linuxrc).to receive(:InstallInf).with("Insecure").and_return(insecure)
-      allow(Yast::Linuxrc).to receive(:InstallInf).with("SelfUpdate")
-        .and_return(url)
+      allow(Yast::Linuxrc).to receive(:InstallInf).with("SelfUpdate").and_return(url)
     end
 
     context "when update works" do
@@ -588,6 +283,13 @@ describe Yast::InstUpdateInstaller do
         allow(manager).to receive(:add_repository).and_return(true)
         allow(manager).to receive(:apply_all)
         expect(subject.update_installer).to eq(true)
+      end
+    end
+
+    context "when update fails" do
+      it "returns false" do
+        allow(manager).to receive(:add_repository).and_return(false)
+        expect(subject.update_installer).to eq(false)
       end
     end
   end

--- a/test/inst_update_installer_test.rb
+++ b/test/inst_update_installer_test.rb
@@ -18,6 +18,7 @@ describe Yast::InstUpdateInstaller do
   end
   let(:url) { "http://update.opensuse.org/\$arch/update.dud" }
   let(:real_url) { "http://update.opensuse.org/#{arch}/update.dud" }
+  let(:remote_url) { true }
   let(:arch) { "x86_64" }
   let(:all_signed?) { true }
   let(:network_running) { true }
@@ -28,7 +29,7 @@ describe Yast::InstUpdateInstaller do
   let(:ay_profile) { double("Yast::Profile", current: profile) }
   let(:ay_profile_location) { double("Yast::ProfileLocation") }
   let(:finder) { ::Installation::UpdateRepositoriesFinder.new }
-  let(:update) { double("update", uri: URI(real_url)) }
+  let(:update) { double("update", uri: URI(real_url), remote?: remote_url) }
   let(:updates) { [update] }
 
   before do
@@ -180,6 +181,7 @@ describe Yast::InstUpdateInstaller do
 
         context "and self-update URL is not remote" do
           let(:real_url) { "cd:/?device=sr0" }
+          let(:remote_url) { false }
 
           it "shows a dialog suggesting to check the network configuration" do
             expect(Yast::Popup).to_not receive(:YesNo)

--- a/test/lib/update_repositories_finder_test.rb
+++ b/test/lib/update_repositories_finder_test.rb
@@ -6,6 +6,12 @@ require "installation/update_repositories_finder"
 Yast.import "Linuxrc"
 
 describe Installation::UpdateRepositoriesFinder do
+  # Registration::Storage::InstallationOptions fake
+  class FakeInstallationOptions
+    include Singleton
+    attr_accessor :custom_url
+  end
+
   describe "#updates" do
     let(:url_from_linuxrc) { nil }
     let(:url_from_control) { "http://update.opensuse.org/\$arch/42.2" }
@@ -19,8 +25,6 @@ describe Installation::UpdateRepositoriesFinder do
 
     before do
       stub_const("Yast::Profile", ay_profile)
-      allow(Installation::UpdateRepository).to receive(:new)
-        .and_return(repo)
       allow(Yast::Linuxrc).to receive(:InstallInf).with("SelfUpdate")
         .and_return(url_from_linuxrc)
     end
@@ -28,11 +32,10 @@ describe Installation::UpdateRepositoriesFinder do
     context "when URL was specified via Linuxrc" do
       let(:url_from_linuxrc) { "http://example.net/sles12/" }
 
-      it "returns the custom URL from Linuxrc" do
+      it "returns the updates repository using the URL from Linuxrc" do
         expect(Installation::UpdateRepository).to receive(:new)
-          .with(URI(url_from_linuxrc), :user)
-        update = finder.updates.first
-        expect(update).to eq(repo)
+          .with(URI(url_from_linuxrc), :user).and_return(repo)
+        expect(finder.updates).to eq([repo])
       end
     end
 
@@ -44,11 +47,10 @@ describe Installation::UpdateRepositoriesFinder do
         allow(Yast::Mode).to receive(:auto).and_return(true)
       end
 
-      it "returns the custom URL from the profile" do
+      it "returns the updates repository using the custom URL from the profile" do
         expect(Installation::UpdateRepository).to receive(:new)
-          .with(URI(profile_url), :user)
-        update = finder.updates.first
-        expect(update).to eq(repo)
+          .with(URI(profile_url), :user).and_return(repo)
+        expect(finder.updates).to eq([repo])
       end
     end
 
@@ -63,11 +65,131 @@ describe Installation::UpdateRepositoriesFinder do
           .and_return(nil)
       end
 
-      it "returns the URL from the control file" do
-        expect(Installation::UpdateRepository).to receive(:new)
-          .with(URI(real_url_from_control), :default)
-        update = finder.updates.first
-        expect(update).to eq(repo)
+      context "when system is not registrable" do
+        before do
+          hide_const("::Registration::UrlHelpers")
+        end
+
+        it "gets the URL from the control file" do
+          expect(Installation::UpdateRepository).to receive(:new)
+            .with(URI(real_url_from_control), :default).and_return(repo)
+          expect(finder.updates).to eq([repo])
+        end
+      end
+
+      context "when a SCC/SMT server defines the URL" do
+        let(:smt0) { double("service", slp_url: "http://update.suse.com") }
+        let(:smt1) { double("service", slp_url: "http://update.example.net") }
+
+        let(:update0) do
+          OpenStruct.new(
+            name: "SLES-12-Installer-Updates-0",
+            url:  "http://update.suse.com/updates/sle12/12.2"
+            )
+        end
+
+        let(:update1) do
+          OpenStruct.new(
+            name: "SLES-12-Installer-Updates-1",
+            url:  "http://update.suse.com/updates/sles12/12.2"
+            )
+        end
+
+        let(:regservice_selection) { Class.new }
+
+        let(:url_helpers) { double("url_helpers", registration_url: smt0.slp_url, slp_discovery: []) }
+        let(:regurl) { nil }
+
+        let(:registration) { double("registration", url: smt0.slp_url) }
+        let(:registration_class) { double("registration_class", new: registration) }
+
+        let(:updates) { [update0] }
+
+        before do
+          stub_const("Registration::Registration", registration_class)
+          stub_const("Registration::UrlHelpers", url_helpers)
+          stub_const("Registration::UI::RegserviceSelectionDialog", regservice_selection)
+          stub_const("Registration::Storage::InstallationOptions", FakeInstallationOptions)
+
+          allow(url_helpers).to receive(:service_url) { |u| u }
+          allow(url_helpers).to receive(:boot_reg_url).and_return(regurl)
+          allow(registration).to receive(:get_updates_list).and_return(updates)
+        end
+
+        it "gets the URL defined by the server" do
+          expect(Installation::UpdateRepository).to receive(:new)
+            .with(URI(update0.url), :default).and_return(repo)
+          expect(finder.updates).to eq([repo])
+        end
+
+        context "when the registration server returns an empty list" do
+          let(:updates) { [] }
+
+          it "falls back to use updates URL defined in the control file" do
+            expect(Installation::UpdateRepository).to receive(:new)
+              .with(URI(real_url_from_control), :default).and_return(repo)
+            expect(finder.updates).to eq([repo])
+          end
+        end
+
+        context "when more than one SMT server is found via SLP" do
+          before do
+            allow(url_helpers).to receive(:slp_discovery).and_return([smt0, smt1])
+          end
+
+          context "if the user selects a SMT server" do
+            before do
+              allow(regservice_selection).to receive(:run).and_return(smt0)
+            end
+
+            it "asks the SMT server for the updates URLs" do
+              expect(registration_class).to receive(:new).with(smt0.slp_url)
+                .and_return(registration)
+              expect(Installation::UpdateRepository).to receive(:new)
+                .with(URI(update0.url), :default).and_return(repo)
+              finder.updates
+            end
+          end
+
+          context "if user cancels the dialog" do
+            before do
+              allow(regservice_selection).to receive(:run).and_return(:cancel)
+            end
+
+            it "falls back to use updates URL defined in the control file" do
+              expect(registration).to_not receive(:get_updates_list)
+              expect(Installation::UpdateRepository).to receive(:new)
+                .with(URI(real_url_from_control), :default).and_return(repo)
+              expect(finder.updates).to eq([repo])
+            end
+          end
+        end
+
+        context "if users selects the SCC server" do
+          before do
+            allow(regservice_selection).to receive(:run).and_return(:scc)
+          end
+
+          it "asks the SCC server for the updates URLs" do
+            expect(registration_class).to receive(:new).with(nil)
+              .and_return(registration)
+            expect(registration).to receive(:get_updates_list)
+              .and_return([update1])
+            expect(Installation::UpdateRepository).to receive(:new)
+              .with(URI(update1.url), :default).and_return(repo)
+            finder.updates
+          end
+        end
+
+        context "when a regurl was specified via Linuxrc" do
+          let(:regurl) { "http://regserver.example.net" }
+
+          it "asks the SCC server for the updates URLs" do
+            expect(registration_class).to receive(:new).with(regurl)
+              .and_return(registration)
+            finder.updates
+          end
+        end
       end
     end
   end

--- a/test/lib/update_repositories_finder_test.rb
+++ b/test/lib/update_repositories_finder_test.rb
@@ -82,14 +82,14 @@ describe Installation::UpdateRepositoriesFinder do
           OpenStruct.new(
             name: "SLES-12-Installer-Updates-0",
             url:  "http://update.suse.com/updates/sle12/12.2"
-            )
+          )
         end
 
         let(:update1) do
           OpenStruct.new(
             name: "SLES-12-Installer-Updates-1",
             url:  "http://update.suse.com/updates/sles12/12.2"
-            )
+          )
         end
 
         let(:regservice_selection) { Class.new }

--- a/test/lib/update_repositories_finder_test.rb
+++ b/test/lib/update_repositories_finder_test.rb
@@ -1,0 +1,74 @@
+#!/usr/bin/env rspec
+
+require_relative "../test_helper"
+require "installation/update_repositories_finder"
+
+Yast.import "Linuxrc"
+
+describe Installation::UpdateRepositoriesFinder do
+  describe "#updates" do
+    let(:url_from_linuxrc) { nil }
+    let(:url_from_control) { "http://update.opensuse.org/\$arch/42.2" }
+    let(:real_url_from_control) { "http://update.opensuse.org/#{arch}/42.2" }
+    let(:arch) { "x86_64" }
+    let(:profile) { {} }
+    let(:ay_profile) { double("Yast::Profile", current: profile) }
+    let(:repo) { double("UpdateRepository") }
+
+    subject(:finder) { described_class.new }
+
+    before do
+      stub_const("Yast::Profile", ay_profile)
+      allow(Installation::UpdateRepository).to receive(:new)
+        .and_return(repo)
+      allow(Yast::Linuxrc).to receive(:InstallInf).with("SelfUpdate")
+        .and_return(url_from_linuxrc)
+    end
+
+    context "when URL was specified via Linuxrc" do
+      let(:url_from_linuxrc) { "http://example.net/sles12/" }
+
+      it "returns the custom URL from Linuxrc" do
+        expect(Installation::UpdateRepository).to receive(:new)
+          .with(URI(url_from_linuxrc), :user)
+        update = finder.updates.first
+        expect(update).to eq(repo)
+      end
+    end
+
+    context "when URL was specified via an AutoYaST profile" do
+      let(:profile_url) { "http://ay.test.example.com/update" }
+      let(:profile) { { "general" => { "self_update_url" => profile_url } } }
+
+      before do
+        allow(Yast::Mode).to receive(:auto).and_return(true)
+      end
+
+      it "returns the custom URL from the profile" do
+        expect(Installation::UpdateRepository).to receive(:new)
+          .with(URI(profile_url), :user)
+        update = finder.updates.first
+        expect(update).to eq(repo)
+      end
+    end
+
+    context "when no custom URL is specified" do
+      before do
+        allow(Yast::ProductFeatures).to receive(:GetStringFeature)
+          .with("globals", "self_update_url")
+          .and_return(url_from_control)
+        # TODO: test don't mock!
+        allow(finder).to receive(:add_installation_repo)
+        allow(Yast::Linuxrc).to receive(:InstallInf).with("regurl")
+          .and_return(nil)
+      end
+
+      it "returns the URL from the control file" do
+        expect(Installation::UpdateRepository).to receive(:new)
+          .with(URI(real_url_from_control), :default)
+        update = finder.updates.first
+        expect(update).to eq(repo)
+      end
+    end
+  end
+end

--- a/test/lib/update_repositories_finder_test.rb
+++ b/test/lib/update_repositories_finder_test.rb
@@ -1,17 +1,12 @@
 #!/usr/bin/env rspec
 
 require_relative "../test_helper"
+require_relative "../support/fake_registration"
 require "installation/update_repositories_finder"
 
 Yast.import "Linuxrc"
 
 describe Installation::UpdateRepositoriesFinder do
-  # Registration::Storage::InstallationOptions fake
-  class FakeInstallationOptions
-    include Singleton
-    attr_accessor :custom_url
-  end
-
   describe "#updates" do
     let(:url_from_linuxrc) { nil }
     let(:url_from_control) { "http://update.opensuse.org/\$arch/42.2" }

--- a/test/lib/update_repositories_finder_test.rb
+++ b/test/lib/update_repositories_finder_test.rb
@@ -20,6 +20,8 @@ describe Installation::UpdateRepositoriesFinder do
 
     before do
       stub_const("Yast::Profile", ay_profile)
+      stub_const("::Registration::ConnectHelpers", FakeConnectHelpers)
+      allow(finder).to receive(:require).with("registration/connect_helpers")
       allow(Yast::Linuxrc).to receive(:InstallInf).with("SelfUpdate")
         .and_return(url_from_linuxrc)
     end
@@ -144,6 +146,12 @@ describe Installation::UpdateRepositoriesFinder do
                 .with(URI(update0.url), :default).and_return(repo)
               finder.updates
             end
+
+            it "handles registration errors" do
+              expect(Registration::ConnectHelpers).to receive(:catch_registration_errors)
+                .and_call_original
+              finder.updates
+            end
           end
 
           context "if user cancels the dialog" do
@@ -174,6 +182,11 @@ describe Installation::UpdateRepositoriesFinder do
               .with(URI(update1.url), :default).and_return(repo)
             finder.updates
           end
+
+          it "does not handle registration errors" do
+            expect(Registration::ConnectHelpers).to_not receive(:catch_registration_errors)
+            finder.updates
+          end
         end
 
         context "when a regurl was specified via Linuxrc" do
@@ -182,6 +195,12 @@ describe Installation::UpdateRepositoriesFinder do
           it "asks the SCC server for the updates URLs" do
             expect(registration_class).to receive(:new).with(regurl)
               .and_return(registration)
+            finder.updates
+          end
+
+          it "handles registration errors" do
+            expect(Registration::ConnectHelpers).to receive(:catch_registration_errors)
+              .and_call_original
             finder.updates
           end
         end

--- a/test/support/fake_registration.rb
+++ b/test/support/fake_registration.rb
@@ -9,3 +9,10 @@ class FakeRegConfig
   include Singleton
   def import(_args); end
 end
+
+module FakeConnectHelpers
+  def self.catch_registration_errors
+    yield
+    true
+  end
+end

--- a/test/support/fake_registration.rb
+++ b/test/support/fake_registration.rb
@@ -1,0 +1,11 @@
+# Registration::Storage::InstallationOptions fake
+class FakeInstallationOptions
+  include Singleton
+  attr_accessor :custom_url
+end
+
+# Registration::Storage::Config fake
+class FakeRegConfig
+  include Singleton
+  def import(_args); end
+end

--- a/test/update_repository_test.rb
+++ b/test/update_repository_test.rb
@@ -251,4 +251,28 @@ describe Installation::UpdateRepository do
       subject.cleanup
     end
   end
+
+  describe "#user_defined?" do
+    context "when origin is :user" do
+      subject(:repo) { Installation::UpdateRepository.new(uri, :user) }
+
+      it "returns true" do
+        expect(repo).to be_user_defined
+      end
+    end
+
+    context "when origin is :default" do
+      subject(:repo) { Installation::UpdateRepository.new(uri, :default) }
+
+      it "returns false" do
+        expect(repo).to_not be_user_defined
+      end
+    end
+
+    context "when origin is not specified" do
+      it "returns false" do
+        expect(repo).to_not be_user_defined
+      end
+    end
+  end
 end

--- a/test/update_repository_test.rb
+++ b/test/update_repository_test.rb
@@ -275,4 +275,24 @@ describe Installation::UpdateRepository do
       end
     end
   end
+
+  describe "#remote?" do
+    context "when is a remote URL according to libzypp" do
+      it "returns true" do
+        expect(Yast::Pkg).to receive(:UrlSchemeIsRemote).with("http")
+          .and_call_original
+        expect(repo).to be_remote
+      end
+    end
+
+    context "when is not a remote URL according to libzypp" do
+      let(:uri) { URI("cd:/?device=sr0") }
+
+      it "returns false" do
+        expect(Yast::Pkg).to receive(:UrlSchemeIsRemote).with("cd")
+          .and_call_original
+        expect(repo).to_not be_remote
+      end
+    end
+  end
 end

--- a/test/update_repository_test.rb
+++ b/test/update_repository_test.rb
@@ -195,7 +195,7 @@ describe Installation::UpdateRepository do
 
     before do
       allow(repo).to receive(:update_files).and_return([update_path])
-      allow(repo.instsys_parts_path).to receive(:open).and_yield(file)
+      allow(Installation::UpdateRepository::INSTSYS_PARTS_PATH).to receive(:open).and_yield(file)
       allow(FileUtils).to receive(:mkdir_p).with(mount_point)
     end
 

--- a/test/update_repository_test.rb
+++ b/test/update_repository_test.rb
@@ -295,4 +295,20 @@ describe Installation::UpdateRepository do
       end
     end
   end
+
+  describe "#inspect" do
+    let(:uri) { URI("http://user:123456@updates.suse.com") }
+
+    it "does not contain sensitive information" do
+      expect(repo.inspect).to_not include("123456")
+    end
+  end
+
+  describe "#to_s" do
+    let(:uri) { URI("http://user:123456@updates.suse.com") }
+
+    it "does not contain sensitive information" do
+      expect(repo.to_s).to_not include("123456")
+    end
+  end
 end


### PR DESCRIPTION
## Improving the self-update feature usability

As you may know, YaST includes a [nice feature](https://fate.suse.com/319716) which allows the installer to update itself in order to solve bugs in the installation media. This mechanism has been included in SUSE Linux Enterprise 12 SP2, although it's not enabled by default (you need to pass an extra option `selfupdate=1` to make it work).

So after getting some feedback, we're working toward fixing some usability problems. The first of them is that, in some situations, the self-update mechanism is too intrusive.

Consider the following scenario: you're installing a system behind a firewall which prevents the machine to connect to the outside network. As the SUSE Customer Center will be unreachable, YaST complains about not being able to get the list of repositories for the self-update. And, after that, you get another complain because the fallback repository is not accessible. Two error messages and 2 timeouts.

And the situation could be even worse if you don't have access to a DNS server (add another error message).

So after some discussion we've decided to show such errors only if the user has specified SMT or a custom self-update repository (which is also possible). In any other case, the error is logged and the self-update is skipped completely.

You can find further information in our [Self-Update Use Cases and Error Handling dcument](https://gist.github.com/imobachgs/cb03b6a87dd5e31c89a9463d30db4252).

During upcoming sprints, we'll keep working on making the self-update feature great!

## Not for the blog

The idea of this PR is to extract some logic from the InstUpdateInstaller because, IMHO, it has too many responsabilities.

* `UpdateRepositoriesFinder` takes care of finding the update repositories (checking `Linuxrc`, the control file, SCC, etc.). It returns an array of `UpdateRepository` objects instead of just plain strings.
* `UpdateRepository` gets a new method `user_defined?` which determines whether is a user defined repository or not. Additionally, it also gets a `remote?` method and that responsability is also removed from the client.
* Storing and loading the used registration server is still done by the client.