### PR TITLE
Add system roles through addons

### DIFF
--- a/doc/control-file.md
+++ b/doc/control-file.md
@@ -1778,27 +1778,6 @@ modules specified in the add-on product control file.
     </clone_modules>
 ```
 
-### Adding a system role
-
-This example shows how to add an additional `example_role`.
-
-```xml
-    <system_roles>
-      <insert_system_roles config:type="list">
-        <insert_system_roles>
-          <system_roles config:type="list">
-            <system_role>
-              <id>example_role</id>
-            </system_role>
-          </system_roles>
-        </insert_system_roles>
-      </insert_system_roles>
-    </system_roles>
-```
-
-NOTE: do not forget to add labels and descriptions to the `texts` section. Check
-*System Roles* section for more details.
-
 ### Example of OES 1.0
 
 The network code is instructed to force a static IP address.

--- a/doc/control-file.md
+++ b/doc/control-file.md
@@ -1508,13 +1508,13 @@ section, which defines changes to the existing workflow and proposals.
             </inst_finish>
             <system_roles>
               <insert_system_roles config:type="list">
-                <insert_system_roles>
+                <insert_system_role>
                   <system_roles config:type="list">
                     <system_role>
                       <id>additional_role</id>
                     </system_role>
                   </system_roles>
-                </insert_system_roles>
+                </insert_system_role>
               </insert_system_roles>
             </system_roles>
         </update>

--- a/doc/control-file.md
+++ b/doc/control-file.md
@@ -1303,6 +1303,12 @@ the installation workflow. Basically, adding proposal has two steps:
 Is possible as replacing or removing a step of the installation
 workflow.
 
+#### Adding new system roles
+
+Add-ons are allowed to define additional system roles. Those roles will be shown
+at the bottom of the list of already existing roles. For the time being,
+modifying or removing system roles is not possible.
+
 ### File layout
 
 #### Add-on Product CD
@@ -1500,6 +1506,17 @@ section, which defines changes to the existing workflow and proposals.
                     <module>before_umount_2</module>
                 </before_umount>
             </inst_finish>
+            <system_roles>
+              <insert_system_roles config:type="list">
+                <insert_system_roles>
+                  <system_roles config:type="list">
+                    <system_role>
+                      <id>additional_role</id>
+                    </system_role>
+                  </system_roles>
+                </insert_system_roles>
+              </insert_system_roles>
+            </system_roles>
         </update>
     </productDefines>
 ```
@@ -1760,6 +1777,27 @@ modules specified in the add-on product control file.
         [...]
     </clone_modules>
 ```
+
+### Adding a system role
+
+This example shows how to add an additional `example_role`.
+
+```xml
+    <system_roles>
+      <insert_system_roles config:type="list">
+        <insert_system_roles>
+          <system_roles config:type="list">
+            <system_role>
+              <id>example_role</id>
+            </system_role>
+          </system_roles>
+        </insert_system_roles>
+      </insert_system_roles>
+    </system_roles>
+```
+
+NOTE: do not forget to add labels and descriptions to the `texts` section. Check
+*System Roles* section for more details.
 
 ### Example of OES 1.0
 

--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Mar 13 12:16:23 UTC 2017 - igonzalezsosa@suse.com
+
+- Support to add roles through addons (FATE#320772)
+- 3.2.28
+
+-------------------------------------------------------------------
 Thu Mar  9 17:48:25 UTC 2017 - jreidinger@suse.com
 
 - fix crash when reading if desktop role should have default

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation
-Version:        3.2.27
+Version:        3.2.28
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -40,14 +40,14 @@ BuildRequires:  yast2-xml
 BuildRequires:  rubygem(rspec)
 BuildRequires:  rubygem(yast-rake)
 
-# UI::Widgets
-BuildRequires: yast2 >= 3.2.8
+# ProductControl.system_roles
+BuildRequires: yast2 >= 3.2.15
 
 # AutoinstSoftware.SavePackageSelection()
 Requires:       autoyast2-installation >= 3.1.105
 
-# Needs UI:Widgets
-Requires:       yast2 >= 3.2.8
+# ProductControl.system_roles
+Requires:       yast2 >= 3.2.15
 
 # Language::GetLanguageItems and other API
 # Language::Set (handles downloading the translation extensions)

--- a/src/lib/installation/select_system_role.rb
+++ b/src/lib/installation/select_system_role.rb
@@ -34,9 +34,6 @@ module Installation
       attr_accessor :original_role_id
     end
 
-    # @return [Array<SystemRole>] List of defined roles
-    attr_reader :roles
-
     NON_OVERLAY_ATTRIBUTES = [
       "additional_dialogs",
       "id",
@@ -50,7 +47,7 @@ module Installation
     end
 
     def run
-      if roles.empty?
+      if roles(true).empty?
         log.info "No roles defined, skipping their dialog"
         return :auto # skip forward or backward
       end
@@ -206,8 +203,17 @@ module Installation
       Installation::Services.enabled = to_enable
     end
 
-    def roles
-      @roles ||= SystemRole.roles
+    # Return the list of defined roles
+    #
+    # @param [Boolean] refresh Refresh system roles cache
+    # @return [Array<SystemRole>] List of defined roles
+    #
+    # @see SystemRole.all
+    # @see SystemRole.clear
+    def roles(refresh = false)
+      # Refresh system roles list
+      SystemRole.clear if refresh
+      SystemRole.all
     end
   end
 end

--- a/src/lib/installation/select_system_role.rb
+++ b/src/lib/installation/select_system_role.rb
@@ -20,6 +20,7 @@
 require "yast"
 require "ui/installation_dialog"
 require "installation/services"
+require "installation/system_role"
 
 Yast.import "GetInstArgs"
 Yast.import "Popup"
@@ -32,6 +33,9 @@ module Installation
       # once the user selects a role, remember it in case they come back
       attr_accessor :original_role_id
     end
+
+    # @return [Array<SystemRole>] List of defined roles
+    attr_reader :roles
 
     NON_OVERLAY_ATTRIBUTES = [
       "additional_dialogs",
@@ -46,7 +50,7 @@ module Installation
     end
 
     def run
-      if raw_roles.empty?
+      if roles.empty?
         log.info "No roles defined, skipping their dialog"
         return :auto # skip forward or backward
       end
@@ -83,7 +87,7 @@ module Installation
     def create_dialog
       clear_role
       ok = super
-      role_id = self.class.original_role_id || role_attributes.first[:id]
+      role_id = self.class.original_role_id || (roles.first && roles.first.id)
       Yast::UI.ChangeWidget(Id(:roles), :CurrentButton, role_id)
       ok
     end
@@ -99,7 +103,7 @@ module Installation
       end
       self.class.original_role_id = role_id
 
-      apply_role(role_id)
+      apply_role(SystemRole.find(role_id))
 
       result = run_clients(additional_clients_for(role_id))
       # We show the main role dialog; but the additional clients have
@@ -118,8 +122,8 @@ module Installation
 
     # gets array of clients to run for given role
     def additional_clients_for(role_id)
-      clients = raw_roles.find { |r| r["id"] == role_id }["additional_dialogs"]
-      clients ||= ""
+      role = SystemRole.find(role_id)
+      clients = role["additional_dialogs"] || ""
       clients.split(",").map!(&:strip)
     end
 
@@ -169,11 +173,11 @@ module Installation
     end
 
     def role_buttons
-      ui_roles = role_attributes.each_with_object(VBox()) do |r, vbox|
+      ui_roles = roles.each_with_object(VBox()) do |role, vbox|
         # FIXME: following workaround can be removed as soon as bsc#997402 is fixed:
         # bsc#995082: System role descriptions use a character that is missing in console font
-        description = Yast::UI.TextMode ? r[:description].tr("•", "*") : r[:description]
-        vbox << Left(RadioButton(Id(r[:id]), r[:label]))
+        description = Yast::UI.TextMode ? role.description.tr("•", "*") : role.description
+        vbox << Left(RadioButton(Id(role.id), role.label))
         vbox << HBox(
           HSpacing(Yast::UI.TextMode ? 4 : 2),
           Left(Label(description))
@@ -185,47 +189,25 @@ module Installation
     end
 
     # Applies given role to configuration
-    def apply_role(role_id)
-      log.info "Applying system role '#{role_id}'"
-      features = raw_roles.find { |r| r["id"] == role_id }
-      features = features.dup
-      NON_OVERLAY_ATTRIBUTES.each { |a| features.delete(a) }
-      Yast::ProductFeatures.SetOverlay(features)
-      adapt_services(role_id)
+    def apply_role(role)
+      log.info "Applying system role '#{role.id}'"
+      role.overlay_features
+      adapt_services(role)
     end
 
     # for given role sets in {::Installation::Services} list of services to enable
     # according to its config. Do not use alone and use apply_role instead.
-    def adapt_services(role_id)
-      services = raw_roles.find { |r| r["id"] == role_id }["services"]
-      services ||= []
+    def adapt_services(role)
+      services = role["services"] || []
 
       to_enable = services.map { |s| s["name"] }
-      log.info "enable for #{role_id} these services: #{to_enable.inspect}"
+      log.info "enable for #{role.id} these services: #{to_enable.inspect}"
 
       Installation::Services.enabled = to_enable
     end
 
-    # the contents is an overlay for ProductFeatures sections
-    # [
-    #  { "id" => "foo", "partitioning" => ... },
-    #  { "id" => "bar", "partitioning" => ... , "software" => ...},
-    # ]
-    # @return [Array<Hash{String => Object}>]
-    def raw_roles
-      Yast::ProductControl.productControl.fetch("system_roles", [])
-    end
-
-    def role_attributes
-      raw_roles.map do |r|
-        id = r["id"]
-
-        {
-          id:          id,
-          label:       Yast::ProductControl.GetTranslatedText(id),
-          description: Yast::ProductControl.GetTranslatedText(id + "_description")
-        }
-      end
+    def roles
+      @roles ||= SystemRole.roles
     end
   end
 end

--- a/src/lib/installation/select_system_role.rb
+++ b/src/lib/installation/select_system_role.rb
@@ -47,7 +47,7 @@ module Installation
     end
 
     def run
-      if roles(true).empty?
+      if roles(refresh: true).empty?
         log.info "No roles defined, skipping their dialog"
         return :auto # skip forward or backward
       end
@@ -210,7 +210,7 @@ module Installation
     #
     # @see SystemRole.all
     # @see SystemRole.clear
-    def roles(refresh = false)
+    def roles(refresh: false)
       # Refresh system roles list
       SystemRole.clear if refresh
       SystemRole.all

--- a/src/lib/installation/system_role.rb
+++ b/src/lib/installation/system_role.rb
@@ -104,6 +104,11 @@ module Installation
         end
       end
 
+      # Clears roles cache
+      def clear
+        @roles = nil
+      end
+
       # Fetchs the roles from the control file and returns them as they are.
       #
       # @example

--- a/src/lib/installation/system_role.rb
+++ b/src/lib/installation/system_role.rb
@@ -116,7 +116,7 @@ module Installation
       #
       # @return [Array<Hash>] returns an empty array if no roles defined
       def raw_roles
-        @raw_roles ||= Yast::ProductControl.productControl.fetch("system_roles", []) || []
+        Yast::ProductControl.system_roles
       end
 
       # Returns an array with all the SystemRole objects

--- a/src/lib/installation/system_role.rb
+++ b/src/lib/installation/system_role.rb
@@ -89,7 +89,7 @@ module Installation
 
       # returns if roles should set default or have no role preselected
       def default?
-        !all.values.first["no_default"]
+        !all.first["no_default"]
       end
 
       # Returns an array with all the SystemRole objects

--- a/src/lib/installation/system_role.rb
+++ b/src/lib/installation/system_role.rb
@@ -84,7 +84,7 @@ module Installation
       #
       # @return [Array<String>] array with all the role ids; empty if no roles
       def ids
-        all.keys
+        all.map(&:id)
       end
 
       # returns if roles should set default or have no role preselected
@@ -92,16 +92,11 @@ module Installation
         !all.values.first["no_default"]
       end
 
-      # Initializes and maintains a map with the id of the roles and
-      # SystemRole objects with the roles defined in the control file.
+      # Returns an array with all the SystemRole objects
       #
       # @return [Hash<String, SystemRole>]
       def all
-        return @roles if @roles
-
-        @roles = raw_roles.each_with_object({}) do |raw_role, entries|
-          entries[raw_role["id"]] = from_control(raw_role)
-        end
+        @roles ||= raw_roles.map { |r| from_control(r) }
       end
 
       # Clears roles cache
@@ -117,13 +112,6 @@ module Installation
       # @return [Array<Hash>] returns an empty array if no roles defined
       def raw_roles
         Yast::ProductControl.system_roles
-      end
-
-      # Returns an array with all the SystemRole objects
-      #
-      # @return [Array<SystemRole>] retuns an empty array if no roles defined
-      def roles
-        all.values
       end
 
       # Establish as the current role the one given as parameter.
@@ -147,7 +135,7 @@ module Installation
       # @param role_id [String]
       # @return [SystemRole, nil]
       def find(role_id)
-        all[role_id]
+        all.find { |r| r.id == role_id }
       end
 
       # Creates a SystemRole instance for the given role (in raw format).

--- a/src/lib/installation/system_role.rb
+++ b/src/lib/installation/system_role.rb
@@ -164,6 +164,7 @@ module Installation
             description: Yast::ProductControl.GetTranslatedText("#{id}_description")
           )
 
+        role["additional_dialogs"] = raw_role["additional_dialogs"]
         role["services"] = raw_role["services"] || []
         role["no_default"] = raw_role["no_default"] || false
 

--- a/test/select_system_role_test.rb
+++ b/test/select_system_role_test.rb
@@ -29,8 +29,8 @@ describe ::Installation::SelectSystemRole do
 
     context "when no roles are defined" do
       before do
-        allow(Yast::ProductControl).to receive(:productControl)
-          .and_return("system_roles" => [])
+        allow(Yast::ProductControl).to receive(:system_roles)
+          .and_return([])
       end
 
       it "does not display dialog, and returns :auto" do
@@ -48,8 +48,8 @@ describe ::Installation::SelectSystemRole do
       end
 
       before do
-        allow(Yast::ProductControl).to receive(:productControl)
-          .and_return("system_roles" => control_file_roles)
+        allow(Yast::ProductControl).to receive(:system_roles)
+          .and_return(control_file_roles)
       end
 
       it "displays dialog, and sets ProductFeatures on Next" do

--- a/test/select_system_role_test.rb
+++ b/test/select_system_role_test.rb
@@ -14,6 +14,8 @@ describe ::Installation::SelectSystemRole do
     end
 
     allow(Yast::UI).to receive(:ChangeWidget)
+
+    Installation::SystemRole.clear # Clear system roles cache
   end
 
   describe "#run" do

--- a/test/system_role_test.rb
+++ b/test/system_role_test.rb
@@ -87,8 +87,8 @@ describe Installation::SystemRole do
   describe ".from_control" do
     it "creates a new instance of SystemRole based on a control file role entry definition" do
       raw_role = {
-        "id" => "raw_role",
-        "services" => [{ "name" => "services_one" }],
+        "id"                 => "raw_role",
+        "services"           => [{ "name" => "services_one" }],
         "additional_dialogs" => "dialog"
       }
 
@@ -96,7 +96,7 @@ describe Installation::SystemRole do
 
       expect(system_role.class).to eql(described_class)
       expect(system_role.id).to eql("raw_role")
-      expect(system_role["services"]).to eq([{"name" => "services_one"}])
+      expect(system_role["services"]).to eq([{ "name" => "services_one" }])
       expect(system_role["additional_dialogs"]).to eq("dialog")
     end
   end

--- a/test/system_role_test.rb
+++ b/test/system_role_test.rb
@@ -20,15 +20,11 @@ describe Installation::SystemRole do
   end
 
   before do
-    allow(described_class).to receive(:raw_roles).and_return(system_roles)
+    allow(Yast::ProductControl).to receive(:system_roles).and_return(system_roles)
   end
 
   describe ".raw_roles" do
     it "returns the roles from the control file" do
-      allow(described_class).to receive(:raw_roles).and_call_original
-      expect(Yast::ProductControl).to receive(:productControl)
-        .and_return("system_roles" => system_roles)
-
       raw_roles = described_class.raw_roles
 
       expect(raw_roles.size).to eql 2

--- a/test/system_role_test.rb
+++ b/test/system_role_test.rb
@@ -94,13 +94,18 @@ describe Installation::SystemRole do
 
   describe ".from_control" do
     it "creates a new instance of SystemRole based on a control file role entry definition" do
-      raw_role = { "id" => "raw_role", "services" => [{ "name" => "services_one" }] }
+      raw_role = {
+        "id" => "raw_role",
+        "services" => [{ "name" => "services_one" }],
+        "additional_dialogs" => "dialog"
+      }
 
       system_role = described_class.from_control(raw_role)
 
       expect(system_role.class).to eql(described_class)
       expect(system_role.id).to eql("raw_role")
-      expect(system_role["services"].size).to eql(1)
+      expect(system_role["services"]).to eq([{"name" => "services_one"}])
+      expect(system_role["additional_dialogs"]).to eq("dialog")
     end
   end
 

--- a/test/system_role_test.rb
+++ b/test/system_role_test.rb
@@ -108,6 +108,15 @@ describe Installation::SystemRole do
     end
   end
 
+  describe ".clear" do
+    it "clears roles cache" do
+      expect(Yast::ProductControl).to receive(:system_roles).twice
+      described_class.all
+      described_class.clear
+      described_class.all
+    end
+  end
+
   describe "#adapt_services" do
     it "sets to be enable the specific services for this role" do
       role = described_class.find("role_two")

--- a/test/system_role_test.rb
+++ b/test/system_role_test.rb
@@ -21,6 +21,7 @@ describe Installation::SystemRole do
 
   before do
     allow(Yast::ProductControl).to receive(:system_roles).and_return(system_roles)
+    described_class.clear
   end
 
   describe ".raw_roles" do
@@ -38,19 +39,10 @@ describe Installation::SystemRole do
     end
   end
 
-  describe ".roles" do
-    it "returns an array of SystemRole objects for all the declared roles " do
-      expect(described_class.roles.size).to eql(2)
-
-      expect(described_class.roles.last.class).to eql(described_class)
-    end
-  end
-
   describe ".all" do
-    it "returns a hash indexed by roles 'id' and the related SystemRole object as the value" do
+    it "returns an array of SystemRole objects for all the declared roles " do
       expect(described_class.all.size).to eql(2)
-      expect(described_class.all.keys).to eql(["role_one", "role_two"])
-      expect(described_class.all.values.first.class).to eql(described_class)
+      expect(described_class.all.last.class).to eql(described_class)
     end
   end
 
@@ -62,8 +54,8 @@ describe Installation::SystemRole do
 
   describe ".find" do
     it "looks for the given role 'id' and returns the specific SystemRole object" do
-      role_two = described_class.all["role_two"]
-      expect(described_class.find("role_two")).to eql(role_two)
+      role_two = described_class.find("role_two")
+      expect(role_two.id).to eq("role_two")
     end
   end
 


### PR DESCRIPTION
This PR adds support to allow add-ons to add new roles and requires https://github.com/yast/yast-yast2/pull/542.

Apart from that, I adapted the `SelectSystemRole` dialog to use the `SystemRole` class written by @teclator.