### PR TITLE
Stub Console module

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -23,14 +23,15 @@ def stub_module(name)
 end
 
 # stub classes from other modules to speed up a build
-stub_module("Packages")
-stub_module("InstURL")
-stub_module("Language")
-stub_module("Keyboard")
 stub_module("AddOnProduct")
-stub_module("ProductLicense")
-stub_module("AutoinstGeneral")
 stub_module("AutoinstConfig")
+stub_module("AutoinstGeneral")
+stub_module("Console")
+stub_module("InstURL")
+stub_module("Keyboard")
+stub_module("Language")
+stub_module("Packages")
+stub_module("ProductLicense")
 stub_module("Profile")
 stub_module("ProfileLocation")
 


### PR DESCRIPTION
Fixes [yast2-installation](https://ci.suse.de/job/yast-installation-master/198/console) build. It adds Console to the list of stubbed modules (and it sorts the list btw).