### PR TITLE
Do not block autoinstallation when no disks/controllers are found

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Feb 27 14:12:10 UTC 2018 - igonzalezsosa@suse.com
+
+- Do not block autoinstallation when local disk controllers are
+  not found (bsc#1082854).
+- 3.2.51
+
+-------------------------------------------------------------------
 Thu Jan 18 13:27:26 UTC 2018 - qzhao@suse.com
 
 - Update YaST2-Firstboot.service: Depreciate plymouth --wait, add

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation
-Version:        3.2.50
+Version:        3.2.51
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/installation/clients/inst_install_inf.rb
+++ b/src/lib/installation/clients/inst_install_inf.rb
@@ -33,7 +33,7 @@ module Yast
 
     # Checks if the given url is invalid and needs to be fixed.
     #
-    # @params url [String]
+    # @param url [String]
     # @return [Boolean] return true if not nil and invalid.
     def need_fix?(url)
       url && !valid_url?(url)
@@ -68,7 +68,7 @@ module Yast
 
     # Check if the given URI is valid or not
     #
-    # @params url [String]
+    # @param url [String]
     # @return [Boolean]
     def valid_url?(url)
       VALID_URL_SCHEMES.include?(URI(url).scheme)

--- a/src/lib/installation/clients/inst_system_analysis.rb
+++ b/src/lib/installation/clients/inst_system_analysis.rb
@@ -244,7 +244,7 @@ module Yast
             Report.Error(
               Builtins.sformat(
                 _(
-                  "No hard disks were found for the installation.\n" \
+                  "No local hard disks were found for the installation.\n" \
                     "Please check your hardware!\n" \
                     "%1\n"
                 ),
@@ -254,7 +254,7 @@ module Yast
           else
             Report.Warning(
               _(
-                "No hard disks were found for the installation.\n" \
+                "No local hard disks were found for the installation.\n" \
                   "During an automatic installation, they might be detected later.\n" \
                   "(especially on S/390 or iSCSI systems)\n"
               )
@@ -266,7 +266,7 @@ module Yast
             Report.Error(
               Builtins.sformat(
                 _(
-                  "No hard disks and no hard disk controllers were\n" \
+                  "No local hard disks and no hard disk controllers were\n" \
                   "found for the installation.\n" \
                   "Check your hardware.\n" \
                   "%1\n"
@@ -279,7 +279,7 @@ module Yast
             Report.Warning(
               Builtins.sformat(
                 _(
-                  "No local hard disks and no local hard disk controllers were\n" \
+                  "No local hard disks and no hard disk controllers were\n" \
                   "found for the installation.\n" \
                   "During an automatic installation, they might be detected later.\n" \
                   "%1\n"

--- a/src/lib/installation/clients/inst_system_analysis.rb
+++ b/src/lib/installation/clients/inst_system_analysis.rb
@@ -260,34 +260,32 @@ module Yast
               )
             )
           end
+        elsif !Mode.auto
+          # pop-up error report
+          Report.Error(
+            Builtins.sformat(
+              _(
+                "No local hard disks and no hard disk controllers were\n" \
+                "found for the installation.\n" \
+                "Check your hardware.\n" \
+                "%1\n"
+              ),
+              drivers_info
+            )
+          )
         else
-          if !Mode.auto
-            # pop-up error report
-            Report.Error(
-              Builtins.sformat(
-                _(
-                  "No local hard disks and no hard disk controllers were\n" \
-                  "found for the installation.\n" \
-                  "Check your hardware.\n" \
-                  "%1\n"
-                ),
-                drivers_info
-              )
+          # pop-up warning report
+          Report.Warning(
+            Builtins.sformat(
+              _(
+                "No local hard disks and no hard disk controllers were\n" \
+                "found for the installation.\n" \
+                "During an automatic installation, they might be detected later.\n" \
+                "%1\n"
+              ),
+              drivers_info
             )
-          else
-            # pop-up warning report
-            Report.Warning(
-              Builtins.sformat(
-                _(
-                  "No local hard disks and no hard disk controllers were\n" \
-                  "found for the installation.\n" \
-                  "During an automatic installation, they might be detected later.\n" \
-                  "%1\n"
-                ),
-                drivers_info
-              )
-            )
-          end
+          )
         end
 
         return false

--- a/src/lib/installation/clients/inst_system_analysis.rb
+++ b/src/lib/installation/clients/inst_system_analysis.rb
@@ -239,7 +239,7 @@ module Yast
 
       if Builtins.size(targetMap) == 0
         if @found_controllers || Arch.s390
-          if !(Mode.autoinst || Mode.autoupgrade)
+          if !Mode.auto
             # pop-up error report
             Report.Error(
               Builtins.sformat(
@@ -261,18 +261,33 @@ module Yast
             )
           end
         else
-          # pop-up error report
-          Report.Error(
-            Builtins.sformat(
-              _(
-                "No hard disks and no hard disk controllers were\n" \
+          if !Mode.auto
+            # pop-up error report
+            Report.Error(
+              Builtins.sformat(
+                _(
+                  "No hard disks and no hard disk controllers were\n" \
                   "found for the installation.\n" \
                   "Check your hardware.\n" \
                   "%1\n"
-              ),
-              drivers_info
+                ),
+                drivers_info
+              )
             )
-          )
+          else
+            # pop-up warning report
+            Report.Warning(
+              Builtins.sformat(
+                _(
+                  "No local hard disks and no local hard disk controllers were\n" \
+                  "found for the installation.\n" \
+                  "During an automatic installation, they might be detected later.\n" \
+                  "%1\n"
+                ),
+                drivers_info
+              )
+            )
+          end
         end
 
         return false

--- a/src/lib/installation/dialogs/url_dialog.rb
+++ b/src/lib/installation/dialogs/url_dialog.rb
@@ -51,8 +51,7 @@ module Installation
 
     # Shows a dialog when the given url is wrong
     #
-    # @param [String] original Original value
-    # @return [String] new value
+    # @return [Yast::Term] Dialog's content
     def dialog_content
       VBox(
         show_heading? ? Heading(dialog_title) : Empty(),

--- a/test/inst_system_analysis_test.rb
+++ b/test/inst_system_analysis_test.rb
@@ -104,7 +104,7 @@ describe Yast::InstSystemAnalysisClient do
           end
         end
 
-        context "during autoinstallation" do
+        context "during normal installation" do
           let(:auto) { false }
 
           it "reports an error" do
@@ -126,7 +126,7 @@ describe Yast::InstSystemAnalysisClient do
           end
         end
 
-        context "during autoinstallation" do
+        context "during normal installation" do
           let(:auto) { false }
 
           it "reports an error" do
@@ -145,7 +145,7 @@ describe Yast::InstSystemAnalysisClient do
             end
           end
 
-          context "during autoinstallation" do
+          context "during normal installation" do
             let(:auto) { false }
 
             it "reports an error" do

--- a/test/inst_system_analysis_test.rb
+++ b/test/inst_system_analysis_test.rb
@@ -5,8 +5,12 @@ require "installation/clients/inst_system_analysis"
 
 Yast.import "Product"
 Yast.import "InstData"
+Yast.import "StorageDevices"
+Yast.import "StorageControllers"
 
 describe Yast::InstSystemAnalysisClient do
+  subject(:client) { Yast::InstSystemAnalysisClient.new }
+
   describe "#download_and_show_release_notes" do
     let(:product) { "openSUSE" }
     let(:notes) { "some release notes" }
@@ -25,7 +29,7 @@ describe Yast::InstSystemAnalysisClient do
       it "does not enable the button nor load release notes again" do
         expect(Yast::Wizard).to_not receive(:ShowReleaseNotesButton)
         expect(Yast::UI).to_not receive(:SetReleaseNotes)
-        subject.download_and_show_release_notes
+        client.download_and_show_release_notes
       end
     end
 
@@ -34,27 +38,121 @@ describe Yast::InstSystemAnalysisClient do
 
       context "but can be loaded from media" do
         before do
-          allow(subject).to receive(:load_release_notes).and_return(true)
-          subject.instance_variable_set(:@media_text, notes)
+          allow(client).to receive(:load_release_notes).and_return(true)
+          client.instance_variable_set(:@media_text, notes)
         end
 
         it "enables the button and load the release notes" do
           expect(Yast::Wizard).to receive(:ShowReleaseNotesButton)
           expect(Yast::UI).to receive(:SetReleaseNotes).with(product => notes)
-          subject.download_and_show_release_notes
+          client.download_and_show_release_notes
           expect(Yast::InstData.release_notes).to eq(product => notes)
         end
       end
 
       context "and could not be loaded from media" do
         before do
-          allow(subject).to receive(:load_release_notes).and_return(false)
+          allow(client).to receive(:load_release_notes).and_return(false)
         end
 
         it "does not enable the button nor load release notes" do
           expect(Yast::Wizard).to_not receive(:ShowReleaseNotesButton)
           expect(Yast::UI).to_not receive(:SetReleaseNotes)
-          subject.download_and_show_release_notes
+          client.download_and_show_release_notes
+        end
+      end
+    end
+  end
+
+  describe "#ActionHDDProbe" do
+    let(:controllers) { 1 }
+    let(:auto) { false }
+    let(:s390) { false }
+
+    before do
+      allow(Yast::StorageDevices).to receive(:Probe).and_return(target_map)
+      allow(Yast::StorageControllers).to receive(:Probe).and_return(controllers)
+      allow(Yast::Mode).to receive(:auto).and_return(auto)
+      allow(Yast::Arch).to receive(:s390).and_return(s390)
+      client.ActionHHDControllers
+    end
+
+    context "when disks were found" do
+      let(:target_map) { [{ "bus" => "ide" }] }
+
+      it "returns true" do
+        expect(client.ActionHDDProbe).to eq(true)
+      end
+    end
+
+    context "when no disk were found" do
+      let(:target_map) { [] }
+
+      it "returns false" do
+        expect(client.ActionHDDProbe).to eq(false)
+      end
+
+      context "but disk controllers were found" do
+        let(:controllers) { 1 }
+
+        context "during autoinstallation" do
+          let(:auto) { true }
+
+          it "reports a warning" do
+            expect(Yast::Report).to receive(:Warning)
+            client.ActionHDDProbe
+          end
+        end
+
+        context "during autoinstallation" do
+          let(:auto) { false }
+
+          it "reports an error" do
+            expect(Yast::Report).to receive(:Error)
+            client.ActionHDDProbe
+          end
+        end
+      end
+
+      context "and disks controllers were not found" do
+        let(:controllers) { 0 }
+
+        context "during autoinstallation" do
+          let(:auto) { true }
+
+          it "reports a warning" do
+            expect(Yast::Report).to receive(:Warning)
+            client.ActionHDDProbe
+          end
+        end
+
+        context "during autoinstallation" do
+          let(:auto) { false }
+
+          it "reports an error" do
+            expect(Yast::Report).to receive(:Error)
+            client.ActionHDDProbe
+          end
+        end
+
+        context "but is a s390 system" do
+          context "during autoinstallation" do
+            let(:auto) { true }
+
+            it "reports a warning" do
+              expect(Yast::Report).to receive(:Warning)
+              client.ActionHDDProbe
+            end
+          end
+
+          context "during autoinstallation" do
+            let(:auto) { false }
+
+            it "reports an error" do
+              expect(Yast::Report).to receive(:Error)
+              client.ActionHDDProbe
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
Fixes [bsc#1082854](https://bugzilla.suse.com/show_bug.cgi?id=1082854#c3).