### PR TITLE
Better handling of aborted libstorage-ng operations

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,15 @@
 -------------------------------------------------------------------
+Tue Feb 27 01:41:17 UTC 2018 - ancor@suse.com
+
+- More gentle handling of aborts caused by hardware probing errors
+  (bsc#1079228, bsc#1079817, bsc#1063059, bsc#1080554, bsc#1076776,
+  bsc#1070459 and some others).
+- Re-enable the old fix for bsc#298049 (abort button during ongoing
+  hardware probing).
+- Cleanup of dead code
+- 4.0.44
+
+-------------------------------------------------------------------
 Tue Feb 13 12:53:44 UTC 2018 - jreidinger@suse.com
 
 - Ensure previous role selection is cleared when doing desktop

--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -7,7 +7,7 @@ Tue Feb 27 01:41:17 UTC 2018 - ancor@suse.com
 - Re-enable the old fix for bsc#298049 (abort button during ongoing
   hardware probing).
 - Cleanup of dead code
-- 4.0.44
+- 4.0.34
 
 -------------------------------------------------------------------
 Tue Feb 13 12:53:44 UTC 2018 - jreidinger@suse.com

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.0.33
+Version:        4.0.34
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -45,9 +45,9 @@ BuildRequires:  yast2 >= 4.0.49
 # Yast::Packages.check_remote_installation_packages
 BuildRequires:	yast2-packager >= 4.0.9
 
-# Y2Storage::StorageManager#activate accepts an argument
-BuildRequires: yast2-storage-ng >= 4.0.43
-Requires:      yast2-storage-ng >= 4.0.43
+# Y2Storage::StorageManager#activate and #probe as boolean
+BuildRequires: yast2-storage-ng >= 4.0.114
+Requires:      yast2-storage-ng >= 4.0.114
 
 # Mandatory language in Product#release_notes
 Requires:       yast2 >= 4.0.49
@@ -64,11 +64,6 @@ Conflicts:	yast2-mouse < 2.18.0
 
 # Yast::Packages.check_remote_installation_packages
 Requires:	yast2-packager >= 4.0.9
-
-# FIXME: some code present in this package still depends on the old yast2-storage
-# and will break without this dependency. That's acceptable at this point of the
-# migration to storage-ng. See installer-hacks.md in the yast-storage-ng repo.
-# Requires:  yast2-storage >= 2.24.1
 
 # use in startup scripts
 Requires:	initviocons

--- a/src/lib/installation/clients/inst_system_analysis.rb
+++ b/src/lib/installation/clients/inst_system_analysis.rb
@@ -68,8 +68,6 @@ module Yast
       # always return `back when came from the previous dialog
       return :back if GetInstArgs.going_back
 
-      @found_controllers = true
-
       @packager_initialized = false
 
       Wizard.SetContents(_("Analyzing the Computer"), Empty(), "", false, false)
@@ -197,37 +195,23 @@ module Yast
       end
 
       if devicegraph.empty?
-        if @found_controllers || Arch.s390
-          if !(Mode.autoinst || Mode.autoupgrade)
-            # pop-up error report
-            Report.Error(
-              Builtins.sformat(
-                _(
-                  "No hard disks were found for the installation.\n" \
-                    "Please check your hardware!\n" \
-                    "%1\n"
-                ),
-                drivers_info
-              )
+        if Mode.auto
+          Report.Warning(
+            # TRANSLATORS: Error pop-up
+            _(
+              "No hard disks were found for the installation.\n" \
+              "During an automatic installation, they might be detected later.\n" \
+              "(especially on S/390 or iSCSI systems)\n"
             )
-          else
-            Report.Warning(
-              _(
-                "No hard disks were found for the installation.\n" \
-                  "During an automatic installation, they might be detected later.\n" \
-                  "(especially on S/390 or iSCSI systems)\n"
-              )
-            )
-          end
+          )
         else
-          # pop-up error report
           Report.Error(
             Builtins.sformat(
+              # TRANSLATORS: Error pop-up
               _(
-                "No hard disks and no hard disk controllers were\n" \
-                  "found for the installation.\n" \
-                  "Check your hardware.\n" \
-                  "%1\n"
+                "No hard disks were found for the installation.\n" \
+                "Please check your hardware!\n" \
+                "%1\n"
               ),
               drivers_info
             )

--- a/src/lib/installation/clients/inst_system_analysis.rb
+++ b/src/lib/installation/clients/inst_system_analysis.rb
@@ -59,9 +59,7 @@ module Yast
 
       # This dialog in not interactive
       # always return `back when came from the previous dialog
-      if GetInstArgs.going_back
-        return :back
-      end
+      return :back if GetInstArgs.going_back
 
       @found_controllers = true
 

--- a/src/lib/installation/clients/inst_system_analysis.rb
+++ b/src/lib/installation/clients/inst_system_analysis.rb
@@ -50,13 +50,6 @@ module Yast
       Yast.import "ProductFeatures"
       Yast.import "Progress"
       Yast.import "Report"
-# storage-ng
-# rubocop:disable Style/BlockComments
-=begin
-      Yast.import "Storage"
-      Yast.import "StorageControllers"
-      Yast.import "StorageDevices"
-=end
       Yast.import "Wizard"
       Yast.import "PackageCallbacks"
 
@@ -67,10 +60,6 @@ module Yast
       # This dialog in not interactive
       # always return `back when came from the previous dialog
       if GetInstArgs.going_back
-# storage-ng
-=begin
-        Storage.ActivateHld(false)
-=end
         return :back
       end
 
@@ -104,27 +93,7 @@ module Yast
           actions_todo      << _("Probe FireWire devices")
           actions_doing     << _("Probing FireWire devices...")
           actions_functions << fun_ref(method(:ActionFireWire), "boolean ()")
-
-# storage-ng
-=begin
-          actions_todo      << _("Probe floppy disk devices")
-          actions_doing     << _("Probing floppy disk devices...")
-          actions_functions << fun_ref(method(:ActionFloppyDisks), "boolean ()")
-=end
         end
-
-# storage-ng
-# As soon as we introduce support for RAID or multipath, we'll need to replace
-# StorageController with a new OOP way of probing and loading controllers
-=begin
-        actions_todo      << _("Probe hard disk controllers")
-        actions_doing     << _("Probing hard disk controllers...")
-        actions_functions << fun_ref(method(:ActionHHDControllers), "boolean ()")
-
-        actions_todo      << _("Load kernel modules for hard disk controllers")
-        actions_doing     << _("Loading kernel modules for hard disk controllers...")
-        actions_functions << fun_ref(method(:ActionLoadModules), "boolean ()")
-=end
 
         WFM.CallFunction("inst_features", [])
       end
@@ -200,43 +169,6 @@ module Yast
     # --------------------------------------------------------------
     def ActionFireWire
       Hotplug.StartFireWire
-
-      true
-    end
-
-    # --------------------------------------------------------------
-    #				    Floppy
-    # --------------------------------------------------------------
-    def ActionFloppyDisks
-      StorageDevices.FloppyReady
-
-      true
-    end
-
-    # --------------------------------------------------------------
-    #			     Hard disk controllers
-    # 1. Probe
-    # 2. Initialize (module loading)
-    # --------------------------------------------------------------
-    # In live_eval mode, all modules have been loaded by linuxrc. But
-    # they are loaded by StorageControllers::Initialize(). Well, there
-    # also was another reason for skipping StorageControllers::Probe ()
-    # but nobody seems to remember more.
-    # --------------------------------------------------------------
-    def ActionHHDControllers
-      @found_controllers = Ops.greater_than(StorageControllers.Probe, 0)
-
-      true
-    end
-
-    # --------------------------------------------------------------
-    # Don't abort or even warn if no storage controllers can be
-    # found.  Disks might be detected even without proper knowledge
-    # about the controller.  There's a warning below if no disks were
-    # found.
-    # --------------------------------------------------------------
-    def ActionLoadModules
-      StorageControllers.Initialize
 
       true
     end

--- a/src/lib/installation/clients/inst_system_analysis.rb
+++ b/src/lib/installation/clients/inst_system_analysis.rb
@@ -130,7 +130,7 @@ module Yast
 
           if Popup.ConfirmAbort(:painless)
             Builtins.y2warning("User decided to abort the installation")
-            next :abort
+            return :abort
           end
         end
 

--- a/test/lib/clients/inst_system_analysis_test.rb
+++ b/test/lib/clients/inst_system_analysis_test.rb
@@ -66,7 +66,7 @@ describe Yast::InstSystemAnalysisClient do
     context "when activation fails and the error is not recovered" do
       let(:activate_result) { false }
 
-      it "does not probe and raises AbortedByUserError" do
+      it "does not probe and raises AbortError" do
         expect(storage).to_not receive(:probe)
         expect { client.ActionHDDProbe }
           .to raise_error Yast::InstSystemAnalysisClient::AbortError
@@ -76,7 +76,7 @@ describe Yast::InstSystemAnalysisClient do
     context "when probing fails and the error is not recovered" do
       let(:probe_result) { false }
 
-      it "raises AbortedByUserError" do
+      it "raises AbortError" do
         expect { client.ActionHDDProbe }
           .to raise_error Yast::InstSystemAnalysisClient::AbortError
       end


### PR DESCRIPTION
Part of https://trello.com/c/ZFRZeyzr/240-3-ruby-code-handle-errors-during-probing

It also implements https://trello.com/c/LiG0TAoK/213-finish-adaptation-of-instsystemanalysis

Depends on https://github.com/yast/yast-storage-ng/pull/549

Bonus: bring back a very old fix
Bonus2: removal of dead code will prevent [bsc#1082854](https://bugzilla.suse.com/show_bug.cgi?id=1082854) in the master branch (still needs to be fixed for old branches)