### PR TITLE
Replace xinetd by xvnc.socket in startup scripts

### DIFF
--- a/package/YaST2-Second-Stage.service
+++ b/package/YaST2-Second-Stage.service
@@ -1,7 +1,5 @@
 [Unit]
 Description=YaST2 Second Stage
-# If xinetd is enabled, make sure it's already running so we can stop it during
-# initialization of the VNC server
 After=apparmor.service local-fs.target plymouth-start.service
 Conflicts=plymouth-start.service
 Before=getty@tty1.service serial-getty@ttyS0.service serial-getty@ttyS1.service serial-getty@ttyS2.service

--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Thu Feb  8 13:55:21 UTC 2018 - knut.anderssen@suse.com
+
+- Startup scripts: Replaced xinetd by xvnc.socket (fate#323373)
+- Revert changes added in 4.0.29 bringing back the enablement of
+  the xvnc.socket during the first stage if Linuxrc.vnc is set.
+  (bnc#1077236)
+- 4.0.32
+
+-------------------------------------------------------------------
 Tue Feb  6 12:24:34 CET 2018 - schubi@suse.de
 
 - Added requirement iproute2 to spec file. This is needed by

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.0.31
+Version:        4.0.32
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/installation/remote_finish_client.rb
+++ b/src/lib/installation/remote_finish_client.rb
@@ -50,7 +50,7 @@ module Installation
           "when"  => modes
         }
       when "Write"
-        remote.write
+        enable_remote
       else
         log.error "unknown function: #{func}"
       end
@@ -67,11 +67,17 @@ module Installation
       _("Enabling remote administration...")
     end
 
-    # Modes which will be used for writing settings
+    # Modes in which #enable_remote should be called
     #
     # @return [Array<Symbol>]
     def modes
       Yast::Linuxrc.vnc ? [:installation, :autoinst] : []
+    end
+
+    # Enables remote access
+    def enable_remote
+      remote.enable!
+      remote.write
     end
 
     def remote

--- a/startup/Second-Stage/S09-cleanup
+++ b/startup/Second-Stage/S09-cleanup
@@ -10,13 +10,12 @@ if test ! -z "$SPID" ; then
 	log "\tkill console with PID: $SPID"
 	kill -KILL $SPID >/dev/null 2>&1
 fi
-# 13.2) kill VNC server, VNC passwd and allow
-#       xinetd to control de VNC port again
+# 13.2) kill VNC server, VNC passwd
 if [ ! -z "$VNC" ] && [ "$VNC" -eq 1 ] ; then
 	log "\tkill all VNC sessions..."
 	killall Xvnc >/dev/null 2>&1
 	rm -fv /root/.vnc/passwd.yast
-	systemctl reload xinetd.service >/dev/null 2>&1
+	restore_xvnc
 fi
 # 13.3) stop network and sshd
 if [ "$Y2_NETWORK_ACTIVE" -ne 0 ] ; then

--- a/startup/YaST2.call
+++ b/startup/YaST2.call
@@ -165,24 +165,9 @@ function prepare_for_vnc () {
 	if [ $VNCPASS_EXCEPTION = 0 ];then
 		disable_splash
 		displayVNCMessage
-		stop_xinetd
+		stop_xvnc
 		startVNCServer
 		wait_for_x11
-		if is_xinetd_active; then
-			# xinetd shouldn't be running since we stopped it right
-			# before starting VNC. But there is still one small
-			# chance that xinetd was started by the systemd boot
-			# sequence during VNC startup. If it's running we cannot
-			# be sure that our VNC got the ports, so retry.
-			#
-			# Using systemd dependencies to ensure the correct order
-			# looks nicer, but is fragile (bnc#931643, bnc#947521).
-			killall Xvnc >/dev/null 2>&1
-			stop_xinetd
-			startVNCServer
-			wait_for_x11
-		fi
-		restore_xinetd
 		if [ "$server_running" = 1 ];then
 			log "\tXvnc-Server is ready: $xserver_pid"
 		fi

--- a/startup/common/misc.sh
+++ b/startup/common/misc.sh
@@ -186,39 +186,31 @@ function disable_splash () {
 	[ -f /proc/splash ] && echo "verbose" > /proc/splash
 }
 
-#----[ stop_xinetd ]-----#
-function stop_xinetd () {
+#----[ stop_xvnc]-----#
+function stop_xvnc () {
 #--------------------------------------------------
-# stop xinetd since its default configuration collides
+# stop xvnc since its default configuration collides
 # with the Xvnc server used for VNC installation
 # ---
-	systemctl stop xinetd.service >/dev/null 2>&1
+	systemctl stop xvnc.socket >/dev/null 2>&1
 }
 
-#----[ is_xinetd_enabled ]-----#
-function is_xinetd_enabled () {
-# return 0 if xinetd is enabled
+#----[ is_xvnc_enabled ]-----#
+function is_xvnc_enabled () {
+# return 0 if xvnc is enabled
 # ---
-	systemctl --quiet is-enabled xinetd.service >/dev/null 2>&1
+	systemctl --quiet is-enabled xvnc.socket >/dev/null 2>&1
 	return $?
 }
 
-#----[ is_xinetd_active ]-----#
-function is_xinetd_active () {
-# return 0 if xinetd is currently running
-# ---
-	systemctl --quiet is-active xinetd.service >/dev/null 2>&1
-	return $?
-}
-
-#----[ restore_xinetd ]-----#
-function restore_xinetd () {
+#----[ restore_xvnc ]-----#
+function restore_xvnc () {
 #--------------------------------------------------
-# start xinetd again if it is enabled, once the Xvnc
+# start xvnc again if it is enabled, once the Xvnc
 # server already owns its port
 # ---
-	if is_xinetd_enabled; then
-		systemctl start xinetd.service
+	if is_xvnc_enabled; then
+		systemctl start xvnc.socket
 	fi
 }
 

--- a/test/remote_finish_test.rb
+++ b/test/remote_finish_test.rb
@@ -21,7 +21,7 @@ module Yast
       end
 
       it "can be called as a WFM client with 'Write'" do
-        expect(remote).to receive(:write)
+        expect_any_instance_of(::Installation::RemoteFinishClient).to receive(:enable_remote)
         expect(Yast::WFM.CallFunction("remote_finish", ["Write"])).to be_nil
       end
     end
@@ -52,5 +52,13 @@ module Yast
       end
     end
 
+    describe "#enable_remote" do
+      it "enables remote access" do
+        expect(remote).to receive(:enable!)
+        expect(remote).to receive(:write)
+
+        subject.enable_remote
+      end
+    end
   end
 end


### PR DESCRIPTION
Alternative PR see (#659), in this PR we bring back the `xvnc.socket` enablement during the first stage when the linuxrc `vnc` option is given, the startup scripts have been adapted to stop the socket and restore it as we were doing with xinetd not supposing a problem during the `Second Stage` anymore

## Bugs related: ##

https://bugzilla.suse.com/show_bug.cgi?id=893501 (bug where the VNC service was originilally enabled during the installation)

https://bugzilla.suse.com/show_bug.cgi?id=1077236 (where it was removed due to a problem trying to launch the VNC Server during the Second Stage)

https://bugzilla.suse.com/show_bug.cgi?id=1078785 (To take in account, there is no `java client` anymore, so we should modify the current text (`startup/common/vnc.sh`) and adapt the script to serve the novnc javascript client)