### PR TITLE
Fixed push button label (bsc#1039988)

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon May 22 10:50:32 UTC 2017 - lslezak@suse.cz
+
+- Fixed push button label ("Configure Online Repositories")
+  (bsc#1039988)
+- 3.2.40
+
+-------------------------------------------------------------------
 Mon May  8 13:17:17 UTC 2017 - knut.anderssen@suse.com
 
 - Don't crash if the regurl provided by linuxrc is invalid using

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation
-Version:        3.2.39
+Version:        3.2.40
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/installation/widgets/online_repos.rb
+++ b/src/lib/installation/widgets/online_repos.rb
@@ -10,7 +10,8 @@ module Installation
       end
 
       def label
-        _("Configure On-line Repositories")
+        # TRANSLATORS: Push button label
+        _("Configure Online Repositories")
       end
 
       def handle


### PR DESCRIPTION
- Use `Configure Online Repositories` (without dash)
- See https://bugzilla.suse.com/show_bug.cgi?id=1039988
- 3.2.40