### PR TITLE
Break dependency cycle

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Dec  4 12:32:49 UTC 2017 - igonzalezsosa@suse.com
+
+- Break autoyast2 and yast2-installation dependency cycle
+  (bsc#1070996) 
+- 4.0.15
+
+-------------------------------------------------------------------
 Thu Nov 30 14:33:07 UTC 2017 - igonzalezsosa@suse.com
 
 - Do not ignore start_multipath setting (bsc#1070343).

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.0.14
+Version:        4.0.15
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -49,10 +49,6 @@ BuildRequires:	yast2-packager >= 4.0.9
 BuildRequires: yast2-storage-ng >= 4.0.43
 Requires:      yast2-storage-ng >= 4.0.43
 
-# Y2Autoinstall::ActivateCallbacks
-BuildRequires:  autoyast2-installation >= 4.0.11
-Requires:       autoyast2-installation >= 4.0.11
-
 # Yast::WorkflowManager.merge_modules_extensions
 Requires:       yast2 >= 4.0.8
 

--- a/src/lib/installation/clients/inst_system_analysis.rb
+++ b/src/lib/installation/clients/inst_system_analysis.rb
@@ -27,7 +27,6 @@
 
 require "yast"
 require "y2storage"
-require "autoinstall/activate_callbacks"
 
 module Yast
   class InstSystemAnalysisClient < Client
@@ -35,6 +34,9 @@ module Yast
       Yast.import "UI"
 
       textdomain "installation"
+
+      # Require here to break dependency cycle (bsc#1070996)
+      require "autoinstall/activate_callbacks"
 
       Yast.import "Arch"
       Yast.import "GetInstArgs"

--- a/test/lib/clients/inst_system_analysis_test.rb
+++ b/test/lib/clients/inst_system_analysis_test.rb
@@ -33,6 +33,10 @@ describe Yast::InstSystemAnalysisClient do
     let(:auto) { false }
 
     before do
+      allow(client).to receive(:require).with("autoinstall/activate_callbacks")
+    end
+
+    before do
       allow(Y2Storage::StorageManager).to receive(:instance).and_return(storage)
       allow(Yast::Mode).to receive(:auto).and_return(auto)
     end
@@ -44,9 +48,13 @@ describe Yast::InstSystemAnalysisClient do
 
     context "when running AutoYaST" do
       let(:auto) { true }
+      let(:callbacks_class) { double("Y2Autoinstallation::ActivateCallbacks", new: callbacks) }
+      let(:callbacks) { instance_double("Y2Autoinstallation::ActivateCallbacks") }
+
+      before { stub_const("Y2Autoinstallation::ActivateCallbacks", callbacks_class) }
 
       it "uses AutoYaST activation callbacks" do
-        expect(storage).to receive(:activate).with(Y2Autoinstallation::ActivateCallbacks)
+        expect(storage).to receive(:activate).with(callbacks)
         client.ActionHDDProbe
       end
     end


### PR DESCRIPTION
I guess that a better solution for [bsc#1070996](https://bugzilla.suse.com/show_bug.cgi?id=1070996) (breaking autoyast2 and yast2-installation dependency cycle) could be used, which probably would imply moving some code between modules. For the time being, this one should work.