### PR TITLE
Don't crash in case of an invalid linuxrc registration url is provided (bsc#1035908)

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon May  8 13:17:17 UTC 2017 - knut.anderssen@suse.com
+
+- Don't crash if the regurl provided by linuxrc is invalid using
+  the one provided by the control file as fallback (bsc#1035908).
+- 3.2.39
+
+-------------------------------------------------------------------
 Wed Apr 26 15:03:33 UTC 2017 - igonzalezsosa@suse.com
 
 - Move CaaSP specific code to yast2-caasp package

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation
-Version:        3.2.38
+Version:        3.2.39
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/installation/clients/inst_update_installer.rb
+++ b/src/lib/installation/clients/inst_update_installer.rb
@@ -176,6 +176,10 @@ module Yast
       @update_repositories = update_repositories_finder.updates
       log.info("self-update repositories are #{@update_repositories.inspect}")
       @update_repositories
+    rescue ::Registration::InvalidURL
+      Yast::Popup.Error(_("The registration URL provided is not valid.\n" \
+                          "Skipping installer update.\n"))
+      @update_repositories = []
     end
 
     # Return the custom self-update URL
@@ -311,6 +315,7 @@ module Yast
       require "registration/url_helpers"
       require "registration/registration"
       require "registration/ui/regservice_selection_dialog"
+      require "registration/exceptions"
       @require_registration_libraries = true
     rescue LoadError
       log.info "yast2-registration is not available"

--- a/src/lib/installation/update_repositories_finder.rb
+++ b/src/lib/installation/update_repositories_finder.rb
@@ -124,7 +124,13 @@ module Installation
     #
     # @return [Array<URI>,false] self-update URLs or false in case of error
     def update_urls_from_connect
-      url = registration_url
+      begin
+        url = registration_url
+      rescue URI::InvalidURIError => e
+        log.error("Custom registration url is wrong, URI failed with: #{e.message}")
+        return []
+      end
+
       return [] if url == :cancel
 
       custom_regserver = url != :scc

--- a/src/lib/installation/update_repositories_finder.rb
+++ b/src/lib/installation/update_repositories_finder.rb
@@ -25,7 +25,6 @@ Yast.import "Linuxrc"
 Yast.import "Mode"
 Yast.import "Profile"
 Yast.import "ProductFeatures"
-Yast.import "Report"
 
 module Installation
   # This class find repositories to be used by the self-update feature.
@@ -126,9 +125,8 @@ module Installation
     def update_urls_from_connect
       begin
         url = registration_url
-      rescue URI::InvalidURIError => e
-        log.error("Custom registration url is wrong, URI failed with: #{e.message}")
-        return []
+      rescue URI::InvalidURIError
+        raise ::Registration::InvalidURL
       end
 
       return [] if url == :cancel
@@ -260,24 +258,6 @@ module Installation
       ::Registration::Storage::Config.instance.import(
         Yast::Profile.current.fetch("suse_register", {})
       )
-    end
-
-    # Display a warning message about using the default update URL from
-    # control.xml when the registration server does not return any URL or fails.
-    # In AutoYaST mode the dialog is closed after a timeout.
-    def display_fallback_warning
-      # TRANSLATORS: error message
-      msg = _("<p>Cannot obtain the installer update repository URL\n" \
-        "from the registration server.</p>")
-
-      if update_url_from_control
-        # TRANSLATORS: part of an error message, %s is the default repository
-        # URL from control.xml
-        msg += _("<p>The default URL %s will be used.<p>") % update_url_from_control
-      end
-
-      # display the message in a RichText widget to wrap long lines
-      Yast::Report.LongWarning(msg)
     end
 
     # Runs a block of code handling errors


### PR DESCRIPTION
An exception will be raised now when a wrong registration url is provided and an error will be reported:

![skippingupdates](https://cloud.githubusercontent.com/assets/7056681/25891891/8bb072c8-356a-11e7-9960-e6aab7ec81af.png)

This is in case of not asking about a new one.