### PR TITLE
Remove yast-slp dependency

### DIFF
--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -93,10 +93,6 @@ Requires:	yast2-users >= 3.1.57.4
 BuildRequires:	yast2-country >= 3.1.33.1
 Requires:	yast2-country >= 3.1.33.1
 
-# SlpServices.find
-Requires:      yast2-slp
-BuildRequires: yast2-slp
-
 # Pkg::SourceProvideSignedFile Pkg::SourceProvideDigestedFile
 # pkg-bindings are not directly required
 Conflicts:	yast2-pkg-bindings < 2.17.25


### PR DESCRIPTION
The yast2-slp dependency was introduced in dde4be57. As the code have been moved to CaaSP, this dependency is not needed anymore.