### PR TITLE
Update file_from_url.rb

### DIFF
--- a/src/lib/transfer/file_from_url.rb
+++ b/src/lib/transfer/file_from_url.rb
@@ -268,7 +268,7 @@ module Yast::Transfer
                   # autoyast tried to mount the CD but had no success.
                   @GET_error = Ops.add(
                     @GET_error,
-                    Builtins.sformat(_("Mounting %1 failed."), cdrom)
+                    Builtins.sformat(_("Mounting %1 failed."), cdrom_device)
                   )
                   Builtins.y2warning("Mount failed")
                   ok = false


### PR DESCRIPTION
Not defined variable, could be cause of problem during installation (tested on SLE-12-SP3), Information on screen expose detail described below
Details: Undefined local variable or method 'cdrom' from #<Yast:AutoinstScriptClass:0x00000004386ce8>
Caller: /usr/share/Yast2/lib/transfer/file_from_url.rb:271:in 'get_file_from_url'