### PR TITLE
Enable using home partition as generic separate data partition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
     - sudo apt-get install libaugeas-dev libxml2-dev
     # end of augeas install
     - wget https://raw.githubusercontent.com/yast/yast-devtools/master/travis-tools/travis_setup.sh
-    - sh ./travis_setup.sh -p "rake yast2-devtools yast2-testsuite yast2-core-dev yast2 yast2-network yast2-transfer yast2-users yast2-country yast2-slp libaugeas-dev" -g "rspec:3.3.0 yast-rake gettext rubocop:0.41.2 coveralls:0.8.19 cheetah abstract_method cfa"
+    - sh ./travis_setup.sh -p "rake yast2-devtools yast2-testsuite yast2-core-dev yast2 yast2-network yast2-transfer yast2-users yast2-country yast2-slp libaugeas-dev gettext" -g "rspec:3.3.0 yast-rake gettext rubocop:0.41.2 coveralls:0.8.19 cheetah abstract_method cfa"
 script:
     - rake check:syntax
     - rake check:pot

--- a/doc/control-file.md
+++ b/doc/control-file.md
@@ -1065,6 +1065,19 @@ parameters in this control.xml file) will be used as for "/home", just for
 (with its own subvolume if Btrfs is used). Notice that you cannot have both a
 separate "/home" and a separate "/data" with this mechanism.
 
+**NOTICE:**
+
+_This "home_path" parameter is a hack, introduced to make a feature possible
+against all odds at the very latest stages of CaaSP 1.0 development without
+breaking the entire storage proposal logic._
+
+It is strongly advised not to use this in general. This documentation only
+exists for the sake of completeness, not as an encouragement to use this
+parameter.
+
+Please contact the YaST team if you feel you need this.
+
+
 
 #### Subvolumes
 

--- a/doc/control-file.md
+++ b/doc/control-file.md
@@ -1054,6 +1054,17 @@ property should be set to _true_. This works only for Btrfs root
 filesystems. If another root filesystem type is chosen, this might fail
 silently.
 
+*home_path* (string) is the path (mount point) for the home
+partition or volume, if any is created (depending on *try_separate_home*,
+*limit_try_home* and available disk space).
+
+By default, this is "/home". This can be set to another value like "/data", in
+which case the same partitioning proposal logic (including the other _home_
+parameters in this control.xml file) will be used as for "/home", just for
+"/data" as the mount point, and "/home" will be on the root filesystem again
+(with its own subvolume if Btrfs is used). Notice that you cannot have both a
+separate "/home" and a separate "/data" with this mechanism.
+
 
 #### Subvolumes
 

--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Jun 26 11:11:19 CEST 2017 - shundhammer@suse.de
+
+- Allow different mount point for home partition (Fate#323532)
+- 3.1.217.35
+
+-------------------------------------------------------------------
 Wed Apr 26 15:03:33 UTC 2017 - igonzalezsosa@suse.com
 
 - Move CaaSP specific code to yast2-caasp package

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation
-Version:        3.1.217.34
+Version:        3.1.217.35
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
https://trello.com/c/iOESXcm7/624-5-caasp-hack-separate-data-partition

_XML format documentation for the new parameter_

CaaSP needs a separate partition for /var/lib/docker in the storage proposal, and since this would be very tricky to add to the existing proposal mechanism in yast-storage-old, we suggested to repurpose the home partition for that; it can now get another mount point from control.xml. The mechanics and the other parameters in control.xml (size etc.) are still taken from the home partition / volume.

