### PR TITLE
Configure Snapper at the end of installation if requested

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Sep  4 12:18:45 UTC 2017 - ancor@suse.com
+
+- Configure Snapper at the end of installation if requested
+  (part of fate#318196).
+- 3.3.12
+
+-------------------------------------------------------------------
 Fri Sep  1 12:43:42 UTC 2017 - igonzalezsosa@suse.com
 
 - On multi-product installation medias, the product selection

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation
-Version:        3.3.11
+Version:        3.3.12
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -52,9 +52,8 @@ Requires:      yast2-storage-ng >= 0.1.32
 # AutoinstSoftware.SavePackageSelection()
 Requires:       autoyast2-installation >= 3.1.105
 
-# Yast::WorkflowManager#merge_product_workflow
-# CWM.show support to disable buttons
-Requires:       yast2 >= 4.0.2
+# Yast2::FsSnapshots.configure_snapper (& friends)
+Requires:       yast2 >= 4.0.3
 
 # Language::GetLanguageItems and other API
 # Language::Set (handles downloading the translation extensions)

--- a/src/lib/installation/snapshots_finish.rb
+++ b/src/lib/installation/snapshots_finish.rb
@@ -17,12 +17,16 @@ module Installation
 
     # Writes configuration
     #
-    # It creates a snapshot when no second stage is required and
+    # It finishes the Snapper configuration, if needed.
+    #
+    # It also creates a snapshot when no second stage is required and
     # Snapper is configured.
     #
     # @return [TrueClass,FalseClass] True if snapshot was created;
     #                                otherwise it returns false.
     def write
+      snapper_config
+
       if !InstFunctions.second_stage_required? && Yast2::FsSnapshot.configured?
         log.info("Creating root filesystem snapshot")
         if Mode.update
@@ -54,6 +58,15 @@ module Installation
       # TRANSLATORS: label for filesystem snapshot taken after system installation
       Yast2::FsSnapshot.create_single(_("after installation"), cleanup: :number, important: true)
       true
+    end
+
+    def snapper_config
+      if Mode.installation && Yast2::FsSnapshot.configure_on_install?
+        log.info("Finishing Snapper configuration")
+        Yast2::FsSnapshot.configure_snapper
+      else
+        log.info("There is no need to configure Snapper")
+      end
     end
   end
 end

--- a/test/snapshots_finish_test.rb
+++ b/test/snapshots_finish_test.rb
@@ -35,7 +35,7 @@ describe ::Installation::SnapshotsFinish do
         end
       end
 
-      context "is Snapper configuration was not requested" do
+      context "if Snapper configuration was not requested" do
         let(:configure) { false }
 
         it "does not configure Snapper" do
@@ -57,7 +57,7 @@ describe ::Installation::SnapshotsFinish do
         end
       end
 
-      context "is Snapper configuration was not requested" do
+      context "if Snapper configuration was not requested" do
         let(:configure) { false }
 
         it "does not configure Snapper" do

--- a/test/snapshots_finish_test.rb
+++ b/test/snapshots_finish_test.rb
@@ -14,6 +14,57 @@ describe ::Installation::SnapshotsFinish do
     before do
       allow(Yast::InstFunctions).to receive(:second_stage_required?).and_return(second_stage_required)
       allow(Yast2::FsSnapshot).to receive(:configured?).and_return(snapper_configured)
+      allow(Yast::Mode).to receive(:installation).and_return(mode == :installation)
+      allow(Yast2::FsSnapshot).to receive(:configure_on_install?).and_return configure
+    end
+
+    let(:second_stage_required) { false }
+    let(:snapper_configured) { false }
+    let(:mode) { :normal }
+    let(:configure) { false }
+
+    context "during a fresh installation" do
+      let(:mode) { :installation }
+
+      context "if Snapper configuration was requested" do
+        let(:configure) { true }
+
+        it "configures Snapper" do
+          expect(Yast2::FsSnapshot).to receive(:configure_snapper)
+          subject.write
+        end
+      end
+
+      context "is Snapper configuration was not requested" do
+        let(:configure) { false }
+
+        it "does not configure Snapper" do
+          expect(Yast2::FsSnapshot).to_not receive(:configure_snapper)
+          subject.write
+        end
+      end
+    end
+
+    context "during update" do
+      let(:mode) { :update }
+
+      context "if Snapper configuration was requested" do
+        let(:configure) { true }
+
+        it "does not configure Snapper" do
+          expect(Yast2::FsSnapshot).to_not receive(:configure_snapper)
+          subject.write
+        end
+      end
+
+      context "is Snapper configuration was not requested" do
+        let(:configure) { false }
+
+        it "does not configure Snapper" do
+          expect(Yast2::FsSnapshot).to_not receive(:configure_snapper)
+          subject.write
+        end
+      end
     end
 
     context "when second stage is required" do


### PR DESCRIPTION
Part of https://trello.com/c/ytK5Yoe4/554-5-storageng-installation-to-root-subvolume

It depends on https://github.com/yast/yast-yast2/pull/620 and the yast2-storage-ng PR in the PBI depends on this one.