### PR TITLE
Make fs type for home and root configurable

### DIFF
--- a/doc/control-file.md
+++ b/doc/control-file.md
@@ -1054,6 +1054,12 @@ property should be set to _true_. This works only for Btrfs root
 filesystems. If another root filesystem type is chosen, this might fail
 silently.
 
+*root_fs* (string, default _btrfs_) is the filesystem type for the root
+ partition.
+
+*home_fs* (string, default _xfs_) is the filesystem type for the home
+ partition.
+
 *home_path* (string) is the path (mount point) for the home
 partition or volume, if any is created (depending on *try_separate_home*,
 *limit_try_home* and available disk space).

--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Aug 16 11:59:37 CEST 2017 - shundhammer@suse.de
+
+- Documentation for configurable filesystem type for home and root
+  in control.xml (bsc#1051762)
+- 3.1.217.36
+
+-------------------------------------------------------------------
 Mon Jun 26 11:11:19 CEST 2017 - shundhammer@suse.de
 
 - Allow different mount point for home partition (Fate#323532)

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation
-Version:        3.1.217.35
+Version:        3.1.217.36
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
https://trello.com/c/SQQ1x4Bg/691-5-suse-caasp-10-p2-1051762-docker-on-xfs-by-default

This makes the filesystem type for both home and root in the storage proposal configurable: When home_fs is configurable, root_fs is only a heartbeat away, and it's trivial to add it at the same time.

Test against SLE-12 SP3:

![home_fs_sp3](https://user-images.githubusercontent.com/11538225/29368427-f4cd0af0-829f-11e7-8823-0e48cf0f162a.png)
