### PR TITLE
skip writing of desktop for opensuse (bsc#1030873)

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -2,7 +2,7 @@
 Thu Jun 29 08:40:43 UTC 2017 - jreidinger@suse.com
 
 - openSUSE only: when custom role is selected in desktop selection
-  keep default value in /etc/sysconfig/windowmanager
+  keep default value in /etc/sysconfig/windowmanager (bsc#1030873)
 - 3.2.46
 
 -------------------------------------------------------------------

--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Jun 29 08:40:43 UTC 2017 - jreidinger@suse.com
+
+- openSUSE only: when custom role is selected in desktop selection
+  keep default value in /etc/sysconfig/windowmanager
+- 3.2.46
+
+-------------------------------------------------------------------
 Mon Jun 19 07:03:16 UTC 2017 - lslezak@suse.cz
 
 - install the yast2-registration package only in SLE (bsc#1043122)

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation
-Version:        3.2.45
+Version:        3.2.46
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/installation/clients/desktop_finish.rb
+++ b/src/lib/installation/clients/desktop_finish.rb
@@ -43,6 +43,7 @@ module Yast
       Yast.import "Mode"
       Yast.import "ProductFeatures"
       Yast.import "FileUtils"
+      Yast.import "Product"
       Yast.import "String"
 
       @ret = nil
@@ -80,6 +81,12 @@ module Yast
 
           @selected_desktop = DefaultDesktop.Desktop
           Builtins.y2milestone("Selected desktop: %1", @selected_desktop)
+
+          if @selected_desktop.nil? && Product.short_name =~ /opensuse/i
+            Builtins.y2milestone("no desktop set, skipping.")
+            Builtins.y2milestone("desktop_finish finished")
+            return nil
+          end
 
           if @selected_desktop.nil? || @selected_desktop == ""
             @selected_desktop = "gnome"


### PR DESCRIPTION
tested manually and it do what expected ( keep /etc/sysconfig/windowmanager ) untouched, but it still do not work, so more discussion in bnc is needed.

trello: https://trello.com/c/Nesqzfs9/1053-3-dont-write-default-desktop-if-none-selected-opensuse-only
bsc: https://bugzilla.opensuse.org/show_bug.cgi?id=1030873