### PR TITLE
Install the yast2-registration package only in SLE (bsc#1043122)

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Jun 19 07:03:16 UTC 2017 - lslezak@suse.cz
+
+- install the yast2-registration package only in SLE (bsc#1043122)
+- 3.2.45
+
+-------------------------------------------------------------------
 Thu Jun  1 12:58:03 CEST 2017 - schubi@suse.de
 
 - "custom" roles: Initialize pattern selection screen with settings

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -131,7 +131,11 @@ Requires:	coreutils
 # BNC 446533, /sbin/lspci called but not installed
 Requires:	pciutils
 
+# install the registration module only in SLE (bsc#1043122)
+%if !0%{?is_opensuse}
 Recommends:	yast2-registration
+%endif
+
 Recommends:	yast2-online-update
 Recommends:	yast2-firewall
 Recommends:	release-notes


### PR DESCRIPTION
See https://bugzilla.suse.com/show_bug.cgi?id=1043122

- 3.2.45

Avoid accidentally installing the package in openSUSE.