### PR TITLE
Adapt to cleaned Y2Storage::StorageManager API

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Jul 25 15:08:59 UTC 2017 - ancor@suse.com
+
+- storage-ng: adapted to the new Y2Storage::StorageManager API
+  and improved probing and activation of storage devices.
+
+-------------------------------------------------------------------
 Wed Jul  5 12:06:33 CEST 2017 - shundhammer@suse.de
 
 - Merged master to storage-ng branch

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -44,9 +44,9 @@ BuildRequires:  rubygem(yast-rake)
 # CWM::RadioButtons#vspacing
 BuildRequires: yast2 >= 3.2.20
 
-# Y2Storage
-BuildRequires: yast2-storage-ng >= 0.1.1
-Requires:      yast2-storage-ng >= 0.1.18
+# New Y2Storage::StorageManager API
+BuildRequires: yast2-storage-ng >= 0.1.32
+Requires:      yast2-storage-ng >= 0.1.32
 
 # AutoinstSoftware.SavePackageSelection()
 Requires:       autoyast2-installation >= 3.1.105

--- a/src/lib/installation/clients/inst_system_analysis.rb
+++ b/src/lib/installation/clients/inst_system_analysis.rb
@@ -123,12 +123,12 @@ module Yast
         actions_functions << fun_ref(method(:ActionLoadModules), "boolean ()")
 =end
 
-        actions_todo      << _("Probe hard disks")
-        actions_doing     << _("Probing hard disks...")
-        actions_functions << fun_ref(method(:ActionHDDProbe), "boolean ()")
-
         WFM.CallFunction("inst_features", [])
       end
+
+      actions_todo      << _("Probe hard disks")
+      actions_doing     << _("Probing hard disks...")
+      actions_functions << fun_ref(method(:ActionHDDProbe), "boolean ()")
 
 # storage-ng
 =begin
@@ -245,7 +245,14 @@ module Yast
     #				  Hard disks
     # --------------------------------------------------------------
     def ActionHDDProbe
-      devicegraph = Y2Storage::StorageManager.instance.y2storage_probed
+      storage = Y2Storage::StorageManager.instance
+      # Activate high level devices (RAID, multipath, LVM, encryption...)
+      # and (re)probe. Reprobing ensures we don't bring bug#806454 back and
+      # invalidates cached proposal, so we we are also safe from bug#865579.
+      storage.activate
+      storage.probe
+
+      devicegraph = storage.probed
 
       # additonal error when HW was not found
       drivers_info = _(
@@ -352,12 +359,6 @@ module Yast
       # FATE #300421: Import ssh keys from previous installations
       # FATE #120103: Import Users From Existing Partition
       # FATE #302980: Simplified user config during installation
-      #	All needs to be known before configuring users
-      # ReReadTargetMap is needed to fix bug #806454
-      Storage.ReReadTargetMap()
-      # SetPartProposalFirst is needed to fix bug #865579
-      Storage.SetPartProposalFirst(true)
-
       Builtins.y2milestone("PreInstallFunctions -- start --")
       WFM.CallFunction("inst_pre_install", [])
       Builtins.y2milestone("PreInstallFunctions -- end --")

--- a/src/lib/installation/clients/inst_system_analysis.rb
+++ b/src/lib/installation/clients/inst_system_analysis.rb
@@ -248,7 +248,7 @@ module Yast
       storage = Y2Storage::StorageManager.instance
       # Activate high level devices (RAID, multipath, LVM, encryption...)
       # and (re)probe. Reprobing ensures we don't bring bug#806454 back and
-      # invalidates cached proposal, so we we are also safe from bug#865579.
+      # invalidates cached proposal, so we are also safe from bug#865579.
       storage.activate
       storage.probe
 

--- a/test/inst_disks_activate_test.rb
+++ b/test/inst_disks_activate_test.rb
@@ -17,7 +17,6 @@ describe Yast::InstDisksActivateClient do
       allow(Yast::Arch).to receive(:s390).and_return(s390)
       allow(Yast::GetInstArgs).to receive(:going_back) { going_back }
 
-      Y2Storage::StorageManager.create_test_instance
       allow(Y2Storage::StorageManager.instance).to receive(:probe)
 
       stub_const("Yast::Packages", double(GetBaseSourceID: 0))


### PR DESCRIPTION
To be merged right after merging yast2-storage-ng 0.1.32.

Breakage in tests is expected until the new API is merged in storage-ng