### PR TITLE
Less eager inst-sys cleanup (bsc#1063459)

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Oct 24 10:05:38 UTC 2017 - lslezak@suse.cz
+
+- Less eager inst-sys cleanup, libzypp actually needs some cached
+  files during package installation, remove only the white listed
+  known files (bsc#1063459)
+- 4.0.10
+
+-------------------------------------------------------------------
 Fri Oct 20 12:59:37 UTC 2017 - jsrain@suse.cz
 
 - umount efivars properly (bsc#1063063)

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation
-Version:        4.0.9
+Version:        4.0.10
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
- Libzypp actually needs some cached repository files even during package installation. We can remove only the white listed files we know are safe to remove.
- See [bsc#1063459#c5](https://bugzilla.suse.com/show_bug.cgi?id=1063459#c25) for details
- 4.0.10
