### PR TITLE
Move product selection to welcome

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,4 @@ script:
   # the "yast-travis-ruby" script is included in the base yastdevel/ruby image
   # see https://github.com/yast/docker-yast-ruby/blob/master/yast-travis-ruby
   - docker run -it -e TRAVIS=1 -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" yast-installation-image yast-travis-ruby
+  - docker run -it yast-installation-image rake check:doc

--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Sep  1 12:43:42 UTC 2017 - igonzalezsosa@suse.com
+
+- On multi-product installation medias, the product selection
+  happens in the welcome screen (fate#322276)
+- 3.3.10
+
+-------------------------------------------------------------------
 Wed Aug 30 07:28:06 UTC 2017 - gsouza@suse.com
 
 - Show README.BETA if it exists (bsc#1047060)

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation
-Version:        3.3.9
+Version:        3.3.10
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -41,8 +41,9 @@ BuildRequires:  yast2-xml
 BuildRequires:  rubygem(rspec)
 BuildRequires:  rubygem(yast-rake)
 
-# CWM::RadioButtons#vspacing
-BuildRequires: yast2 >= 3.2.20
+# Yast::WorkflowManager#merge_product_workflow
+# CWM.show support to disable buttons
+BuildRequires: yast2 >= 4.0.2
 
 # New Y2Storage::StorageManager API
 BuildRequires: yast2-storage-ng >= 0.1.32
@@ -51,8 +52,9 @@ Requires:      yast2-storage-ng >= 0.1.32
 # AutoinstSoftware.SavePackageSelection()
 Requires:       autoyast2-installation >= 3.1.105
 
-# PackageDownloader and PackageExtractor
-Requires:       yast2 >= 3.2.19
+# Yast::WorkflowManager#merge_product_workflow
+# CWM.show support to disable buttons
+Requires:       yast2 >= 4.0.2
 
 # Language::GetLanguageItems and other API
 # Language::Set (handles downloading the translation extensions)
@@ -64,8 +66,8 @@ Requires:	yast2-pkg-bindings >= 3.1.33
 # Mouse-related scripts moved to yast2-mouse
 Conflicts:	yast2-mouse < 2.18.0
 
-# Y2Packager::Product
-Requires:	yast2-packager >= 3.3.7
+# Y2Packager::Widgets::ProductLicense
+Requires:	yast2-packager >= 3.3.8
 
 # FIXME: some code present in this package still depends on the old yast2-storage
 # and will break without this dependency. That's acceptable at this point of the

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -67,7 +67,7 @@ Requires:	yast2-pkg-bindings >= 3.1.33
 Conflicts:	yast2-mouse < 2.18.0
 
 # Y2Packager::Widgets::ProductLicense
-Requires:	yast2-packager >= 3.3.8
+Requires:	yast2-packager >= 3.3.9
 
 # FIXME: some code present in this package still depends on the old yast2-storage
 # and will break without this dependency. That's acceptable at this point of the

--- a/src/lib/installation/clients/inst_complex_welcome.rb
+++ b/src/lib/installation/clients/inst_complex_welcome.rb
@@ -116,18 +116,9 @@ module Yast
       Yast::ProductControl.RunFrom(Yast::ProductControl.CurrentStep + 1, true)
     end
 
-    def retranslate_yast
-      Console.SelectFont(Language.language)
-      # no yast translation for nn_NO, use nb_NO as a backup
-      # FIXME: remove the hack, please
-      if Language.language == "nn_NO"
-        log.info "Nynorsk not translated, using Bokm\u00E5l"
-        Language.WfmSetGivenLanguage("nb_NO")
-      else
-        Language.WfmSetLanguage
-      end
-    end
-
+    # Change YaST interface language
+    #
+    # @see #retranslate_yast
     def change_language
       if Language.SwitchToEnglishIfNeeded(true)
         log.debug "UI switched to en_US"
@@ -137,6 +128,7 @@ module Yast
       end
     end
 
+    # Set up system according to user choices
     def setup_final_choice
       # Language has been set already.
       # On first run store users decision as default.
@@ -163,6 +155,18 @@ module Yast
       end
 
       log.info "Language: '#{Language.language}', system encoding '#{WFM.GetEncoding}'"
+    end
+
+    def retranslate_yast
+      Console.SelectFont(Language.language)
+      # no yast translation for nn_NO, use nb_NO as a backup
+      # FIXME: remove the hack, please
+      if Language.language == "nn_NO"
+        log.info "Nynorsk not translated, using Bokm\u00E5l"
+        Language.WfmSetGivenLanguage("nb_NO")
+      else
+        Language.WfmSetLanguage
+      end
     end
 
     # Return the list of base products

--- a/src/lib/installation/clients/inst_complex_welcome.rb
+++ b/src/lib/installation/clients/inst_complex_welcome.rb
@@ -22,7 +22,21 @@
 require "yaml"
 require "fileutils"
 require "yast"
+require "installation/dialogs/complex_welcome"
 require "y2packager/product"
+
+Yast.import "Console"
+Yast.import "FileUtils"
+Yast.import "GetInstArgs"
+Yast.import "InstShowInfo"
+Yast.import "Keyboard"
+Yast.import "Language"
+Yast.import "Mode"
+Yast.import "Pkg"
+Yast.import "Popup"
+Yast.import "Stage"
+Yast.import "Timezone"
+Yast.import "Wizard"
 
 module Yast
   # This client shows main dialog for choosing the language,
@@ -31,14 +45,8 @@ module Yast
     include Yast::Logger
     extend Yast::I18n
 
-    HEADING_TEXT = N_("Language, Keyboard and License Agreement")
     BETA_FILE = "/README.BETA".freeze
-
     def main
-      Yast.import "Mode"
-      Yast.import "InstShowInfo"
-      Yast.import "FileUtils"
-
       if FileUtils.Exists(BETA_FILE) && !GetInstArgs.going_back
         InstShowInfo.show_info_txt(BETA_FILE)
       end
@@ -46,153 +54,50 @@ module Yast
       # bnc#206706
       return :auto if Mode.autoinst
 
-      import_modules
-
       textdomain "installation"
 
-      @license_id = Ops.get(Pkg.SourceGetCurrent(true), 0, 0)
+      Yast::Wizard.EnableAbortButton
 
-      # ------------------------------------- main part of the client -----------
-
-      @argmap = GetInstArgs.argmap
-
-      @language = Language.language
-      @keyboard = ""
-
-      InstData.product_license_accepted ||= false
-
-      # ----------------------------------------------------------------------
-      # Build dialog
-      # ----------------------------------------------------------------------
-      # Screen title for the first interactive dialog
-      initialize_dialog
-
-      event_loop
+      loop do
+        dialog_result = ::Installation::Dialogs::ComplexWelcome.run(
+          products, disable_buttons: disable_buttons
+        )
+        result = handle_ret(dialog_result)
+        return result if result
+      end
     end
 
-    def import_modules
-      Yast.import "Console"
-      Yast.import "GetInstArgs"
-      Yast.import "InstData"
-      Yast.import "Keyboard"
-      Yast.import "Label"
-      Yast.import "Language"
-      Yast.import "Pkg"
-      Yast.import "Popup"
-      Yast.import "ProductLicense"
-      Yast.import "Report"
-      Yast.import "Stage"
-      Yast.import "Timezone"
-      Yast.import "UI"
-      Yast.import "Wizard"
-      Yast.import "ProductFeatures"
+    def handle_ret(ret)
+      case ret
+      when :language_changed
+        return if Mode.config
+        change_language
+        :again
+
+      when :keyboard_changed
+        Keyboard.user_decision = true
+        nil
+
+      when :abort
+        return :abort if Yast::Popup.ConfirmAbort(:painless)
+        nil
+
+      when :next
+        return nil unless Language.CheckIncompleteTranslation(@language)
+        setup_final_choice
+        merge_and_run_workflow if selected_product
+        :next
+
+      else
+        ret
+      end
     end
 
   private
 
-    def event_loop
-      loop do
-        ret = UI.UserInput
-        log.info "UserInput() returned #{ret}"
-
-        case ret
-        when :back
-          return ret
-        when :abort, :cancel
-          next unless Popup.ConfirmAbort(:painless)
-          Wizard.RestoreNextButton
-          return :abort
-        when :keyboard
-          read_ui_state
-          Keyboard.Set(@keyboard)
-          Keyboard.user_decision = true
-        when :license_agreement
-          read_ui_state
-        when :language
-          next if Mode.config
-          read_ui_state
-          change_language
-          Wizard.SetFocusToNextButton
-          return :again
-        when :next
-          next if Mode.config
-          read_ui_state
-
-          # BNC #448598
-          # Check whether the license has been accepted only if required
-          if license_required? && !license_accepted?
-            warn_license_required
-            next
-          end
-
-          next if !Language.CheckIncompleteTranslation(@language)
-
-          Language.CheckLanguagesSupport(@language) if Stage.initial
-
-          setup_final_choice
-
-          return :next
-        when :show_fulscreen_license
-          UI.OpenDialog(all_licenses_dialog)
-          ProductLicense.ShowFullScreenLicenseInInstallation(
-            :full_screen_license_rp,
-            @license_id
-          )
-          UI.CloseDialog
-        else
-          raise "unknown input '#{ret}'"
-        end
-      end
-    end
-
-    def initialize_license
-      # Showing empty license to prevent from redrawing the dialog when
-      # the translated license is found and shown to the user
-      UI.ReplaceWidget(Id(:base_license_rp), RichText(""))
-
-      # If accepting the license is required, show the check-box
-      if license_required?
-        UI.ReplaceWidget(:license_checkbox_rp, license_agreement_checkbox)
-        UI.ChangeWidget(Id(:license_agreement), :Value, InstData.product_license_accepted)
-      end
-
-      log.info "Acceptance needed: #{@id} => #{license_required?}"
-    end
-
-    def initialize_keyboard_selection
-      if Keyboard.user_decision
-        UI.ChangeWidget(Id(:keyboard), :Value, Keyboard.current_kbd)
-      else
-        kbd = Keyboard.GetKeyboardForLanguage(@language, "english-us")
-        UI.ChangeWidget(Id(:keyboard), :Value, kbd)
-        Keyboard.Set(kbd)
-      end
-    end
-
-    def initialize_widgets
-      UI.BusyCursor
-
-      initialize_license if show_license?
-
-      Wizard.EnableAbortButton
-
-      UI.ChangeWidget(Id(:language), :Value, @language)
-
-      initialize_keyboard_selection
-
-      # In case of going back, Release Notes button may be shown, retranslate it (bnc#886660)
-      # Assure that relnotes have been downloaded first
-      if !InstData.release_notes.empty?
-        Wizard.ShowReleaseNotesButton(_("Re&lease Notes..."), "rel_notes")
-      end
-
-      # This also shows content of the info file if it exists, so it has to be
-      # called at the very end
-      show_license if show_license?
-
-      UI.SetFocus(Id(:language))
-
-      UI.NormalCursor
+    def merge_and_run_workflow
+      Yast::WorkflowManager.merge_product_workflow(selected_product)
+      Yast::ProductControl.RunFrom(Yast::ProductControl.CurrentStep + 1, true)
     end
 
     def help_text
@@ -233,105 +138,11 @@ module Yast
         )
     end
 
-    def all_licenses_dialog
-      # As long as possible
-      # bnc #385257
-      HBox(
-        VSpacing(text_mode? ? 21 : 25),
-        VBox(
-          Left(
-            # TRANSLATORS: dialog caption
-            Heading(_("License Agreement"))
-          ),
-          VSpacing(text_mode? ? 0.1 : 0.5),
-          HSpacing(82),
-          HBox(
-            VStretch(),
-            ReplacePoint(Id(:full_screen_license_rp), Opt(:vstretch), Empty())
-          ),
-          ButtonBox(
-            PushButton(
-              Id(:close),
-              Opt(:okButton, :default, :key_F10),
-              Label.OKButton
-            )
-          )
-        )
-      )
-    end
-
-    def language_selection
-      ComboBox(
-        Id(:language),
-        Opt(:notify, :hstretch),
-        # combo box label
-        _("&Language"),
-        Language.GetLanguageItems(:first_screen)
-      )
-    end
-
-    def keyboard_selection
-      ComboBox(
-        Id(:keyboard),
-        Opt(:notify, :hstretch),
-        # combo box label
-        _("&Keyboard Layout"),
-        Keyboard.GetKeyboardItems
-      )
-    end
-
-    # BNC #448598
-    # License sometimes doesn't need to be manually accepted
-    def license_agreement_checkbox
-      Left(
-        CheckBox(
-          # bnc #359456
-          Id(:license_agreement),
-          Opt(:notify),
-          # TRANSLATORS: check-box
-          _("I &Agree to the License Terms."),
-          InstData.product_license_accepted
-        )
-      )
-    end
-
-    # Determines whether the license was accepted or not
-    #
-    # It relies in the value of the :license_agreement widget.
-    #
-    # @return [Boolean] true if license was accepted; false otherwise.
-    def license_accepted?
-      read_ui_state
-      InstData.product_license_accepted
-    end
-
-    # Determines whether the license is required or not
-    #
-    # @return [Boolean] true if license is required; false otherwise.
-    def license_required?
-      return false unless show_license?
-      return @license_required unless @license_required.nil?
-      @license_required = (selected_product && selected_product.license_confirmation_required?) ||
-        ProductLicense.AcceptanceNeeded(@license_id.to_s)
-    end
-
-    # Report error about missing license acceptance
-    def warn_license_required
-      UI.SetFocus(Id(:license_agreement))
-      Report.Message(_("You must accept the license to install this product"))
-    end
-
-    def read_ui_state
-      @language = UI.QueryWidget(Id(:language), :Value)
-      @keyboard = UI.QueryWidget(Id(:keyboard), :Value)
-      InstData.product_license_accepted = UI.QueryWidget(Id(:license_agreement), :Value)
-    end
-
     def retranslate_yast
-      Console.SelectFont(@language)
+      Console.SelectFont(Language.language)
       # no yast translation for nn_NO, use nb_NO as a backup
       # FIXME: remove the hack, please
-      if @language == "nn_NO"
+      if Language.language == "nn_NO"
         log.info "Nynorsk not translated, using Bokm\u00E5l"
         Language.WfmSetGivenLanguage("nb_NO")
       else
@@ -340,15 +151,6 @@ module Yast
     end
 
     def change_language
-      return if @language == Language.language
-
-      log.info "Language changed from #{Language.language} to #{@language}"
-      Timezone.ResetZonemap
-
-      # Set it in the Language module.
-      Language.Set(@language)
-      Language.languages = Language.RemoveSuffix(@language)
-
       if Language.SwitchToEnglishIfNeeded(true)
         log.debug "UI switched to en_US"
       else
@@ -358,14 +160,12 @@ module Yast
     end
 
     def setup_final_choice
-      Keyboard.Set(@keyboard)
-
       # Language has been set already.
       # On first run store users decision as default.
       log.info "Resetting to default language"
       Language.SetDefault
 
-      Timezone.SetTimezoneForLanguage(@language)
+      Timezone.SetTimezoneForLanguage(Language.language)
 
       if !Stage.initial && !Mode.update
         # save settings (rest is saved in LanguageWrite)
@@ -375,8 +175,8 @@ module Yast
 
       # Bugzilla #354133
       log.info "Adjusting package and text locale to #{@language}"
-      Pkg.SetPackageLocale(@language)
-      Pkg.SetTextLocale(@language)
+      Pkg.SetPackageLocale(Language.language)
+      Pkg.SetTextLocale(Language.language)
 
       # In case of normal installation, solver run will follow without this explicit call
       if Mode.live_installation && Language.PackagesModified
@@ -384,120 +184,7 @@ module Yast
         Language.PackagesInit(selected_languages)
       end
 
-      selected_product.license_confirmation = true if selected_product
-
-      log.info "Language: '#{@language}', system encoding '#{WFM.GetEncoding}'"
-    end
-
-    def text_mode?
-      return @text_mode unless @text_mode.nil?
-
-      @text_mode = UI.TextMode
-    end
-
-    # Showing where the EULA will be installed
-    def license_location
-      file_location = ProductFeatures.GetStringFeature(
-        "globals",
-        "base_product_license_directory"
-      )
-      if file_location.nil?
-        Empty()
-      else
-        Left(
-          ReplacePoint(
-            Id(:license_location),
-            Label(
-              # TRANSLATORS: addition license information
-              # %1 is replaced with the filename. Please keep
-              # the translation VERY short.
-              _("EULA location in the installed system: %s") %
-                file_location
-            )
-          )
-        )
-      end
-    end
-
-    def dialog_content
-      # this type of contents will be shown only for initial installation dialog
-      VBox(
-        VWeight(1, VStretch()),
-        Left(
-          HBox(
-            HWeight(1, Left(language_selection)),
-            HSpacing(3),
-            HWeight(1, Left(keyboard_selection))
-          )
-        ),
-        Left(
-          HBox(
-            HWeight(1, HStretch()),
-            HSpacing(3),
-            HWeight(1, Left(InputField(Id(:keyboard_test), Opt(:hstretch), _("K&eyboard Test"))))
-          )
-        ),
-        show_license? ? license_agreement_content : Empty(),
-        VWeight(1, VStretch())
-      )
-    end
-
-    def products
-      Y2Packager::Product.available_base_products
-    end
-
-    def license_agreement_content
-      VWeight(
-        30,
-        Left(
-          HSquash(
-            VBox(
-              HBox(
-                Left(Label(Opt(:boldFont), _("License Agreement"))),
-                HStretch()
-              ),
-              # bnc #438100
-              HSquash(
-                MinWidth(
-                  # BNC #607135
-                  text_mode? ? 85 : 106,
-                  Left(ReplacePoint(Id(:base_license_rp), Opt(:hstretch), Empty()))
-                )
-              ),
-              VSpacing(text_mode? ? 0.5 : 1),
-              HBox(
-                license_location
-              ),
-              VSpacing(text_mode? ? 0.1 : 0.5),
-              MinHeight(
-                1,
-                HBox(
-                  # Will be replaced with license checkbox if required
-                  ReplacePoint(Id(:license_checkbox_rp), Empty()),
-                  HStretch(),
-                  PushButton(
-                    Id(:show_fulscreen_license),
-                    # TRANSLATORS: button label
-                    _("License &Translations...")
-                  )
-                )
-              )
-            )
-          )
-        )
-      )
-    end
-
-    def initialize_dialog
-      Wizard.SetContents(
-        _(HEADING_TEXT),
-        dialog_content,
-        help_text,
-        GetInstArgs.argmap.fetch("enable_back", true),
-        GetInstArgs.argmap.fetch("enable_next", true)
-      )
-
-      initialize_widgets
+      log.info "Language: '#{Language.language}', system encoding '#{WFM.GetEncoding}'"
     end
 
     # Return the list of base products
@@ -507,33 +194,19 @@ module Yast
       @products ||= Y2Packager::Product.available_base_products
     end
 
-    # Determine the selected product
+    # Convenience method to find out the selected base product
     #
-    # @return [Y2Packager::Product]
-    # @see Y2Packager::Product.selected_base
+    # @return [Y2Packager::Product] Selected base product
     def selected_product
-      @selected_product ||= Y2Packager::Product.selected_base
+      Y2Packager::Product.selected_base
     end
 
-    # Determine whether the license should be shown
+    # Buttons to disable according to GetInstArgs
     #
-    # * If a base product is already selected, the license should be shown.
-    # * If no products are detected, show the license.
-    #
-    # @return [Boolean] A license should be shown
-    def show_license?
-      !selected_product.nil? || products.empty?
-    end
-
-    # Show the license
-    #
-    # It will try to obtain the license from libzypp (using Y2Packager::Product#license).
-    # Otherwise, it will fallback to the old license.tar.gz tarball.
-    def show_license
-      if selected_product && selected_product.license?
-        UI.ReplaceWidget(Id(:base_license_rp), RichText(selected_product.license))
-      else
-        ProductLicense.ShowLicenseInInstallation(:base_license_rp, @license_id)
+    # @return [Array<Symbol>] Buttons to disable (:next, :back)
+    def disable_buttons
+      [:back, :next].reject do |button|
+        GetInstArgs.argmap.fetch("enable_#{button}", true)
       end
     end
   end unless defined? Yast::InstComplexWelcomeClient

--- a/src/lib/installation/clients/inst_complex_welcome.rb
+++ b/src/lib/installation/clients/inst_complex_welcome.rb
@@ -84,6 +84,10 @@ module Yast
 
       when :next
         return nil unless Language.CheckIncompleteTranslation(@language)
+        if selected_product.nil?
+          Yast::Popup.Error(_("Please select a product to install."))
+          return nil
+        end
         setup_final_choice
         merge_and_run_workflow if selected_product
         :next

--- a/src/lib/installation/clients/inst_complex_welcome.rb
+++ b/src/lib/installation/clients/inst_complex_welcome.rb
@@ -116,44 +116,6 @@ module Yast
       Yast::ProductControl.RunFrom(Yast::ProductControl.CurrentStep + 1, true)
     end
 
-    def help_text
-      # help text for initial (first time) language screen
-      @help_text = _(
-        "<p>\n" \
-          "Choose the <b>Language</b> and the <b>Keyboard layout</b> to be used during\n" \
-          "installation and for the installed system.\n" \
-          "</p>\n"
-      ) +
-        # help text, continued
-        # Describes the #ICW_B1 button
-        _(
-          "<p>\n" \
-            "The license must be accepted before the installation continues.\n" \
-            "Use <b>License Translations...</b> to show the license in all available translations.\n" \
-            "</p>\n"
-        ) +
-        # help text, continued
-        _(
-          "<p>\n" \
-            "Click <b>Next</b> to proceed to the next dialog.\n" \
-            "</p>\n"
-        ) +
-        # help text, continued
-        _(
-          "<p>\n" \
-            "Nothing will happen to your computer until you confirm\n" \
-            "all your settings in the last installation dialog.\n" \
-            "</p>\n"
-        ) +
-        # help text, continued
-        _(
-          "<p>\n" \
-            "Select <b>Abort</b> to abort the\n" \
-            "installation process at any time.\n" \
-            "</p>\n"
-        )
-    end
-
     def retranslate_yast
       Console.SelectFont(Language.language)
       # no yast translation for nn_NO, use nb_NO as a backup

--- a/src/lib/installation/clients/inst_complex_welcome.rb
+++ b/src/lib/installation/clients/inst_complex_welcome.rb
@@ -69,7 +69,8 @@ module Yast
           products, disable_buttons: disable_buttons
         )
         result = handle_dialog_result(dialog_result)
-        return result if result
+        next unless result
+        return result == :next ? merge_and_run_workflow : result
       end
     end
 
@@ -101,7 +102,6 @@ module Yast
           return nil
         end
         setup_final_choice
-        merge_and_run_workflow if selected_product
         :next
 
       else

--- a/src/lib/installation/clients/inst_complex_welcome.rb
+++ b/src/lib/installation/clients/inst_complex_welcome.rb
@@ -28,6 +28,7 @@ require "y2packager/product"
 Yast.import "Console"
 Yast.import "FileUtils"
 Yast.import "GetInstArgs"
+Yast.import "InstData"
 Yast.import "InstShowInfo"
 Yast.import "Keyboard"
 Yast.import "Language"
@@ -61,6 +62,7 @@ module Yast
       textdomain "installation"
 
       Yast::Wizard.EnableAbortButton
+      show_release_notes
 
       loop do
         dialog_result = ::Installation::Dialogs::ComplexWelcome.run(
@@ -172,6 +174,12 @@ module Yast
       else
         Language.WfmSetLanguage
       end
+    end
+
+    # Show release notes if they have been downloaded
+    def show_release_notes
+      return if InstData.release_notes.empty?
+      Wizard.ShowReleaseNotesButton(_("Re&lease Notes..."), "rel_notes")
     end
 
     # Return the list of base products

--- a/src/lib/installation/clients/inst_complex_welcome.rb
+++ b/src/lib/installation/clients/inst_complex_welcome.rb
@@ -41,14 +41,15 @@ Yast.import "Wizard"
 Yast.import "WorkflowManager"
 
 module Yast
-  # This client shows main dialog for choosing the language,
-  # keyboard and accepting the license.
+  # This client shows main dialog for choosing the language, keyboard,
+  # selecting the product/accepting the license.
   class InstComplexWelcomeClient < Client
     include Yast::Logger
     extend Yast::I18n
 
     BETA_FILE = "/README.BETA".freeze
 
+    # Main client method
     def main
       if FileUtils.Exists(BETA_FILE) && !GetInstArgs.going_back
         InstShowInfo.show_info_txt(BETA_FILE)
@@ -118,6 +119,9 @@ module Yast
 
     # Change YaST interface language
     #
+    # Most of the work is done by #retranslate_yast. If changing to english if
+    # needed, no configuration changes are performed.
+    #
     # @see #retranslate_yast
     def change_language
       if Language.SwitchToEnglishIfNeeded(true)
@@ -157,6 +161,7 @@ module Yast
       log.info "Language: '#{Language.language}', system encoding '#{WFM.GetEncoding}'"
     end
 
+    # Change YaST interface language
     def retranslate_yast
       Console.SelectFont(Language.language)
       # no yast translation for nn_NO, use nb_NO as a backup

--- a/src/lib/installation/clients/inst_complex_welcome.rb
+++ b/src/lib/installation/clients/inst_complex_welcome.rb
@@ -72,7 +72,7 @@ module Yast
 
     # Handle dialog's result
     #
-    # @param [Symbol] Dialog's return value (:next, :language_changed, etc.)
+    # @param value [Symbol] Dialog's return value (:next, :language_changed, etc.)
     # @return [Symbol,nil] Client's return value. Nil if client should not
     #   finish yet.
     def handle_dialog_result(value)

--- a/src/lib/installation/clients/inst_complex_welcome.rb
+++ b/src/lib/installation/clients/inst_complex_welcome.rb
@@ -121,8 +121,8 @@ module Yast
 
     # Change YaST interface language
     #
-    # Most of the work is done by #retranslate_yast. If changing to english if
-    # needed, no configuration changes are performed.
+    # Most of the work is done by #retranslate_yast. No configuration will be
+    # performed if changing to english is needed.
     #
     # @see #retranslate_yast
     def change_language

--- a/src/lib/installation/clients/inst_install_inf.rb
+++ b/src/lib/installation/clients/inst_install_inf.rb
@@ -33,7 +33,7 @@ module Yast
 
     # Checks if the given url is invalid and needs to be fixed.
     #
-    # @params url [String]
+    # @param url [String]
     # @return [Boolean] return true if not nil and invalid.
     def need_fix?(url)
       url && !valid_url?(url)
@@ -68,7 +68,7 @@ module Yast
 
     # Check if the given URI is valid or not
     #
-    # @params url [String]
+    # @param url [String]
     # @return [Boolean]
     def valid_url?(url)
       VALID_URL_SCHEMES.include?(URI(url).scheme)

--- a/src/lib/installation/dialogs/complex_welcome.rb
+++ b/src/lib/installation/dialogs/complex_welcome.rb
@@ -38,8 +38,8 @@ module Installation
 
       # Constructor
       #
-      # @param [Array<Y2Packager::Product>] List of available products
-      # @param [Array<Symbol>] List of buttons to disable
+      # @param products        [Array<Y2Packager::Product>] List of available products
+      # @param disable_buttons [Array<Symbol>] List of buttons to disable
       def initialize(products, disable_buttons: [])
         @products = products
         @disable_buttons = disable_buttons.map { |b| "#{b}_button" }

--- a/src/lib/installation/dialogs/complex_welcome.rb
+++ b/src/lib/installation/dialogs/complex_welcome.rb
@@ -1,0 +1,106 @@
+# ------------------------------------------------------------------------------
+# Copyright (c) 2017 SUSE LLC, All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of version 2 of the GNU General Public License as published by the
+# Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# ------------------------------------------------------------------------------
+
+require "yast"
+require "cwm"
+require "cwm/dialog"
+
+require "installation/widgets/product_selector"
+require "installation/widgets/language_keyboard_selection"
+require "y2packager/widgets/product_license"
+
+Yast.import "UI"
+
+module Installation
+  module Dialogs
+    # This class implements a welcome dialog for the installer
+    #
+    # The dialog contains:
+    #
+    # * A language/keyboard selector
+    # * If only 1 product is available, it shows the product's license.
+    # * If more than 1 product is available, it shows the product selector.
+    class ComplexWelcome < CWM::Dialog
+      # @return [Array<Y2Packager::Product>] List of available products
+      attr_reader :products
+
+      # @return [Array<Symbol>] list of buttons to disable (:next, :abort, :back)
+      attr_reader :disable_buttons
+
+      # Constructor
+      #
+      # @param [Array<Y2Packager::Product>] List of available products
+      # @param [Array<Symbol>] List of buttons to disable
+      def initialize(products, disable_buttons: [])
+        @products = products
+        @disable_buttons = disable_buttons.map { |b| "#{b}_button" }
+      end
+
+      # Returns the dialog title
+      #
+      # The title can vary depending if the license agreement or the product
+      # selection is shown.
+      #
+      # @return [String] Dialog's title
+      def title
+        if show_license?
+          _("Language, Keyboard and License Agreement")
+        else
+          _("Language, Keyboard and Product Selection")
+        end
+      end
+
+      # Dialog content
+      #
+      # @return [Yast::Term] Dialog's content
+      def contents
+        VBox(
+          filling,
+          Left(::Installation::Widgets::LanguageKeyboardSelection.new),
+          show_license? ? product_license : product_selector,
+          filling
+        )
+      end
+
+    private
+
+      # Product selection widget
+      #
+      # @return [::Installation::Widgets::ProductSelector]
+      def product_selector
+        ::Installation::Widgets::ProductSelector.new(products)
+      end
+
+      # Product license widget
+      #
+      # @return [Y2Packager::Widgets::ProductLicense]
+      def product_license
+        Y2Packager::Widgets::ProductLicense.new(products.first)
+      end
+
+      # Determine whether the license must be shown
+      #
+      # The license will be shown when only one product is available.
+      #
+      # @return [Boolean] true if the license must be shown; false otherwise
+      def show_license?
+        products.size == 1
+      end
+
+      # Fill space if needed
+      def filling
+        (show_license? || Yast::UI.TextMode) ? Empty() : VWeight(1, VStretch())
+      end
+
+    end
+  end
+end

--- a/src/lib/installation/dialogs/complex_welcome.rb
+++ b/src/lib/installation/dialogs/complex_welcome.rb
@@ -96,7 +96,7 @@ module Installation
         products.size == 1
       end
 
-      # Fill space if needed
+      # UI to fill space if needed
       def filling
         (show_license? || Yast::UI.TextMode) ? Empty() : VWeight(1, VStretch())
       end

--- a/src/lib/installation/dialogs/complex_welcome.rb
+++ b/src/lib/installation/dialogs/complex_welcome.rb
@@ -77,7 +77,7 @@ module Installation
       #
       # @return [::Installation::Widgets::ProductSelector]
       def product_selector
-        ::Installation::Widgets::ProductSelector.new(products)
+        ::Installation::Widgets::ProductSelector.new(products, skip_validation: true)
       end
 
       # Product license widget
@@ -100,7 +100,6 @@ module Installation
       def filling
         (show_license? || Yast::UI.TextMode) ? Empty() : VWeight(1, VStretch())
       end
-
     end
   end
 end

--- a/src/lib/installation/dialogs/product_selection.rb
+++ b/src/lib/installation/dialogs/product_selection.rb
@@ -12,10 +12,6 @@ module Installation
     # The dialog is used to select from available product that can do system installation.
     # Currently it is mainly used for LeanOS that have on one media more products.
     class ProductSelection < CWM::Dialog
-      class << self
-        attr_accessor :selected_package
-      end
-
       def initialize
         textdomain "installation"
       end

--- a/src/lib/installation/dialogs/product_selection.rb
+++ b/src/lib/installation/dialogs/product_selection.rb
@@ -41,15 +41,7 @@ module Installation
         res = super
         return res if res != :next
 
-        # remove already selected if it is not first run of dialog
-        if self.class.selected_package
-          Yast::WorkflowManager.RemoveWorkflow(:package, 0, self.class.selected_package)
-        end
-        product = selector.product
-        Yast::WorkflowManager.AddWorkflow(:package, 0, product.installation_package)
-        Yast::WorkflowManager.MergeWorkflows
-        Yast::WorkflowManager.RedrawWizardSteps
-        self.class.selected_package = product.installation_package
+        Yast::WorkflowManager.merge_product_workflow(product)
         # run new steps for product
         Yast::ProductControl.RunFrom(Yast::ProductControl.CurrentStep + 1, true)
       end

--- a/src/lib/installation/dialogs/url_dialog.rb
+++ b/src/lib/installation/dialogs/url_dialog.rb
@@ -51,7 +51,6 @@ module Installation
 
     # Shows a dialog when the given url is wrong
     #
-    # @param [String] original Original value
     # @return [String] new value
     def dialog_content
       VBox(

--- a/src/lib/installation/widgets/language_keyboard_selection.rb
+++ b/src/lib/installation/widgets/language_keyboard_selection.rb
@@ -30,6 +30,7 @@ module Installation
       # @see CWM::AbstractWidget#handle
       def handle
         return :language_changed if language_changed?
+        return :keyboard_changed if keyboard_changed?
         nil
       end
 
@@ -82,11 +83,18 @@ module Installation
         @keyboard_selector ||= Y2Country::Widgets::KeyboardSelectionCombo.new(initial_keyboard)
       end
 
-      # Determine whether the language has been changed
+      # Determine whether the language has changed
       #
-      # @return [Boolean] true if the language has been changed
+      # @return [Boolean] true if the language has changed
       def language_changed?
         initial_language != language_selector.value
+      end
+
+      # Determine wether the keyboard has changed
+      #
+      # @return [Boolean] true if the keyboard has changed
+      def keyboard_changed?
+        initial_keyboard != keyboard_selector.value
       end
 
       # Determine the default keyboard value

--- a/src/lib/installation/widgets/language_keyboard_selection.rb
+++ b/src/lib/installation/widgets/language_keyboard_selection.rb
@@ -14,10 +14,11 @@ module Installation
     # yast2-country. Additionally, a textfield which can be used by the user to
     # try the keyboard selection is included too.
     #
-    # The main objective of this widget is to signal when language was changed.
-    # In that case, #handle will return :language_changed interrupting the CWM
-    # loop and giving the opportunity to translate the YaST interface.
-    # See Installation::Clients::InstComplexWelcome for further information.
+    # The main objective of this widget is to signal when language or keyboard
+    # is changed.  In that case, #handle will return :language_changed or
+    # :keyboard_changed interrupting the CWM loop and giving the opportunity to
+    # translate the YaST interface.  See
+    # Installation::Clients::InstComplexWelcome for further information.
     class LanguageKeyboardSelection < CWM::CustomWidget
       # Constructor
       def initialize

--- a/src/lib/installation/widgets/language_keyboard_selection.rb
+++ b/src/lib/installation/widgets/language_keyboard_selection.rb
@@ -15,7 +15,7 @@ module Installation
     # try the keyboard selection is included too.
     #
     # The main objective of this widget is to signal when language or keyboard
-    # is changed.  In that case, #handle will return :language_changed or
+    # are changed.  In that case, #handle will return :language_changed or
     # :keyboard_changed interrupting the CWM loop and giving the opportunity to
     # translate the YaST interface.  See
     # Installation::Clients::InstComplexWelcome for further information.

--- a/src/lib/installation/widgets/language_keyboard_selection.rb
+++ b/src/lib/installation/widgets/language_keyboard_selection.rb
@@ -1,0 +1,116 @@
+require "yast"
+require "cwm/widget"
+require "y2country/widgets/language_selection"
+require "y2country/widgets/keyboard_selection"
+
+Yast.import "Language"
+Yast.import "Keyboard"
+
+module Installation
+  module Widgets
+    # Widget to show a language and keyboard selector
+    #
+    # This widget relies on language and keyboard selectors included in
+    # yast2-country. Additionally, a textfield which can be used by the user to
+    # try the keyboard selection is included too.
+    #
+    # The main objective of this widget is to signal when language was changed.
+    # In that case, #handle will return :language_changed interrupting the CWM
+    # loop and giving the opportunity to translate the YaST interface.
+    # See Installation::Clients::InstComplexWelcome for further information.
+    class LanguageKeyboardSelection < CWM::CustomWidget
+      # Constructor
+      def initialize
+        textdomain "installation"
+      end
+
+      # Widget value handler
+      #
+      # @return [:language_changed,nil] :language_changed is language was changed.
+      # @see CWM::AbstractWidget#handle
+      def handle
+        return :language_changed if language_changed?
+        nil
+      end
+
+      # Handle all events
+      #
+      # @return [true]
+      # @see CWM::AbstractWidget#handle_all_events
+      def handle_all_events
+        true
+      end
+
+      # Widget content
+      #
+      # @return [Yast::Term] widget content
+      # @see CWM::CustomWidget#contents
+      def contents
+        VBox(
+          Left(
+            HBox(
+              HWeight(1, Left(language_selector)),
+              HSpacing(3),
+              HWeight(1, Left(keyboard_selector))
+            )
+          ),
+          Left(
+            HBox(
+              HWeight(1, HStretch()),
+              HSpacing(3),
+              HWeight(1, Left(InputField(Id(:keyboard_test), Opt(:hstretch), _("K&eyboard Test"))))
+            )
+          )
+        )
+      end
+
+    private
+
+      # Return the language selector to be embedded
+      #
+      # @return [Yast::Term]
+      # @see Y2Country::Widgets::LanguageSelection
+      def language_selector
+        @language_selector ||= Y2Country::Widgets::LanguageSelection.new(initial_language)
+      end
+
+      # Return the keyboard selector to be embedded
+      #
+      # @return [Yast::Term]
+      # @see Y2Country::Widgets::KeyboardSelectionCombo
+      def keyboard_selector
+        @keyboard_selector ||= Y2Country::Widgets::KeyboardSelectionCombo.new(initial_keyboard)
+      end
+
+      # Determine whether the language has been changed
+      #
+      # @return [Boolean] true if the language has been changed
+      def language_changed?
+        initial_language != language_selector.value
+      end
+
+      # Determine the default keyboard value
+      #
+      # @return [String] Keyboard layout
+      def initial_keyboard
+        return @initial_keyboard if @initial_keyboard
+        @initial_keyboard =
+          if Yast::Keyboard.user_decision
+            Yast::Keyboard.current_kbd
+          else
+            Yast::Keyboard.GetKeyboardForLanguage(initial_language, "english-us")
+          end
+
+        Yast::Keyboard.Set(@initial_keyboard) if @initial_keyboard != Yast::Keyboard.current_kbd
+        @initial_keyboard
+      end
+
+      # Determine the default language value
+      #
+      # @return [String] Language code
+      def initial_language
+        @initial_language ||= Yast::Language.language
+      end
+    end
+  end
+end

--- a/src/lib/installation/widgets/product_selector.rb
+++ b/src/lib/installation/widgets/product_selector.rb
@@ -48,7 +48,7 @@ module Installation
         @product.select
       end
 
-      def validation
+      def validate
         return true if value
 
         Yast::Popup.Error(_("Please select a product to install."))

--- a/src/lib/installation/widgets/product_selector.rb
+++ b/src/lib/installation/widgets/product_selector.rb
@@ -13,9 +13,11 @@ module Installation
       attr_reader :product
 
       # @param products [Array<Installation::Product>] to display
-      def initialize(products)
+      # @param skip_validation [Boolean] Skip value validation
+      def initialize(products, skip_validation: false)
         @products = products
         @items = products.map { |p| [p.name, p.label] }
+        @skip_validation = skip_validation
         textdomain "installation"
       end
 
@@ -49,10 +51,17 @@ module Installation
       end
 
       def validate
-        return true if value
+        return true if value || skip_validation?
 
         Yast::Popup.Error(_("Please select a product to install."))
         false
+      end
+
+      # Determine whether the validation should be skipped
+      #
+      # @see #initialize
+      def skip_validation?
+        @skip_validation
       end
     end
   end

--- a/test/dialogs/complex_welcome_test.rb
+++ b/test/dialogs/complex_welcome_test.rb
@@ -1,0 +1,57 @@
+#!/usr/bin/env rspec
+
+require_relative "../test_helper"
+require "installation/dialogs/complex_welcome"
+
+describe Installation::Dialogs::ComplexWelcome do
+  subject(:widget) { described_class.new(products) }
+
+  let(:products) { [] }
+
+  describe "#title" do
+    it "returns a string" do
+      expect(widget.title).to be_a(::String)
+    end
+  end
+
+  describe "#content" do
+    let(:sles_product) { instance_double("Y2Packager::Product", label: "SLES") }
+    let(:language_widget) { Yast::Term.new(:language_widget) }
+    let(:license_widget) { Yast::Term.new(:license_widget) }
+    let(:selector_widget) { Yast::Term.new(:selector_widget) }
+
+    before do
+      allow(Installation::Widgets::LanguageKeyboardSelection).to receive(:new)
+        .and_return(language_widget)
+      allow(Y2Packager::Widgets::ProductLicense).to receive(:new)
+        .and_return(license_widget)
+      allow(Installation::Widgets::ProductSelector).to receive(:new)
+        .and_return(selector_widget)
+    end
+
+    it "includes a language/keyboard selection" do
+      expect(widget.contents.to_s).to include("language_widget")
+    end
+
+    context "when only 1 product is available" do
+      let(:products) { [sles_product] }
+
+      it "shows the product license" do
+        expect(Y2Packager::Widgets::ProductLicense).to receive(:new)
+          .with(products.first).and_return(license_widget)
+        expect(widget.contents.to_s).to include("license_widget")
+      end
+    end
+
+    context "when more than 1 product is available" do
+      let(:sled_product) { instance_double("Y2Packager::Product", label: "SLED") }
+      let(:products) { [sles_product, sled_product] }
+
+      it "shows the product selector" do
+        expect(Installation::Widgets::ProductSelector).to receive(:new)
+          .with(products)
+        expect(widget.contents.to_s).to include("selector_widget")
+      end
+    end
+  end
+end

--- a/test/dialogs/complex_welcome_test.rb
+++ b/test/dialogs/complex_welcome_test.rb
@@ -49,7 +49,7 @@ describe Installation::Dialogs::ComplexWelcome do
 
       it "shows the product selector" do
         expect(Installation::Widgets::ProductSelector).to receive(:new)
-          .with(products)
+          .with(products, skip_validation: true)
         expect(widget.contents.to_s).to include("selector_widget")
       end
     end

--- a/test/inst_complex_welcome_test.rb
+++ b/test/inst_complex_welcome_test.rb
@@ -29,7 +29,7 @@ describe Yast::InstComplexWelcomeClient do
     double(
       language:                   language,
       languages:                  "en_US,de_DE",
-      GetLanguageItems:           [], 
+      GetLanguageItems:           [],
       CheckIncompleteTranslation: true,
       Save:                       nil,
       SetDefault:                 nil

--- a/test/inst_complex_welcome_test.rb
+++ b/test/inst_complex_welcome_test.rb
@@ -62,7 +62,6 @@ describe Yast::InstComplexWelcomeClient do
   end
 
   describe "#main" do
-    let(:restarting) { false }
     let(:dialog_results) { [:back] }
 
     before do

--- a/test/inst_complex_welcome_test.rb
+++ b/test/inst_complex_welcome_test.rb
@@ -136,8 +136,9 @@ describe Yast::InstComplexWelcomeClient do
     end
 
     context "when keyboard changes" do
+      let(:dialog_results) { [:keyboard_changed, :back] }
+
       it "sets the selection as user selected" do
-        allow(Installation::Dialogs::ComplexWelcome).to receive(:run).and_return(:keyboard_changed, :back)
         expect(Yast::Keyboard).to receive(:user_decision=).with(true)
         subject.main
       end
@@ -363,12 +364,11 @@ describe Yast::InstComplexWelcomeClient do
       context "and additional packages are not needed for the given language" do
         let(:lang_packages_needed) { false }
 
-        it "adds the packages for installation" do
+        it "does not add the packages for installation" do
           expect(Yast::Language).to_not receive(:PackagesInit)
           subject.send(:setup_final_choice)
         end
       end
-
     end
   end
 end

--- a/test/inst_complex_welcome_test.rb
+++ b/test/inst_complex_welcome_test.rb
@@ -97,7 +97,33 @@ describe Yast::InstComplexWelcomeClient do
     end
 
     it "runs the dialog" do
+      expect(Installation::Dialogs::ComplexWelcome).to receive(:run)
+        .and_return(:back)
       subject.main
+    end
+
+    context "release notes" do
+      before do
+        allow(Yast::InstData).to receive(:release_notes).and_return(release_notes)
+      end
+
+      context "when release notes have been downloaded" do
+        let(:release_notes) { "release notes" }
+
+        it "show release notes" do
+          expect(Yast::Wizard).to receive(:ShowReleaseNotesButton)
+          subject.main
+        end
+      end
+
+      context "when release notes have not been downloaded" do
+        let(:release_notes) { "" }
+
+        it "does not download release notes again" do
+          expect(Yast::Wizard).to_not receive(:ShowReleaseNotesButton)
+          subject.main
+        end
+      end
     end
 
     context "when back is pressed" do

--- a/test/lib/widgets/language_keyboard_selection_test.rb
+++ b/test/lib/widgets/language_keyboard_selection_test.rb
@@ -57,17 +57,17 @@ describe Installation::Widgets::LanguageKeyboardSelection do
           allow(keyboard_mock).to receive(:Set)
         end
 
-        it "uses the keyboard which matches the language as default" do
+        it "uses by default the keyboard which matches the language" do
           expect(keyboard_selection_class).to receive(:new).with("german")
           widget.contents
         end
 
-        it "sets keyboard to the default value different" do
+        it "sets keyboard to the default value" do
           expect(keyboard_mock).to receive(:Set).with("german")
           widget.contents
         end
 
-        context "and keyboard which matches the language is still the same" do
+        context "and keyboard that matches the language is the same than the current one" do
           before do
             allow(keyboard_mock).to receive(:GetKeyboardForLanguage).and_return("english-us")
           end

--- a/test/lib/widgets/language_keyboard_selection_test.rb
+++ b/test/lib/widgets/language_keyboard_selection_test.rb
@@ -1,0 +1,109 @@
+#!/usr/bin/env rspec
+
+require_relative "../../test_helper"
+require "installation/widgets/language_keyboard_selection"
+require "cwm/rspec"
+
+describe Installation::Widgets::LanguageKeyboardSelection do
+  include_examples "CWM::CustomWidget"
+
+  subject(:widget) { described_class.new }
+
+  let(:language) { "de_DE" }
+  let(:selected_language) { "de_DE" }
+  let(:user_decision) { true }
+  let(:language_mock) { double("Yast::Language", language: language) }
+  let(:keyboard_mock) { double("Yast::Keyboard", user_decision: user_decision, current_kbd: "english-us") }
+
+  let(:keyboard_selection) do
+    instance_double("Y2Country::Widgets::KeyboardSelectionCombo")
+  end
+
+  let(:language_selection) do
+    instance_double("Y2Country::Widgets::LanguageSelection", value: selected_language)
+  end
+
+  let(:keyboard_selection_class) do
+    double("Y2Country::Widgets::KeyboardSelectionCombo", new: keyboard_selection)
+  end
+
+  let(:language_selection_class) do
+    double("Y2Country::Widgets::LanguageSelection", new: language_selection)
+  end
+
+  before do
+    stub_const("Yast::Language", language_mock)
+    stub_const("Yast::Keyboard", keyboard_mock)
+    stub_const("Y2Country::Widgets::KeyboardSelectionCombo", keyboard_selection_class)
+    stub_const("Y2Country::Widgets::LanguageSelection", language_selection_class)
+  end
+
+  describe "#contents" do
+    context "keyboard selection" do
+      context "when user selected the keyboard" do
+        it "uses the selection as the default value" do
+          expect(keyboard_selection_class).to receive(:new).with("english-us")
+          widget.contents
+        end
+      end
+
+      context "when user did not selected the keyboard" do
+        let(:user_decision) { false }
+
+        before do
+          allow(keyboard_mock).to receive(:GetKeyboardForLanguage).and_return("german")
+          allow(keyboard_selection_class).to receive(:new)
+          allow(keyboard_mock).to receive(:Set)
+        end
+
+        it "uses the keyboard which matches the language as default" do
+          expect(keyboard_selection_class).to receive(:new).with("german")
+          widget.contents
+        end
+
+        it "sets keyboard to the default value different" do
+          expect(keyboard_mock).to receive(:Set).with("german")
+          widget.contents
+        end
+
+        context "and keyboard which matches the language is still the same" do
+          before do
+            allow(keyboard_mock).to receive(:GetKeyboardForLanguage).and_return("english-us")
+          end
+
+          it "does not set keyboard" do
+            expect(keyboard_mock).to_not receive(:Set)
+            widget.contents
+          end
+        end
+      end
+    end
+
+    it "uses current language as default" do
+      expect(language_selection_class).to receive(:new).with(language)
+      widget.contents
+    end
+  end
+
+  describe "#handle" do
+    context "when language has changed" do
+      let(:selected_language) { "es_ES" }
+
+      it "returns :language_changed" do
+        expect(widget.handle).to eq(:language_changed)
+      end
+    end
+
+    context "when language has not changed" do
+      it "returns nil" do
+        expect(widget.handle).to be_nil
+      end
+    end
+  end
+
+  describe "#handle_all_events" do
+    it "returns true" do
+      expect(widget.handle_all_events).to eq(true)
+    end
+  end
+end

--- a/test/lib/widgets/language_keyboard_selection_test.rb
+++ b/test/lib/widgets/language_keyboard_selection_test.rb
@@ -11,12 +11,13 @@ describe Installation::Widgets::LanguageKeyboardSelection do
 
   let(:language) { "de_DE" }
   let(:selected_language) { "de_DE" }
+  let(:selected_keyboard) { "english-us" }
   let(:user_decision) { true }
   let(:language_mock) { double("Yast::Language", language: language) }
   let(:keyboard_mock) { double("Yast::Keyboard", user_decision: user_decision, current_kbd: "english-us") }
 
   let(:keyboard_selection) do
-    instance_double("Y2Country::Widgets::KeyboardSelectionCombo")
+    instance_double("Y2Country::Widgets::KeyboardSelectionCombo", value: selected_keyboard)
   end
 
   let(:language_selection) do
@@ -86,6 +87,10 @@ describe Installation::Widgets::LanguageKeyboardSelection do
   end
 
   describe "#handle" do
+    it "returns nil" do
+      expect(widget.handle).to be_nil
+    end
+
     context "when language has changed" do
       let(:selected_language) { "es_ES" }
 
@@ -94,9 +99,11 @@ describe Installation::Widgets::LanguageKeyboardSelection do
       end
     end
 
-    context "when language has not changed" do
-      it "returns nil" do
-        expect(widget.handle).to be_nil
+    context "when keyboard has changed" do
+      let(:selected_keyboard) { "spanish" }
+
+      it "returns :keyboard_changed" do
+        expect(widget.handle).to eq(:keyboard_changed)
       end
     end
   end


### PR DESCRIPTION
Requires https://github.com/yast/yast-yast2/pull/619, https://github.com/yast/yast-packager/pull/273 and
https://github.com/yast/yast-country/pull/138.

Move product's selection to welcome screen.

![complex-welcome-license](https://user-images.githubusercontent.com/15836/29975866-ef7dfb94-8f2f-11e7-9e6f-20ce24c5864d.gif)

