### PR TITLE
Log the system name for easier debugging

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Dec 12 08:21:36 UTC 2017 - lslezak@suse.cz
+
+- Log the system name at start to see which system is running
+  in the inst-sys (for easier debugging)
+
+-------------------------------------------------------------------
 Mon Dec 11 15:50:04 UTC 2017 - knut.anderssen@suse.com
 
 - Replaced Remote module by the new y2remote/remote class

--- a/src/lib/installation/clients/installation.rb
+++ b/src/lib/installation/clients/installation.rb
@@ -40,6 +40,10 @@ module Yast
       Yast.import "Report"
       Yast.import "Hooks"
       Yast.import "Linuxrc"
+      Yast.import "OSRelease"
+
+      # log the inst-sys identification for easier debugging
+      log_os_release
 
       Hooks.search_path.join!("installation")
 
@@ -100,6 +104,16 @@ module Yast
       WFM.CallFunction("disintegrate_all_extensions") if Stage.initial
 
       deep_copy(@ret)
+    end
+
+    # log the system name found in the /etc/os-release file
+    # to easily find which system is running in inst-sys
+    def log_os_release
+      if OSRelease.os_release_exists?
+        log.info("System identification: #{OSRelease.ReleaseInformation.inspect}")
+      else
+        log.warn("Cannot read the OS release file")
+      end
     end
   end
 end


### PR DESCRIPTION
- Logs this at the very beginning:
```
[Ruby] clients/installation.rb:113 System identification: "SUSE Linux Enterprise 15"
```
- The value is read from `/ets/os-release` (included in inst-sys)
- It would help me a lot in [this case](https://bugzilla.suse.com/show_bug.cgi?id=1068302#c12)
