### PR TITLE
Early check of wrong urls allowing to fix them (bsc#1035908)

### DIFF
--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -76,8 +76,8 @@ Requires:       yast2-proxy
 # writing settings in the first installation stage.
 Requires: yast2-services-manager >= 3.2.1
 
-# Network service setup moved into yast2-network
-Requires: yast2-network >= 3.1.143
+## Moved inst_install_inf from yast2-network to this package
+Requires: yast2-network >= 3.2.25
 
 # Augeas lenses
 Requires:       augeas-lenses

--- a/src/clients/inst_install_inf.rb
+++ b/src/clients/inst_install_inf.rb
@@ -1,0 +1,3 @@
+require "installation/clients/inst_install_inf"
+
+Yast::InstInstallInfClient.new.main

--- a/src/lib/installation/clients/inst_install_inf.rb
+++ b/src/lib/installation/clients/inst_install_inf.rb
@@ -1,0 +1,90 @@
+require "yast"
+require "network/install_inf_convertor"
+require "installation/dialogs/registration_url_dialog"
+
+module Yast
+  class InstInstallInfClient < Client
+    VALID_URL_SCHEMES = ["http", "https"].freeze
+
+    include Yast::Logger
+    include Yast::I18n
+
+    Yast.import "Linuxrc"
+    Yast.import "Wizard"
+    Yast.import "WFM"
+
+    def main
+      textdomain "installation"
+
+      InstallInfConvertor.instance.write_netconfig unless Mode.auto
+
+      Yast::Wizard.CreateDialog if separate_wizard_needed?
+
+      regurl = Linuxrc.InstallInf("regurl")
+
+      fix_regurl(regurl) if need_fix?(regurl)
+
+      Yast::Wizard.CloseDialog if separate_wizard_needed?
+
+      :next
+    end
+
+  private
+
+    def need_fix?(url)
+      url && !valid_url?(url)
+    end
+
+    def fix_regurl(regurl)
+      while regurl && !valid_url?(regurl)
+        new_url = ::Installation::RegistrationURLDialog.new(regurl).run
+        case new_url
+        when :abort
+          if Popup.YesNo(_("If you decide to abort, the custom URL\n" \
+                         "will be completely removed.\n\n Really abort?\n"))
+            regurl = nil
+          end
+        when "",
+          regurl = nil
+        else
+          regurl = new_url
+        end
+      end
+
+      regurl ? replace_install_inf("regurl", regurl) : delete_install_inf("regurl")
+    end
+
+    # Check if the given URI is valid or not
+    #
+    # @params url [String]
+    # @return [Boolean]
+    def valid_url?(url)
+      VALID_URL_SCHEMES.include?(URI(url).scheme)
+    rescue URI::InvalidURIError
+      false
+    end
+
+    # Returns whether we need/ed to create new UI Wizard
+    def separate_wizard_needed?
+      Yast::Mode.normal
+    end
+
+    def replace_install_inf(key, value)
+      # Updating new URI in /etc/install.inf (bnc#963487)
+      # SCR.Write does not work in inst-sys here.
+      WFM.Execute(
+        path(".local.bash"),
+        "sed -i \'/#{key}:/c\\#{key}: #{value}\' /etc/install.inf"
+      )
+    end
+
+    def delete_install_inf(key)
+      # Deleting URI in /etc/install.inf (bnc#963487)
+      # SCR.Write does not work in inst-sys here.
+      WFM.Execute(
+        path(".local.bash"),
+        "sed -i \'/#{key}:/d\' /etc/install.inf"
+      )
+    end
+  end
+end

--- a/src/lib/installation/clients/inst_install_inf.rb
+++ b/src/lib/installation/clients/inst_install_inf.rb
@@ -22,7 +22,10 @@ module Yast
 
       regurl = Linuxrc.InstallInf("regurl")
 
-      fix_regurl(regurl) if need_fix?(regurl)
+      if need_fix?(regurl)
+        fix_regurl!(regurl)
+        Linuxrc.ResetInstallInf
+      end
 
       Yast::Wizard.CloseDialog if separate_wizard_needed?
 
@@ -35,7 +38,7 @@ module Yast
       url && !valid_url?(url)
     end
 
-    def fix_regurl(regurl)
+    def fix_regurl!(regurl)
       while regurl && !valid_url?(regurl)
         new_url = ::Installation::RegistrationURLDialog.new(regurl).run
         case new_url

--- a/src/lib/installation/clients/inst_install_inf.rb
+++ b/src/lib/installation/clients/inst_install_inf.rb
@@ -42,9 +42,10 @@ module Yast
       while regurl && !valid_url?(regurl)
         new_url = ::Installation::RegistrationURLDialog.new(regurl).run
         case new_url
-        when :abort
-          if Popup.YesNo(_("If you decide to abort, the custom URL\n" \
-                         "will be completely removed.\n\n Really abort?\n"))
+        when :cancel
+          if Popup.YesNo(_("If you decide to cancel, the custom URL\n" \
+                         "will be completelly ignored.\n\n" \
+                         "Really cancel URL modification?"))
             regurl = nil
           end
         when "",

--- a/src/lib/installation/clients/inst_update_installer.rb
+++ b/src/lib/installation/clients/inst_update_installer.rb
@@ -177,9 +177,9 @@ module Yast
       log.info("self-update repositories are #{@update_repositories.inspect}")
       @update_repositories
 
-    rescue RegistrationURLError
-      Yast::Popup.Error(_("The registration URL provided is not valid.\n" \
-                          "Skipping installer update.\n"))
+    rescue ::Installation::RegistrationURLError
+      Report.Error(_("The registration URL provided is not valid.\n" \
+                  "Skipping installer update.\n"))
       @update_repositories = []
     end
 

--- a/src/lib/installation/clients/inst_update_installer.rb
+++ b/src/lib/installation/clients/inst_update_installer.rb
@@ -176,7 +176,8 @@ module Yast
       @update_repositories = update_repositories_finder.updates
       log.info("self-update repositories are #{@update_repositories.inspect}")
       @update_repositories
-    rescue ::Registration::InvalidURL
+
+    rescue RegistrationURLError
       Yast::Popup.Error(_("The registration URL provided is not valid.\n" \
                           "Skipping installer update.\n"))
       @update_repositories = []

--- a/src/lib/installation/dialogs/registration_url_dialog.rb
+++ b/src/lib/installation/dialogs/registration_url_dialog.rb
@@ -25,6 +25,7 @@ require "installation/dialogs/url_dialog"
 module Installation
   class RegistrationURLDialog < ::Installation::URLDialog
     def help_text
+      # TRANSLATORS: Help text alerting the user about a invalid url
       _("<p>\n" \
         "The registration url provided in the command line is not valid.\n" \
         "Check that you entered it correctly and try again.\n" \

--- a/src/lib/installation/dialogs/registration_url_dialog.rb
+++ b/src/lib/installation/dialogs/registration_url_dialog.rb
@@ -1,0 +1,42 @@
+# encoding: utf-8
+
+# ------------------------------------------------------------------------------
+# Copyright (c) 2017 SUSE LLC
+#
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of version 2 of the GNU General Public License as published by the
+# Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, contact SUSE.
+#
+# To contact SUSE about this file by physical or electronic mail, you may find
+# current contact information at www.suse.com.
+# ------------------------------------------------------------------------------
+
+require "yast"
+require "installation/dialogs/url_dialog"
+
+module Installation
+  class RegistrationURLDialog < ::Installation::URLDialog
+    def help_text
+      _("<p>\n" \
+        "The registration url provided in the command line is not valid.\n" \
+        "Check that you entered it correctly and try again.\n" \
+        "</p>")
+    end
+
+    def entry_label
+      _("Registration URL")
+    end
+
+    def dialog_title
+      _("Registration URL")
+    end
+  end
+end

--- a/src/lib/installation/dialogs/registration_url_dialog.rb
+++ b/src/lib/installation/dialogs/registration_url_dialog.rb
@@ -27,7 +27,7 @@ module Installation
     def help_text
       # TRANSLATORS: Help text alerting the user about a invalid url
       _("<p>\n" \
-        "The registration url provided in the command line is not valid.\n" \
+        "The registration URL provided in the command line is not valid.\n" \
         "Check that you entered it correctly and try again.\n" \
         "</p>")
     end

--- a/src/lib/installation/dialogs/url_dialog.rb
+++ b/src/lib/installation/dialogs/url_dialog.rb
@@ -123,9 +123,7 @@ module Installation
     #
     # @see help_text
     def show_help?
-      return true if !help_text.empty?
-
-      false
+      !help_text.empty?
     end
 
     # Determines wether the dialog title is shown
@@ -134,9 +132,7 @@ module Installation
     #
     # @see dialog_title
     def show_heading?
-      return true if !dialog_title.empty?
-
-      false
+      !dialog_title.empty?
     end
   end
 end

--- a/src/lib/installation/dialogs/url_dialog.rb
+++ b/src/lib/installation/dialogs/url_dialog.rb
@@ -40,43 +40,50 @@ module Installation
     # @param [String] original Original value
     # @return [String] new value
     def dialog_content
-      HBox(
-        HWeight(30, RichText(help_text)),
-        HStretch(),
-        HSpacing(1),
-        HWeight(
-          70,
-          VBox(
-            Heading(dialog_title),
-            VSpacing(1),
-            VStretch(),
-            MinWidth(60,
-              Left(TextEntry(Id(:uri), entry_label, @url))),
-            VSpacing(1),
-            VStretch(),
-            HBox(
-              PushButton(Id(:retry), Opt(:default), Yast::Label.RetryButton),
-              PushButton(Id(:abort), Yast::Label.AbortButton)
-            )
-          )
+      VBox(
+        Heading(dialog_title),
+        show_help? ? RichText(help_text) : Empty(),
+        VSpacing(1),
+        VStretch(),
+        MinWidth(60,
+          Left(TextEntry(Id(:uri), entry_label, @url))),
+        VSpacing(1),
+        VStretch(),
+        HBox(
+          PushButton(Id(:ok), Opt(:default), ok_label),
+          PushButton(Id(:cancel), cancel_label)
         )
       )
     end
 
-    def retry_handler
+    def ok_handler
       @url = Yast::UI.QueryWidget(Id(:uri), :Value)
       finish_dialog(@url)
     end
 
-    def abort_handler
-      finish_dialog(:abort)
+    def cancel_handler
+      finish_dialog(:cancel)
     end
 
-    # Help text that will be displayed at the left of the dialog
+    def ok_label
+      Yast::Label.OKButton
+    end
+
+    def cancel_label
+      Yast::Label.CancelButton
+    end
+
+    # Help text that will be displayed above the url entry
     #
     # @return [String]
     def help_text
       ""
+    end
+
+    def show_help?
+      return true if help_text && help_text != ""
+
+      false
     end
 
     # Heading title for the dialog

--- a/src/lib/installation/dialogs/url_dialog.rb
+++ b/src/lib/installation/dialogs/url_dialog.rb
@@ -138,6 +138,5 @@ module Installation
 
       false
     end
-
   end
 end

--- a/src/lib/installation/dialogs/url_dialog.rb
+++ b/src/lib/installation/dialogs/url_dialog.rb
@@ -1,0 +1,96 @@
+# encoding: utf-8
+
+# ------------------------------------------------------------------------------
+# Copyright (c) 2017 SUSE LLC
+#
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of version 2 of the GNU General Public License as published by the
+# Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, contact SUSE.
+#
+# To contact SUSE about this file by physical or electronic mail, you may find
+# current contact information at www.suse.com.
+# ------------------------------------------------------------------------------
+
+require "yast"
+require "ui/dialog"
+
+# FIXME: move to yast2
+# (This dialog is based in ProfileSourceDialog)
+module Installation
+  class URLDialog < UI::Dialog
+    include Yast::I18n
+    include Yast::UIShortcuts
+
+    attr_accessor :url
+
+    def initialize(url)
+      @url = url
+    end
+
+    # Shows a dialog when the given url is wrong
+    #
+    # @param [String] original Original value
+    # @return [String] new value
+    def dialog_content
+      HBox(
+        HWeight(30, RichText(help_text)),
+        HStretch(),
+        HSpacing(1),
+        HWeight(
+          70,
+          VBox(
+            Heading(dialog_title),
+            VSpacing(1),
+            VStretch(),
+            MinWidth(60,
+              Left(TextEntry(Id(:uri), entry_label, @url))),
+            VSpacing(1),
+            VStretch(),
+            HBox(
+              PushButton(Id(:retry), Opt(:default), Yast::Label.RetryButton),
+              PushButton(Id(:abort), Yast::Label.AbortButton)
+            )
+          )
+        )
+      )
+    end
+
+    def retry_handler
+      @url = Yast::UI.QueryWidget(Id(:uri), :Value)
+      finish_dialog(@url)
+    end
+
+    def abort_handler
+      finish_dialog(:abort)
+    end
+
+    # Help text that will be displayed at the left of the dialog
+    #
+    # @return [String]
+    def help_text
+      ""
+    end
+
+    # Heading title for the dialog
+    #
+    # @return [String]
+    def dialog_title
+      ""
+    end
+
+    # Text label for the url entry
+    #
+    # @return [String]
+    def entry_label
+      ""
+    end
+  end
+end

--- a/src/lib/installation/dialogs/url_dialog.rb
+++ b/src/lib/installation/dialogs/url_dialog.rb
@@ -22,15 +22,29 @@
 require "yast"
 require "ui/dialog"
 
-# FIXME: move to yast2
-# (This dialog is based in ProfileSourceDialog)
 module Installation
+  # A subclass of UI::Dialog which provides a common dialog to edit an url. It
+  # is composed by two buttons to confirm and cancel the edition, a dialog
+  # heading and a help text.
+  #
+  # @example simple url location dialog
+  #
+  #   class ExampleURLDialog < UI::URLDialog
+  #     def entry_label
+  #       "Example URL"
+  #     end
+  #   end
   class URLDialog < UI::Dialog
     include Yast::I18n
     include Yast::UIShortcuts
 
     attr_accessor :url
 
+    # Constructor
+    #
+    # The dialog text entry will be filled with the url given
+    #
+    # @param url [String]
     def initialize(url)
       @url = url
     end
@@ -41,7 +55,7 @@ module Installation
     # @return [String] new value
     def dialog_content
       VBox(
-        Heading(dialog_title),
+        show_heading? ? Heading(dialog_title) : Empty(),
         show_help? ? RichText(help_text) : Empty(),
         VSpacing(1),
         VStretch(),
@@ -56,11 +70,18 @@ module Installation
       )
     end
 
+    # Handler for the :ok button which queries the value of the URL entry and
+    # finish the dialog returning the value of it
+    #
+    # @return  [String] the value of the url text entry
     def ok_handler
       @url = Yast::UI.QueryWidget(Id(:uri), :Value)
       finish_dialog(@url)
     end
 
+    # Handler for the :cancel button wich finishes the dialog and returns :cancel
+    #
+    # @return [Symbol] :cancel
     def cancel_handler
       finish_dialog(:cancel)
     end
@@ -80,12 +101,6 @@ module Installation
       ""
     end
 
-    def show_help?
-      return true if help_text && help_text != ""
-
-      false
-    end
-
     # Heading title for the dialog
     #
     # @return [String]
@@ -99,5 +114,30 @@ module Installation
     def entry_label
       ""
     end
+
+  private
+
+    # Determines wether the help text is shown
+    #
+    # @return [Boolean] true if the help text is not empty
+    #
+    # @see help_text
+    def show_help?
+      return true if !help_text.empty?
+
+      false
+    end
+
+    # Determines wether the dialog title is shown
+    #
+    # @return [Boolean] true if the dialog title is not empty
+    #
+    # @see dialog_title
+    def show_heading?
+      return true if !dialog_title.empty?
+
+      false
+    end
+
   end
 end

--- a/src/lib/installation/update_repositories_finder.rb
+++ b/src/lib/installation/update_repositories_finder.rb
@@ -27,6 +27,9 @@ Yast.import "Profile"
 Yast.import "ProductFeatures"
 
 module Installation
+  # Invalid registration URL error
+  class RegistrationURLError < URI::InvalidURIError; end
+
   # This class find repositories to be used by the self-update feature.
   class UpdateRepositoriesFinder
     include Yast::Logger
@@ -126,7 +129,7 @@ module Installation
       begin
         url = registration_url
       rescue URI::InvalidURIError
-        raise ::Registration::InvalidURL
+        raise RegistrationURLError
       end
 
       return [] if url == :cancel

--- a/test/inst_install_inf_test.rb
+++ b/test/inst_install_inf_test.rb
@@ -1,0 +1,46 @@
+#!/usr/bin/env rspec
+
+require_relative "test_helper"
+require "installation/clients/inst_install_inf"
+
+describe Yast::InstInstallInfClient do
+
+  before do
+    allow(Yast::InstallInfConvertor.instance).to receive(:write_netconfig)
+    allow(Yast::SCR).to receive(:Read)
+    allow(Yast::SCR).to receive(:Write)
+    allow(Yast::Linuxrc).to receive(:InstallInf)
+    allow(Yast::Mode).to receive(:auto)
+  end
+
+  describe "#main" do
+    it "writes the network configuration given by linuxrc" do
+      expect(Yast::InstallInfConvertor.instance).to receive(:write_netconfig)
+
+      subject.main
+    end
+
+    context "when a regurl is provided by linuxrc" do
+      let(:invalid_url) { "http://wrong_url{}.com" }
+      let(:valid_url) { "http://scc.custom.com" }
+
+      it "allows the user to fix it it's invalid" do
+        expect(Yast::Linuxrc).to receive(:InstallInf).with("regurl").and_return(invalid_url)
+        expect(subject).to receive(:fix_regurl!).with(invalid_url)
+
+        subject.main
+      end
+
+      it "does nothing with the url in case of valid" do
+        expect(Yast::Linuxrc).to receive(:InstallInf).with("regurl").and_return(valid_url)
+        expect(subject).to_not receive(:fix_regurl!)
+
+        subject.main
+      end
+    end
+
+    it "returns :next" do
+      expect(subject.main).to eq(:next)
+    end
+  end
+end

--- a/test/inst_install_inf_test.rb
+++ b/test/inst_install_inf_test.rb
@@ -22,7 +22,7 @@ describe Yast::InstInstallInfClient do
 
     context "when a regurl is provided by linuxrc" do
       let(:invalid_url) { "http://wrong_url{}.com" }
-      let(:valid_url) { "http://scc.custom.com" }
+      let(:valid_url) { "https://scc.custom.com" }
 
       it "allows the user to fix it it's invalid" do
         expect(Yast::Linuxrc).to receive(:InstallInf).with("regurl").and_return(invalid_url)
@@ -31,7 +31,7 @@ describe Yast::InstInstallInfClient do
         subject.main
       end
 
-      it "does nothing with the url in case of valid" do
+      it "does nothing with the URL in case of valid" do
         expect(Yast::Linuxrc).to receive(:InstallInf).with("regurl").and_return(valid_url)
         expect(subject).to_not receive(:fix_regurl!)
 

--- a/test/lib/update_repositories_finder_test.rb
+++ b/test/lib/update_repositories_finder_test.rb
@@ -3,6 +3,7 @@
 require_relative "../test_helper"
 require_relative "../support/fake_registration"
 require "installation/update_repositories_finder"
+require "uri"
 
 Yast.import "Linuxrc"
 
@@ -211,10 +212,10 @@ describe Installation::UpdateRepositoriesFinder do
         context "when a invalid regurl was specified via Linuxrc" do
           let(:regurl) { "http://wrong{}regserver.example.net" }
 
-          it "raises an Registration::InvalidURL exception" do
+          it "raises an RegistrationURLError exception" do
             expect(registration_class).not_to receive(:new).with(regurl)
 
-            expect { finder.updates }.to raise_error(::Registration::InvalidURL)
+            expect { finder.updates }.to raise_error(Installation::RegistrationURLError)
           end
         end
       end

--- a/test/lib/update_repositories_finder_test.rb
+++ b/test/lib/update_repositories_finder_test.rb
@@ -211,17 +211,10 @@ describe Installation::UpdateRepositoriesFinder do
         context "when a invalid regurl was specified via Linuxrc" do
           let(:regurl) { "http://wrong{}regserver.example.net" }
 
-          it "does not ask the SCC server for the updates URLs" do
+          it "raises an Registration::InvalidURL exception" do
             expect(registration_class).not_to receive(:new).with(regurl)
-            expect(finder).to receive(:update_from_control)
 
-            finder.updates
-          end
-
-          it "falls back to use updates URL defined in the control file" do
-            expect(Installation::UpdateRepository).to receive(:new)
-              .with(URI(real_url_from_control), :default).and_return(repo)
-            expect(finder.updates).to eq([repo])
+            expect { finder.updates }.to raise_error(::Registration::InvalidURL)
           end
         end
       end

--- a/test/support/fake_registration.rb
+++ b/test/support/fake_registration.rb
@@ -16,3 +16,8 @@ module FakeConnectHelpers
     true
   end
 end
+
+class Registration
+  class InvalidURL < StandardError
+  end
+end

--- a/test/support/fake_registration.rb
+++ b/test/support/fake_registration.rb
@@ -16,8 +16,3 @@ module FakeConnectHelpers
     true
   end
 end
-
-class Registration
-  class InvalidURL < StandardError
-  end
-end


### PR DESCRIPTION
The idea is to reuse the network 'inst_install_inf' not just writing the hostname and proxy configuration but also checking wrong urls provided in the command line.

The new `::Installation::URLDialog` should be moved to yast-yast2 using the `UI` namespace instead of `Installation`

The current approach allows the user to fix the url, or nullify it in case of not fixed (abort).

![screenshot_sle12sp3_2017-05-10_09 52 09](https://cloud.githubusercontent.com/assets/7056681/25892352/13ae5478-356c-11e7-99a9-7815488c26ef.png)

In case of `AutoYast`, after discussed with @imobachgs seems that we should continue just reporting it to not block the installation..

![skippingupdates](https://cloud.githubusercontent.com/assets/7056681/25891891/8bb072c8-356a-11e7-9960-e6aab7ec81af.png)

In the registration step it will handle it just as a connection error, reporting it so no change is needed there.

![screenshot_sle12sp3_2017-05-08_14 50 16](https://cloud.githubusercontent.com/assets/7056681/25812580/aa66d7dc-340e-11e7-9f9b-c03ffaa44fe0.png)