### PR TITLE
Download release notes only for the selected products (bsc#1056872)

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Sep  5 11:41:50 UTC 2017 - lslezak@suse.cz
+
+- Download release notes only for the selected products (if any
+  product is already selected) (bsc#1056872)
+- 4.0.0
+
+-------------------------------------------------------------------
 Tue Sep  5 10:20:43 UTC 2017 - igonzalezsosa@suse.com
 
 - Fix license confirmation handling on single product medias

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation
-Version:        3.3.13
+Version:        4.0.0
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
- If any product is already selected then download the release notes only for the selected product (LeanOS). If nothing is selected download release notes for all available products - for backward compatibility with a single product medium (openSUSE).

- This is similar to the fix in registration: https://github.com/yast/yast-registration/pull/327

- 4.0.0