### PR TITLE
Add 'cwm/widget' requirement because of changes made for (boo#1039901)

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon May 29 08:37:19 UTC 2017 - knut.anderssen@suse.com
+
+- Added requirement of 'cwm/widget' in hiding_place as consequence
+  of changes made in CWM. (boo#1039901).
+- 3.2.41
+
+-------------------------------------------------------------------
 Mon May 22 10:50:32 UTC 2017 - lslezak@suse.cz
 
 - Fixed push button label ("Configure Online Repositories")

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation
-Version:        3.2.40
+Version:        3.2.41
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/installation/widgets/hiding_place.rb
+++ b/src/lib/installation/widgets/hiding_place.rb
@@ -20,9 +20,8 @@
 # ------------------------------------------------------------------------------
 
 require "yast"
+require "cwm/widget"
 require "installation/system_role"
-
-Yast.import "CWM"
 
 module Installation
   module Widgets


### PR DESCRIPTION
In this PR yast/yast-yast2#573, the requirement of "cwm/widget" was moved to a method probably because of some recursive dependency conflict. So I have replaced the import by a requirement.