### PR TITLE
Redistribute roles buttons space

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Mar 15 10:19:33 UTC 2017 - igonzalezsosa@suse.com
+
+- Improve roles buttons distribution in textmode (related to
+  FATE#320772)
+- 3.2.30 
+
+-------------------------------------------------------------------
 Tue Mar 14 12:05:44 UTC 2017 - igonzalezsosa@suse.com
 
 - Fix desktop selection during installation (bsc#1029312)

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation
-Version:        3.2.29
+Version:        3.2.30
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/installation/select_system_role.rb
+++ b/src/lib/installation/select_system_role.rb
@@ -239,13 +239,13 @@ module Installation
       separation = 2.downto(0).find do |l|
         needed_lines_for_roles + (roles.size * l) + default_opts[:margin] <= available_lines_for_roles
       end
-      opts = separation.nil? ? { description: false } : { separation: separation }
+      opts = separation.nil? ? { description: false, separation: 0 } : { separation: separation }
       merged_opts = default_opts.merge(opts)
       log.info "Options for role buttons: #{merged_opts.inspect}"
       merged_opts
     end
 
-    # Number of required lines to show roles information
+    # Number of required lines to show roles buttons
     #
     # Title + Descriptions
     #

--- a/src/lib/installation/select_system_role.rb
+++ b/src/lib/installation/select_system_role.rb
@@ -298,7 +298,7 @@ module Installation
       return @needed_lines_for_roles if @needed_lines_for_roles
       texts = roles.map(&:description)
       texts << intro_text unless intro_text.nil?
-      lines = texts.compact.map { |t| t.lines }.reduce(:+).size
+      lines = texts.compact.map(&:lines).reduce(:+).size
       @needed_lines_for_roles = roles.size + lines
     end
 

--- a/test/select_system_role_test.rb
+++ b/test/select_system_role_test.rb
@@ -159,4 +159,98 @@ describe ::Installation::SelectSystemRole do
       end
     end
   end
+
+  describe "#dialog_content" do
+    let(:system_roles) do # 5 lines are needed
+      [
+        ::Installation::SystemRole.new(id: "role1", description: "Line 1\nLine 2"),
+        ::Installation::SystemRole.new(id: "role2", description: "Line 1")
+      ]
+    end
+
+    let(:textmode) { true }
+    let(:height) { 25 }
+    let(:display_info) do
+      {
+        "Height" => height,
+        "Width"  => 80
+      }
+    end
+    let(:intro_text) { "Some introductory\ntest" }
+
+    before do
+      allow(Yast::UI).to receive(:TextMode).and_return(textmode)
+      allow(Yast::UI).to receive(:GetDisplayInfo).and_return(display_info)
+      allow(::Installation::SystemRole).to receive(:all).and_return(system_roles)
+      allow(Yast::ProductControl).to receive(:GetTranslatedText).with("roles_text")
+        .and_return(intro_text)
+    end
+
+    context "when there's enough room" do
+      it "shows intro, separations, radio buttons and roles descriptions" do
+        expect(subject).to receive(:Label).with(intro_text) # intro
+        expect(subject).to receive(:VSpacing).with(1) # margin
+        expect(subject).to receive(:RadioButton).with(anything, system_roles[0].label) # rol label
+        expect(subject).to receive(:Label).with(/#{system_roles[0].description}/) # rol description
+        expect(subject).to receive(:VSpacing).with(2) # separator
+        expect(subject).to receive(:RadioButton).with(anything, system_roles[1].label) # rol label
+        expect(subject).to receive(:Label).with(/#{system_roles[1].description}/) # rol description
+        subject.dialog_content
+      end
+    end
+
+    context "when there is enough room just reducing separations" do
+      let(:height) { 14 }
+
+      it "reduces separation" do
+        expect(subject).to receive(:VSpacing).with(1).twice # margin + separator
+        subject.dialog_content
+      end
+    end
+
+    context "when there is not enough room even reducing separations" do
+      let(:height) { 10 }
+
+      it "reduces separation and omits descriptions" do
+        expect(subject).to_not receive(:Label).with(/#{system_roles[0].description}/)
+        expect(subject).to_not receive(:Label).with(/#{system_roles[1].description}/)
+        subject.dialog_content
+      end
+    end
+
+    context "when there is not enough room even omitting descriptions" do
+      let(:height) { 8 }
+
+      it "reduces separation, omits descriptions and removes the margin" do
+        expect(subject).to receive(:Label).with(intro_text) # intro
+        expect(subject).to_not receive(:VSpacing)
+        subject.dialog_content
+      end
+    end
+
+    context "when there is not enough room even removing the margin" do
+      let(:height) { 7 }
+
+      it "reduces separation, omits description and hides the introductory text" do
+        expect(subject).to_not receive(:Label).with(intro_text) # intro
+        expect(subject).to_not receive(:VSpacing)
+        subject.dialog_content
+      end
+    end
+
+    context "when not in textmode" do
+      let(:textmode) { false }
+
+      it "shows intro, separations, radio buttons and roles descriptions" do
+        expect(subject).to receive(:Label).with(intro_text) # intro
+        expect(subject).to receive(:VSpacing).with(2) # margin
+        expect(subject).to receive(:RadioButton).with(anything, system_roles[0].label) # rol label
+        expect(subject).to receive(:Label).with(/#{system_roles[0].description}/) # rol description
+        expect(subject).to receive(:VSpacing).with(2) # separator
+        expect(subject).to receive(:RadioButton).with(anything, system_roles[1].label) # rol label
+        expect(subject).to receive(:Label).with(/#{system_roles[1].description}/) # rol description
+        subject.dialog_content
+      end
+    end
+  end
 end


### PR DESCRIPTION
This PR improves how role buttons are distributed in textmode. The point is that adding a role didn't fit in the 80x25 mode. Now separation is adjusted and, if roles don't fit even without separation, the description and the introductory text will be omitted.

## All roles fit
![selection-role-dialog-textmode-fit](https://cloud.githubusercontent.com/assets/15836/23960681/8b7a52f6-09a0-11e7-85c2-a4a31dcf4545.png)

## All roles still fit
![selection-role-dialog-textmode-still-fit](https://cloud.githubusercontent.com/assets/15836/23960692/92491f54-09a0-11e7-993d-26807589e2bf.png)

## Not enough space
![selection-role-dialog-textmode-out-of-space](https://cloud.githubusercontent.com/assets/15836/23960702/995cf7c0-09a0-11e7-92f0-2aa704ea40dd.png)

If roles don't fit even without the description, the [introductory text will be also omitted](https://github.com/yast/yast-installation/pull/537/files#diff-b9cac9df8ec348a3c81180e449f766e8R234).

## More than 80x25
![selection-role-dialog-textmode-plenty-of-space](https://cloud.githubusercontent.com/assets/15836/23960715/a340b894-09a0-11e7-92ff-83ac34fdbaa6.png)

## Graphic mode
![selection-role-dialog-graphic-mode](https://cloud.githubusercontent.com/assets/15836/23962268/7476f618-09a5-11e7-945e-5b1083206c43.png)