### PR TITLE
Do not show product selection during upgrade

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Sun Oct 15 22:00:11 UTC 2017 - knut.anderssen@suse.com
+
+- Adapted complex welcome client allowing to continue with the
+  installation when there are no products available. (bsc#1059070)
+- 4.0.7
+
+-------------------------------------------------------------------
 Tue Oct 10 08:34:44 UTC 2017 - jreidinger@suse.com
 
 - Dropped call of dasd_reload which caused renumbering of disks and

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation
-Version:        4.0.6
+Version:        4.0.7
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/installation/clients/inst_complex_welcome.rb
+++ b/src/lib/installation/clients/inst_complex_welcome.rb
@@ -69,10 +69,12 @@ module Yast
         result = handle_dialog_result(dialog_result)
         next unless result
 
-        return result if products.empty? || result != :next
+        return result if !available_products? || result != :next
         return merge_and_run_workflow
       end
     end
+
+  private
 
     # Handle dialog's result
     #
@@ -89,7 +91,7 @@ module Yast
         return if Mode.config
         return unless Language.CheckIncompleteTranslation(Language.language)
 
-        return if !products.empty? && !product_selection_finished?
+        return if available_products? && !product_selection_finished?
 
         setup_final_choice
         :next
@@ -98,8 +100,6 @@ module Yast
         value
       end
     end
-
-  private
 
     # Merge selected product's workflow and go to next step
     #
@@ -147,6 +147,13 @@ module Yast
       return @products if @products
 
       @products = Mode.update ? [] : Y2Packager::Product.available_base_products
+    end
+
+    # Determine whether some product is available or not
+    #
+    # @return [Boolean] false if no product available; true otherwise
+    def available_products?
+      !products.empty?
     end
 
     # Convenience method to find out the selected base product

--- a/src/lib/installation/dialogs/complex_welcome.rb
+++ b/src/lib/installation/dialogs/complex_welcome.rb
@@ -53,15 +53,9 @@ module Installation
       #
       # @return [String] Dialog's title
       def title
-        if show_product_selection?
-          if show_license?
-            _("Language, Keyboard and License Agreement")
-          else
-            _("Language, Keyboard and Product Selection")
-          end
-        else
-          _("Language and Keyboard Selection")
-        end
+        return product_title if show_product_selection?
+
+        _("Language and Keyboard Selection")
       end
 
       # Dialog content
@@ -140,10 +134,22 @@ module Installation
         products.size == 1
       end
 
+      # Determine whether the product selection must be shown
+      #
+      # The product selection will be shown only if there are at least some
+      # product available.
+      #
+      # @return [Boolean] true if the products list is not empty
       def show_product_selection?
         !products.empty?
       end
 
+      # Product content
+      #
+      # Shows the product selection if there is more than one product or the
+      # license agreement if there is only one.
+      #
+      # @return [Yast::Term] Product selection content; Empty() if no products
       def product_selection
         return Empty() unless show_product_selection?
 
@@ -156,6 +162,20 @@ module Installation
           Empty()
         else
           VWeight(1, VStretch())
+        end
+      end
+
+      # Title of the dialog in case there are some product available.
+      #
+      # The title can vary depending if the license agreement or the product
+      # selection is shown.
+      #
+      # @return [String] Dialog's title
+      def product_title
+        if show_license?
+          _("Language, Keyboard and License Agreement")
+        else
+          _("Language, Keyboard and Product Selection")
         end
       end
     end

--- a/src/lib/installation/dialogs/complex_welcome.rb
+++ b/src/lib/installation/dialogs/complex_welcome.rb
@@ -53,10 +53,14 @@ module Installation
       #
       # @return [String] Dialog's title
       def title
-        if show_license?
-          _("Language, Keyboard and License Agreement")
+        if show_product_selection?
+          if show_license?
+            _("Language, Keyboard and License Agreement")
+          else
+            _("Language, Keyboard and Product Selection")
+          end
         else
-          _("Language, Keyboard and Product Selection")
+          _("Language and Keyboard Selection")
         end
       end
 
@@ -67,7 +71,7 @@ module Installation
         @contents ||= VBox(
           filling,
           locale_settings,
-          show_license? ? product_license : product_selector,
+          product_selection,
           filling
         )
       end
@@ -134,6 +138,16 @@ module Installation
       # @return [Boolean] true if the license must be shown; false otherwise
       def show_license?
         products.size == 1
+      end
+
+      def show_product_selection?
+        !products.empty?
+      end
+
+      def product_selection
+        return Empty() unless show_product_selection?
+
+        show_license? ? product_license : product_selector
       end
 
       # UI to fill space if needed

--- a/src/lib/installation/dialogs/complex_welcome.rb
+++ b/src/lib/installation/dialogs/complex_welcome.rb
@@ -53,7 +53,7 @@ module Installation
       #
       # @return [String] Dialog's title
       def title
-        return product_title if show_product_selection?
+        return license_or_product_title if available_products?
 
         _("Language and Keyboard Selection")
       end
@@ -65,7 +65,7 @@ module Installation
         @contents ||= VBox(
           filling,
           locale_settings,
-          product_selection,
+          license_or_product_content,
           filling
         )
       end
@@ -134,24 +134,21 @@ module Installation
         products.size == 1
       end
 
-      # Determine whether the product selection must be shown
+      # Determine whether some product is available or not
       #
-      # The product selection will be shown only if there are at least some
-      # product available.
-      #
-      # @return [Boolean] true if the products list is not empty
-      def show_product_selection?
+      # @return [Boolean] false if no product available; true otherwise
+      def available_products?
         !products.empty?
       end
 
-      # Product content
+      # License or Product content
       #
       # Shows the product selection if there is more than one product or the
       # license agreement if there is only one.
       #
       # @return [Yast::Term] Product selection content; Empty() if no products
-      def product_selection
-        return Empty() unless show_product_selection?
+      def license_or_product_content
+        return Empty() unless available_products?
 
         show_license? ? product_license : product_selector
       end
@@ -165,13 +162,13 @@ module Installation
         end
       end
 
-      # Title of the dialog in case there are some product available.
+      # Title of the dialog in case there is some product available.
       #
       # The title can vary depending if the license agreement or the product
       # selection is shown.
       #
       # @return [String] Dialog's title
-      def product_title
+      def license_or_product_title
         if show_license?
           _("Language, Keyboard and License Agreement")
         else


### PR DESCRIPTION
- [Trello Card](https://trello.com/c/BKCh35fR/1191-3-1059070-upgrade-case-let-user-continue-without-selecting-a-product-request-license-agreement-later)

This is an early release just to discuss the current dialog with UI/UX experts to check as soon as possible whether we should adapt it or not. 

![upgrade_sle-12-sp2](https://user-images.githubusercontent.com/7056681/31378892-958d185c-ada4-11e7-8bfc-9c10c8874aec.png)

![upgrade_sle-12-sp2_textmode](https://user-images.githubusercontent.com/7056681/31392527-68bb6fea-add1-11e7-9752-3ac1ee568734.png)

![screenshot_opensusetumbleweed_2017-10-16_00 34 28](https://user-images.githubusercontent.com/7056681/31590562-0cfa4928-b20a-11e7-9676-73bb7c3b0a43.png)