### PR TITLE
The installer extension documentation

### DIFF
--- a/doc/installer_extension.md
+++ b/doc/installer_extension.md
@@ -1,0 +1,105 @@
+# Modifying the Installation by an Add-on
+
+The YaST installation workflow can be easily changed or extended by add-ons.
+
+
+## Configuring the Add-on Metadata
+
+The product package on the add-on medium (usually a `*-release` RPM package)
+should link to a package providing the installer extension by a
+`Provides: installerextension(<package_name>)` dependency.
+
+That referenced package should contain the `installation.xml` file and optionally
+the `y2update.tgz` archive.
+
+## Modifying the Installation Defaults
+
+### Adding a New System Role
+
+This `installation.xml` example adds a new role:
+
+```xml
+<?xml version="1.0"?>
+<!DOCTYPE productDefines SYSTEM "/usr/share/YaST2/control/control.rng">
+<productDefines xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+    <!-- defines the gettext domain for the messages in this XML -->
+    <textdomain>testing-extension-control</textdomain>
+
+    <update>
+        <system_roles>
+          <insert_system_roles config:type="list">
+            <insert_system_role>
+              <system_roles config:type="list">
+                <system_role>
+                  <id>mail_role</id>
+                  <software>
+                    <default_patterns>base Minimal mail_server</default_patterns>
+                  </software>
+                </system_role>
+              </system_roles>
+            </insert_system_role>
+          </insert_system_roles>
+        </system_roles>
+    </update>
+
+    <!-- Don't forget to add the texts -->
+    <texts>
+      <mail_role>
+        <label>Testing Extension Role</label>
+      </mail_role>
+      <mail_role_description>
+        <label>• Mail server software pattern
+• This is just an example!</label>
+      </mail_role_description>
+    </texts>
+</productDefines>
+```
+
+In this case it just configures the default software patterns but it is possible
+to define any other defaults like partitioning, firewall status, etc...
+
+## Adding New YaST Code
+
+The installer extension package can optionally contain `y2update.tgz` archive
+with executable YaST code in the usual directory structure. E.g. the clients are
+read from the `/usr/share/YaST2/clients` directory in the archive.
+
+### YaST Client Example
+
+Here is a trivial example client which just displays a pop up dialog with a message:
+
+```ruby
+module Yast
+  class TestingExtensionClient < Client
+    include Yast::I18n
+
+    def initialize
+      textdomain "testing-extension"
+      Yast.import("Popup")
+    end
+
+    def main
+      # TRANSLATORS: A popup message
+      Popup.Message(_("This is an inserted step from the testing-extension addon."\
+        "\n\nPress OK to continue."))
+      return :auto
+    end
+  end
+end
+
+Yast::TestingExtensionClient.new.main
+```
+
+Save this file to `usr/share/YaST2/clients/inst_testing_extension.rb` file (including
+the directory structure) and then create the `y2update.tgz` archive with command
+
+```
+tar cfzv y2update.tgz usr
+```
+
+and include this file in the installer extension RPM package.
+
+# An Example Add-on
+
+A minimalistic but complete example add-on can be found in the [YaST:extension](
+https://build.opensuse.org/project/show/YaST:extension) OBS project.

--- a/doc/installer_extension.md
+++ b/doc/installer_extension.md
@@ -2,7 +2,6 @@
 
 The YaST installation workflow can be easily changed or extended by add-ons.
 
-
 ## Configuring the Add-on Metadata
 
 The product package on the add-on medium (usually a `*-release` RPM package)
@@ -12,9 +11,74 @@ should link to a package providing the installer extension by a
 That referenced package should contain the `installation.xml` file and optionally
 the `y2update.tgz` archive.
 
-## Modifying the Installation Defaults
+## Modifying the Installation Workflow
 
-### Adding a New System Role
+This `installation.xml` example adds a new step into installtion workflow and
+also in add-on installation in an installed system:
+
+```xml
+<?xml version="1.0"?>
+<!DOCTYPE productDefines SYSTEM "/usr/share/YaST2/control/control.rng">
+<productDefines xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+    <!-- defines the gettext domain for the messages in this XML -->
+    <textdomain>testing-extension-control</textdomain>
+
+    <workflows config:type="list">
+        <!-- Installation on a running system -->
+        <workflow>
+            <stage>normal</stage>
+            <mode>installation,normal</mode>
+
+            <defaults>
+                <enable_back>no</enable_back>
+                <enable_next>no</enable_next>
+            </defaults>
+
+            <modules config:type="list">
+                <module>
+                    <label>Extension Configuration</label>
+                    <name>testing_extension</name>
+                    <execute>inst_testing_extension</execute>
+                    <enable_back>yes</enable_back>
+                    <enable_next>yes</enable_next>
+                </module>
+            </modules>
+        </workflow>
+    </workflows>
+
+    <update>
+        <workflows config:type="list">
+            <workflow>
+                <defaults>
+                    <enable_back>yes</enable_back>
+                    <enable_next>yes</enable_next>
+                </defaults>
+
+                <!-- First Stage Installation -->
+                <stage>initial</stage>
+                <mode>installation</mode>
+
+                <!-- Insert new steps -->
+                <insert_modules config:type="list">
+                    <insert_module>
+                        <before>system_role</before>
+                        <modules config:type="list">
+                            <module>
+                                <label>Extension Configuration</label>
+                                <name>testing_extension</name>
+                                <!-- Name of the executed file without the .rb extension -->
+                                <execute>inst_testing_extension</execute>
+                            </module>
+                        </modules>
+                    </insert_module>
+                </insert_modules>
+            </workflow>
+        </workflows>
+    </update>
+</productDefines>
+```
+
+## Adding a New System Role
 
 This `installation.xml` example adds a new role:
 
@@ -97,9 +161,20 @@ the directory structure) and then create the `y2update.tgz` archive with command
 tar cfzv y2update.tgz usr
 ```
 
-and include this file in the installer extension RPM package.
+and include it in the installer extension RPM package.
 
 # An Example Add-on
 
 A minimalistic but complete example add-on can be found in the [YaST:extension](
 https://build.opensuse.org/project/show/YaST:extension) OBS project.
+
+The [testing-extension-release package](
+https://build.opensuse.org/package/show/YaST:extension/testing-extension-release)
+links to the installer extension using `Provides:
+installerextension(testing-extension-installation)`.
+
+The [testing-extension-installation package](
+https://build.opensuse.org/package/show/YaST:extension/testing-extension-installation)
+contains the `installation.xml` file which defines an additional role and
+adds a new installation step before the role selection dialog. The new installation
+step is defined in the included `y2update.tgz` file.

--- a/doc/installer_extension.md
+++ b/doc/installer_extension.md
@@ -11,12 +11,15 @@ should link to a package providing the installer extension by a
 That referenced package should contain the `installation.xml` file and optionally
 the `y2update.tgz` archive in the root directory. The package should never
 be installed into system, it is used just to provide the temporary data for the
-installer. After the installation is finished the files are not need anymore.
+installer. After the installation is finished the files are not needed anymore.
 
 ## Modifying the Installation Workflow
 
-This `installation.xml` example adds a new step into installtion workflow and
-also in add-on installation in an installed system:
+This `installation.xml` example has two parts:
+
+- The first part adds a new step into the add-on installation workflow in already
+  installed system.
+- The second part adds a new step into the initial installation workflow.
 
 ```xml
 <?xml version="1.0"?>

--- a/doc/installer_extension.md
+++ b/doc/installer_extension.md
@@ -9,7 +9,9 @@ should link to a package providing the installer extension by a
 `Provides: installerextension(<package_name>)` dependency.
 
 That referenced package should contain the `installation.xml` file and optionally
-the `y2update.tgz` archive.
+the `y2update.tgz` archive in the root directory. The package should never
+be installed into system, it is used just to provide the temporary data for the
+installer. After the installation is finished the files are not need anymore.
 
 ## Modifying the Installation Workflow
 
@@ -18,11 +20,7 @@ also in add-on installation in an installed system:
 
 ```xml
 <?xml version="1.0"?>
-<!DOCTYPE productDefines SYSTEM "/usr/share/YaST2/control/control.rng">
 <productDefines xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
-    <!-- defines the gettext domain for the messages in this XML -->
-    <textdomain>testing-extension-control</textdomain>
-
     <workflows config:type="list">
         <!-- Installation on a running system -->
         <workflow>
@@ -84,11 +82,7 @@ This `installation.xml` example adds a new role:
 
 ```xml
 <?xml version="1.0"?>
-<!DOCTYPE productDefines SYSTEM "/usr/share/YaST2/control/control.rng">
 <productDefines xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
-    <!-- defines the gettext domain for the messages in this XML -->
-    <textdomain>testing-extension-control</textdomain>
-
     <update>
         <system_roles>
           <insert_system_roles config:type="list">
@@ -120,7 +114,7 @@ This `installation.xml` example adds a new role:
 ```
 
 In this case it just configures the default software patterns but it is possible
-to define any other defaults like partitioning, firewall status, etc...
+to define any other defaults like partitioning, etc...
 
 ## Adding New YaST Code
 
@@ -178,3 +172,6 @@ https://build.opensuse.org/package/show/YaST:extension/testing-extension-install
 contains the `installation.xml` file which defines an additional role and
 adds a new installation step before the role selection dialog. The new installation
 step is defined in the included `y2update.tgz` file.
+
+![Example Extension](
+https://cloud.githubusercontent.com/assets/907998/24544095/48e4e2d0-1602-11e7-8081-4c35bcf90069.gif)


### PR DESCRIPTION
## A New Documentation for the Installer Extension

*Note: review the [rendered document](https://github.com/yast/yast-installation/blob/installation_xml_doc/doc/installer_extension.md), it looks much better than a plain MD file...*

- The installer allows adding new steps
![add_on_extension_new_step](https://cloud.githubusercontent.com/assets/907998/24543338/916b63e2-15ff-11e7-9d55-86f57989bdd9.png)

- Or adding new roles
![add_on_extension_new_role](https://cloud.githubusercontent.com/assets/907998/24543345/9801f93c-15ff-11e7-84e2-7338a18b9016.png)


# Blog

The YaST installer already allows extending the installation work flow by add-on extensions. However, this was only supported for the SUSE tag repositories (ISO installation media). That means that online repositories, which normally use RPM-MD data format, could not be used with feature.

This sprint we extended the support also for the other repository formats (basically any repository format supported by libzypp). The original limitation was caused by the fact that the other repository types do not support other files except the RPM packages.

To overcome this limitation we now support packaging the installer extension files into a standard RPM package which can be provided by any repository type.

The implementation is [documented](https://github.com/yast/yast-installation/blob/master/doc/installer_extension.md) and there is an example [YaST:extension](https://build.opensuse.org/project/show/YaST:extension) OBS project with an example extension.

![add_on_extension](https://cloud.githubusercontent.com/assets/907998/24544095/48e4e2d0-1602-11e7-8081-4c35bcf90069.gif)
