### PR TITLE
Calling SUSEConnect --cleanup at startup

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu Nov  2 13:05:34 CET 2017 - locilka@suse.com
+
+- Cleanup old registration attempts before starting Installer. This
+  is needed for restarted installation after it has been aborted
+  earlier (bsc#1065167).
+- 4.0.12
+
+-------------------------------------------------------------------
 Mon Oct 30 15:09:06 UTC 2017 - igonzalezsosa@suse.com
 
 - Always show the license agreement on single product media,

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation
-Version:        4.0.11
+Version:        4.0.12
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/startup/First-Stage/F09-start
+++ b/startup/First-Stage/F09-start
@@ -7,6 +7,16 @@ log "====================="
 #---------------------------------------------
 callHooks preFirstCall
 
+# 9.05) cleanup before (re)starting
+
+# bsc#1065167: Installer does not allow to change a base product when it's
+# already registered. When installation is aborted and then restarted,
+# the data of the previous registration was not automatically removed.
+#
+# log "Cleaning up previous registration attempts"
+# Using /dev/null - If there is nothing to do, let it fail silently
+SUSEConnect --cleanup 1>/dev/null 2>/dev/null
+
 #=============================================
 # 9.1) check for driver update mode
 #---------------------------------------------

--- a/startup/First-Stage/F09-start
+++ b/startup/First-Stage/F09-start
@@ -15,7 +15,7 @@ callHooks preFirstCall
 #
 # log "Cleaning up previous registration attempts"
 # Using /dev/null - If there is nothing to do, let it fail silently
-SUSEConnect --cleanup 1>/dev/null 2>/dev/null
+SUSEConnect --cleanup > /dev/null 2>&1
 
 #=============================================
 # 9.1) check for driver update mode


### PR DESCRIPTION
- When you abort an installation after you have registered your product, you can't just start again as selecting any product is then blocked later
- This is not needed for a single-product add-ons, such as openSUSE, but the cleanup redirects everything to /dev/null as it complains at the first start even at SUSE Enterprise anyway
- bsc#1065167