### PR TITLE
Don't forget desktop selection (bsc#1033594)

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,9 +1,9 @@
 -------------------------------------------------------------------
 Tue May 31 21:47:24 UTC 2017 - knut.anderssen@suse.com
 
-- Don't lose the last desktop selection when online repositories is
-  called. (bsc#1033594)
-- Don't allow to continue without desktop selection. (bsc#1040884)
+- Do not lose the desktop selection when the online repositories is
+  pressed. (bsc#1033594)
+- Do not allow to continue without desktop selection. (bsc#1040884)
 - 3.2.43
 
 -------------------------------------------------------------------

--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue May 31 21:47:24 UTC 2017 - knut.anderssen@suse.com
+
+- Don't lose the last desktop selection when online repositories is
+  called. (bsc#1033594)
+- Don't allow to continue without desktop selection. (bsc#1040884)
+- 3.2.43
+
+-------------------------------------------------------------------
 Wed May 31 10:52:59 UTC 2017 - lslezak@suse.cz
 
 - Fixed path to the "adddir" command (it is /sbin instead of /etc)

--- a/src/lib/installation/widgets/system_roles_radio_buttons.rb
+++ b/src/lib/installation/widgets/system_roles_radio_buttons.rb
@@ -66,7 +66,7 @@ module Installation
       end
 
       def validate
-        return true if !value.to_s.empty?
+        return true if value
 
         # TRANSLATORS: Popup error requesting to choose some option.
         Yast::Popup.Error(_("You must choose some option before you continue."))

--- a/src/lib/installation/widgets/system_roles_radio_buttons.rb
+++ b/src/lib/installation/widgets/system_roles_radio_buttons.rb
@@ -39,8 +39,8 @@ module Installation
       alias_method :store_orig, :store
 
       def initialize
-        # We need to handle all the events because if not the current selection
-        # is lost when the widget is redrawn (bsc#1033594)
+        # We need to handle all the events because otherwise the current
+        # selection is lost when the widget is redrawn (bsc#1033594)
         self.handle_all_events = true
       end
 
@@ -69,7 +69,7 @@ module Installation
         return true if !value.to_s.empty?
 
         # TRANSLATORS: Popup error requesting to choose some option.
-        Yast::Popup.Error(_("You must choose some option before continue."))
+        Yast::Popup.Error(_("You must choose some option before you continue."))
 
         false
       end

--- a/src/lib/installation/widgets/system_roles_radio_buttons.rb
+++ b/src/lib/installation/widgets/system_roles_radio_buttons.rb
@@ -40,7 +40,8 @@ module Installation
 
       def initialize
         # We need to handle all the events because otherwise the current
-        # selection is lost when the widget is redrawn (bsc#1033594)
+        # selection is lost when the widget is redrawn.
+        # FIXME: It will not be needed once RadioButtons widget take care of it
         self.handle_all_events = true
       end
 

--- a/src/lib/installation/widgets/system_roles_radio_buttons.rb
+++ b/src/lib/installation/widgets/system_roles_radio_buttons.rb
@@ -37,6 +37,13 @@ module Installation
       include SystemRoleReader
 
       alias_method :store_orig, :store
+
+      def initialize
+        # We need to handle all the events because if not the current selection
+        # is lost when the widget is redrawn (bsc#1033594)
+        self.handle_all_events = true
+      end
+
       def store
         # set flag to show custom patterns only if custom role selected
         CustomPatterns.show = value == "custom"
@@ -50,6 +57,21 @@ module Installation
           # forward and backward, it can be changed
           Yast::DefaultDesktop.ForceReinit
         end
+      end
+
+      def handle
+        ::Installation::SystemRole.select(value)
+
+        nil
+      end
+
+      def validate
+        return true if !value.to_s.empty?
+
+        # TRANSLATORS: Popup error requesting to choose some option.
+        Yast::Popup.Error(_("You must choose some option before continue."))
+
+        false
       end
 
       def vspacing

--- a/test/lib/widgets/system_roles_radio_buttons_test.rb
+++ b/test/lib/widgets/system_roles_radio_buttons_test.rb
@@ -36,9 +36,9 @@ describe Installation::Widgets::SystemRolesRadioButtons do
 
   describe "#handle" do
     it "selects the system role according to the current value" do
-      allow(Installation::SystemRole).to receive(:select)
+      expect(Installation::SystemRole).to receive(:select).with(default)
 
-      expect(widget.handle).to eql(default)
+      widget.handle
     end
 
     it "returns nil" do

--- a/test/lib/widgets/system_roles_radio_buttons_test.rb
+++ b/test/lib/widgets/system_roles_radio_buttons_test.rb
@@ -36,13 +36,13 @@ describe Installation::Widgets::SystemRolesRadioButtons do
 
   describe "#handle" do
     it "selects the system role according to the current value" do
-      expect(Installation::SystemRole).to receive(:select).with(default)
+      allow(Installation::SystemRole).to receive(:select)
 
-      widget.handle
+      expect(widget.handle).to eql(default)
     end
 
     it "returns nil" do
-      expect(Installation::SystemRole).to receive(:select).with(default)
+      allow(Installation::SystemRole).to receive(:select)
 
       expect(widget.handle).to eql(nil)
     end
@@ -50,7 +50,7 @@ describe Installation::Widgets::SystemRolesRadioButtons do
 
   describe "#init" do
     it "initializes the widget with the current system role" do
-      expect(Installation::SystemRole).to receive(:current).and_return("server")
+      allow(Installation::SystemRole).to receive(:current).and_return("server")
       expect(widget).to receive(:value=).with("server")
 
       expect(widget.init).to eql("server")
@@ -64,7 +64,7 @@ describe Installation::Widgets::SystemRolesRadioButtons do
       allow(widget).to receive(:value).and_return(value)
     end
 
-    context "when the value of the widget is nil" do
+    context "when no option has been selected" do
       it "opens an error popup" do
         expect(Yast::Popup).to receive(:Error)
 
@@ -84,11 +84,11 @@ describe Installation::Widgets::SystemRolesRadioButtons do
       it "opens an error popup" do
         expect(Yast::Popup).to receive(:Error)
 
-        expect(widget.validate).to eql(false)
+        widget.validate
       end
 
       it "returns false" do
-        expect(Yast::Popup).to receive(:Error)
+        allow(Yast::Popup).to receive(:Error)
 
         expect(widget.validate).to eql(false)
       end

--- a/test/lib/widgets/system_roles_radio_buttons_test.rb
+++ b/test/lib/widgets/system_roles_radio_buttons_test.rb
@@ -78,22 +78,6 @@ describe Installation::Widgets::SystemRolesRadioButtons do
       end
     end
 
-    context "when the value of the widget is an empty string" do
-      let(:value) { "" }
-
-      it "opens an error popup" do
-        expect(Yast::Popup).to receive(:Error)
-
-        widget.validate
-      end
-
-      it "returns false" do
-        allow(Yast::Popup).to receive(:Error)
-
-        expect(widget.validate).to eql(false)
-      end
-    end
-
     context "when the widget has some value selected" do
       let(:value) { "server" }
 

--- a/test/lib/widgets/system_roles_radio_buttons_test.rb
+++ b/test/lib/widgets/system_roles_radio_buttons_test.rb
@@ -5,6 +5,7 @@ require "installation/widgets/system_roles_radio_buttons"
 
 describe Installation::Widgets::SystemRolesRadioButtons do
   subject(:widget) { Installation::Widgets::SystemRolesRadioButtons.new }
+  let(:default) { nil }
 
   describe "#store" do
     before do
@@ -29,6 +30,77 @@ describe Installation::Widgets::SystemRolesRadioButtons do
         expect(Installation::CustomPatterns).to receive(:show=).with(false)
         expect(Yast::DefaultDesktop).to receive(:ForceReinit)
         widget.store
+      end
+    end
+  end
+
+  describe "#handle" do
+    it "selects the system role according to the current value" do
+      expect(Installation::SystemRole).to receive(:select).with(default)
+
+      widget.handle
+    end
+
+    it "returns nil" do
+      expect(Installation::SystemRole).to receive(:select).with(default)
+
+      expect(widget.handle).to eql(nil)
+    end
+  end
+
+  describe "#init" do
+    it "initializes the widget with the current system role" do
+      expect(Installation::SystemRole).to receive(:current).and_return("server")
+      expect(widget).to receive(:value=).with("server")
+
+      expect(widget.init).to eql("server")
+    end
+  end
+
+  describe "#validate" do
+    let(:value) { nil }
+
+    before do
+      allow(widget).to receive(:value).and_return(value)
+    end
+
+    context "when the value of the widget is nil" do
+      it "opens an error popup" do
+        expect(Yast::Popup).to receive(:Error)
+
+        expect(widget.validate).to eql(false)
+      end
+
+      it "returns false" do
+        expect(Yast::Popup).to receive(:Error)
+
+        expect(widget.validate).to eql(false)
+      end
+    end
+
+    context "when the value of the widget is an empty string" do
+      let(:value) { "" }
+
+      it "opens an error popup" do
+        expect(Yast::Popup).to receive(:Error)
+
+        expect(widget.validate).to eql(false)
+      end
+
+      it "returns false" do
+        expect(Yast::Popup).to receive(:Error)
+
+        expect(widget.validate).to eql(false)
+      end
+    end
+
+    context "when the widget has some value selected" do
+      let(:value) { "server" }
+
+      it "returns true" do
+        expect(Yast::Popup).to_not receive(:Error)
+
+        expect(widget.validate).to eql(true)
       end
     end
   end


### PR DESCRIPTION
We have fixed two different issues,

First of all it fixes the lost of desktop selection when the "Online repositories" is clicked (bsc#1033594)

And secondly we now requires at least the selection of one desktop to continue with the installation fixing (bsc#1040884)

Trello card: https://trello.com/c/40ZZxO2D/

A new card has been created to take care or handle by default the events not only of the main widget but also the buttons below it https://trello.com/c/0gsQI7Gf