### PR TITLE
Check if self_update is explicitly enabled

### DIFF
--- a/doc/SELF_UPDATE.md
+++ b/doc/SELF_UPDATE.md
@@ -259,6 +259,9 @@ Errors during the installer update are handled as described below:
 * If SCC/SMT is used and it returns no URL or fails then the fallback URL from
   `control.xml` is used.
 * If the updates repository is found but it is empty or not valid:
+  * if the installer update was enabled explicitly (using the *SelfUpdate* boot
+    option or through the *self_update* element in an AutoYaST profile), an error
+    will be shown.
   * in the case that the URL was specified by the user (using the *SelfUpdate* boot
     option or through the *self_update_url* element in an AutoYaST profile), an
     error message will be shown.

--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Mon Mar 19 22:53:57 UTC 2018 - knut.anderssen@suse.com
+
+- Self-Update report errors when the self_update is enabled
+  explicitly by linuxrc or using an AutoYaST profile.
+  (bsc#1084820)
+- 4.0.40
+
+-------------------------------------------------------------------
 Tue Mar 13 16:37:23 UTC 2018 - igonzalezsosa@suse.com
 
 - Set the 'ro' property on Btrfs filesystem when using an AutoYaST

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.0.39
+Version:        4.0.40
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/installation/update_repositories_finder.rb
+++ b/src/lib/installation/update_repositories_finder.rb
@@ -25,6 +25,7 @@ Yast.import "Linuxrc"
 Yast.import "Mode"
 Yast.import "Profile"
 Yast.import "ProductFeatures"
+Yast.import "InstFunctions"
 
 module Installation
   # Invalid registration URL error
@@ -141,7 +142,8 @@ module Installation
       # Set custom_url into installation options
       Registration::Storage::InstallationOptions.instance.custom_url = registration.url
 
-      handle_registration_errors(custom_regserver) do
+      show_errors = custom_regserver || Yast::InstFunctions.self_update_explicitly_enabled?
+      handle_registration_errors(show_errors) do
         registration.get_updates_list.map { |u| URI(u.url) }
       end
     end

--- a/src/modules/InstFunctions.rb
+++ b/src/modules/InstFunctions.rb
@@ -133,16 +133,16 @@ module Yast
     end
     alias_method :second_stage_required, :second_stage_required?
 
-    # Determine whether the installer update (self_update=1) has been
-    # explicitly enabled by linuxrc or by the AY profile. It does not check if
-    # a custom url has been provided or not.
+    # Determine whether the installer update has been explicitly enabled by
+    # linuxrc or by the AY profile.
     #
     # return [Boolean] true if enabled explicitly; false otherwise
     def self_update_explicitly_enabled?
+      # Linuxrc always export SelfUpdate with the default value even if not has
+      # been set by the user. For that reason we need to check the cmdline for
+      # knowing whether the user has requested the self update explicitly.
       cmdline = polish(Linuxrc.InstallInf("Cmdline") || "").split
-      cmdline_requested = cmdline.include?("selfupdate=1")
-
-      if cmdline_requested
+      if cmdline.find { |s| s.start_with?("selfupdate=") && s != "selfupdate=0" }
         log.info("Self update was enabled explicitly by linuxrc cmdline")
         return true
       end
@@ -150,9 +150,9 @@ module Yast
       return false unless Mode.auto
 
       profile = Yast::Profile.current
-      profile_requested = profile.fetch("general", {}).fetch("self_update", false)
-      log.info("Self update was enabled explicitly by the AY profile") if profile_requested
-      profile_requested
+      in_profile = profile.fetch("general", {}).fetch("self_update", false)
+      log.info("Self update was enabled explicitly by the AY profile") if in_profile
+      in_profile
     end
 
     publish function: :ignored_features, type: "list ()"

--- a/src/modules/InstFunctions.rb
+++ b/src/modules/InstFunctions.rb
@@ -167,7 +167,7 @@ module Yast
     def self_update_in_cmdline?
       cmdline = polish(SCR.Read(path(".target.string"), "/proc/cmdline").to_s)
 
-      !!cmdline.split.find { |s| s.start_with?("selfupdate=") && s != "selfupdate=0" }
+      cmdline.split.any? { |s| s.start_with?("selfupdate=") && s != "selfupdate=0" }
     end
 
     # Removes unneeded characters from the given string

--- a/src/modules/InstFunctions.rb
+++ b/src/modules/InstFunctions.rb
@@ -141,8 +141,8 @@ module Yast
       # Linuxrc always export SelfUpdate with the default value even if not has
       # been set by the user. For that reason we need to check the cmdline for
       # knowing whether the user has requested the self update explicitly.
-      cmdline = polish(Linuxrc.InstallInf("Cmdline") || "").split
-      if cmdline.find { |s| s.start_with?("selfupdate=") && s != "selfupdate=0" }
+      in_cmdline = Linuxrc.value_for("self_update")
+      if in_cmdline && in_cmdline != "0"
         log.info("Self update was enabled explicitly by linuxrc cmdline")
         return true
       end

--- a/test/inst_functions_test.rb
+++ b/test/inst_functions_test.rb
@@ -264,18 +264,22 @@ describe Yast::InstFunctions do
   end
 
   describe "#self_update_explicitly_enabled?" do
-    context "when self_update=1 is provided by linuxrc" do
-      it "returns true" do
-        stub_install_inf("Cmdline" => "self_update=1 textmode=0")
+    let(:linuxrc_self_update) { nil }
+    before do
+      allow(Yast::Linuxrc).to receive(:value_for).with("self_update")
+        .and_return(linuxrc_self_update)
+    end
 
+    context "when self_update=1 is provided by linuxrc" do
+      let(:linuxrc_self_update) { "1" }
+      it "returns true" do
         expect(subject.self_update_explicitly_enabled?).to eq true
       end
     end
 
     context "when self_update=custom_url is provided by linuxrc" do
+      let(:linuxrc_self_update) { "http://custom_url.com" }
       it "returns true" do
-        stub_install_inf("Cmdline" => "self_update=http://custom_url.com textmode=0")
-
         expect(subject.self_update_explicitly_enabled?).to eq true
       end
     end

--- a/test/inst_functions_test.rb
+++ b/test/inst_functions_test.rb
@@ -262,4 +262,43 @@ describe Yast::InstFunctions do
       end
     end
   end
+
+  describe "#self_update_explicitly_enabled?" do
+    context "when self_update=1 is provided by linuxrc" do
+      it "returns true" do
+        stub_install_inf("Cmdline" => "self_update=1 textmode=0")
+
+        expect(subject.self_update_explicitly_enabled?).to eq true
+      end
+    end
+
+    context "when self_update=custom_url is provided by linuxrc" do
+      it "returns true" do
+        stub_install_inf("Cmdline" => "self_update=http://custom_url.com textmode=0")
+
+        expect(subject.self_update_explicitly_enabled?).to eq true
+      end
+    end
+
+    context "when self_update is explicitly enabled in an AutoYaST profile" do
+      let(:profile) { { "general" => { "self_update" => true } } }
+
+      it "returns true" do
+        allow(Yast::Mode).to receive("auto").and_return(true)
+        allow(Yast::Profile).to receive("current").and_return(profile)
+
+        expect(subject.self_update_explicitly_enabled?).to eq true
+      end
+    end
+
+    context "when sel_update has not been explicitly enabled" do
+      it "returns false" do
+        stub_install_inf("Cmdline" => nil)
+        allow(Yast::Mode).to receive("auto").and_return(true)
+        allow(Yast::Profile).to receive("current").and_return({})
+
+        expect(subject.self_update_explicitly_enabled?).to eq false
+      end
+    end
+  end
 end

--- a/test/inst_functions_test.rb
+++ b/test/inst_functions_test.rb
@@ -264,21 +264,23 @@ describe Yast::InstFunctions do
   end
 
   describe "#self_update_explicitly_enabled?" do
-    let(:linuxrc_self_update) { nil }
+    let(:self_update_in_cmdline) { false }
     before do
       allow(Yast::Linuxrc).to receive(:value_for).with("self_update")
-        .and_return(linuxrc_self_update)
+        .and_return(self_update_in_cmdline)
+      allow(subject).to receive(:self_update_in_cmdline?)
+        .and_return(self_update_in_cmdline)
     end
 
     context "when self_update=1 is provided by linuxrc" do
-      let(:linuxrc_self_update) { "1" }
+      let(:self_update_in_cmdline) { true }
       it "returns true" do
         expect(subject.self_update_explicitly_enabled?).to eq true
       end
     end
 
     context "when self_update=custom_url is provided by linuxrc" do
-      let(:linuxrc_self_update) { "http://custom_url.com" }
+      let(:self_update_in_cmdline) { true }
       it "returns true" do
         expect(subject.self_update_explicitly_enabled?).to eq true
       end

--- a/test/lib/update_repositories_finder_test.rb
+++ b/test/lib/update_repositories_finder_test.rb
@@ -16,7 +16,7 @@ describe Installation::UpdateRepositoriesFinder do
     let(:profile) { {} }
     let(:ay_profile) { double("Yast::Profile", current: profile) }
     let(:repo) { double("UpdateRepository") }
-    let(:linuxrc_self_update) { nil }
+    let(:self_update_in_cmdline) { false }
 
     subject(:finder) { described_class.new }
 
@@ -24,8 +24,8 @@ describe Installation::UpdateRepositoriesFinder do
       stub_const("Yast::Profile", ay_profile)
       stub_const("::Registration::ConnectHelpers", FakeConnectHelpers)
       allow(finder).to receive(:require).with("registration/connect_helpers")
-      allow(Yast::Linuxrc).to receive("value_for").with("self_update")
-        .and_return(linuxrc_self_update)
+      allow(Yast::InstFunctions).to receive("self_update_in_cmdline?")
+        .and_return(self_update_in_cmdline)
       allow(Yast::Linuxrc).to receive(:InstallInf).with("SelfUpdate")
         .and_return(url_from_linuxrc)
       allow(Yast::Pkg).to receive(:GetArchitecture).and_return(arch)
@@ -189,7 +189,7 @@ describe Installation::UpdateRepositoriesFinder do
           end
 
           context "and enables the installer update explicitly by linuxrc" do
-            let(:linuxrc_self_update) { "1" }
+            let(:self_update_in_cmdline) { true }
 
             it "handles registration errors" do
               expect(Registration::ConnectHelpers).to receive(:catch_registration_errors)

--- a/test/lib/update_repositories_finder_test.rb
+++ b/test/lib/update_repositories_finder_test.rb
@@ -16,6 +16,7 @@ describe Installation::UpdateRepositoriesFinder do
     let(:profile) { {} }
     let(:ay_profile) { double("Yast::Profile", current: profile) }
     let(:repo) { double("UpdateRepository") }
+    let(:linuxrc_cmdline) { "" }
 
     subject(:finder) { described_class.new }
 
@@ -23,6 +24,8 @@ describe Installation::UpdateRepositoriesFinder do
       stub_const("Yast::Profile", ay_profile)
       stub_const("::Registration::ConnectHelpers", FakeConnectHelpers)
       allow(finder).to receive(:require).with("registration/connect_helpers")
+      allow(Yast::Linuxrc).to receive(:InstallInf).with("Cmdline")
+        .and_return(linuxrc_cmdline)
       allow(Yast::Linuxrc).to receive(:InstallInf).with("SelfUpdate")
         .and_return(url_from_linuxrc)
       allow(Yast::Pkg).to receive(:GetArchitecture).and_return(arch)
@@ -185,9 +188,33 @@ describe Installation::UpdateRepositoriesFinder do
             finder.updates
           end
 
-          it "does not handle registration errors" do
-            expect(Registration::ConnectHelpers).to_not receive(:catch_registration_errors)
-            finder.updates
+          context "and enables the installer update explicitly by linuxrc" do
+            let(:linuxrc_cmdline) { "self_update=1 ifcfg=*= dhcp" }
+
+            it "handles registration errors" do
+              expect(Registration::ConnectHelpers).to receive(:catch_registration_errors)
+                .and_call_original
+              finder.updates
+            end
+          end
+
+          context "and enables the installer update explicitly by an AutoYaST profile" do
+            let(:profile) { { "general" => { "self_update" => true } } }
+
+            it "handles registration errors" do
+              allow(Yast::Mode).to receive(:auto).and_return(true)
+              allow(finder).to receive(:import_registration_ayconfig)
+              expect(Registration::ConnectHelpers).to receive(:catch_registration_errors)
+                .and_call_original
+              finder.updates
+            end
+          end
+
+          context "and does not enable the installer update explicitly" do
+            it "does not handle registration errors" do
+              expect(Registration::ConnectHelpers).to_not receive(:catch_registration_errors)
+              finder.updates
+            end
           end
         end
 

--- a/test/lib/update_repositories_finder_test.rb
+++ b/test/lib/update_repositories_finder_test.rb
@@ -16,7 +16,7 @@ describe Installation::UpdateRepositoriesFinder do
     let(:profile) { {} }
     let(:ay_profile) { double("Yast::Profile", current: profile) }
     let(:repo) { double("UpdateRepository") }
-    let(:linuxrc_cmdline) { "" }
+    let(:linuxrc_self_update) { nil }
 
     subject(:finder) { described_class.new }
 
@@ -24,8 +24,8 @@ describe Installation::UpdateRepositoriesFinder do
       stub_const("Yast::Profile", ay_profile)
       stub_const("::Registration::ConnectHelpers", FakeConnectHelpers)
       allow(finder).to receive(:require).with("registration/connect_helpers")
-      allow(Yast::Linuxrc).to receive(:InstallInf).with("Cmdline")
-        .and_return(linuxrc_cmdline)
+      allow(Yast::Linuxrc).to receive("value_for").with("self_update")
+        .and_return(linuxrc_self_update)
       allow(Yast::Linuxrc).to receive(:InstallInf).with("SelfUpdate")
         .and_return(url_from_linuxrc)
       allow(Yast::Pkg).to receive(:GetArchitecture).and_return(arch)
@@ -189,7 +189,7 @@ describe Installation::UpdateRepositoriesFinder do
           end
 
           context "and enables the installer update explicitly by linuxrc" do
-            let(:linuxrc_cmdline) { "self_update=1 ifcfg=*= dhcp" }
+            let(:linuxrc_self_update) { "1" }
 
             it "handles registration errors" do
               expect(Registration::ConnectHelpers).to receive(:catch_registration_errors)


### PR DESCRIPTION
- https://trello.com/c/syNlrXoP/1371-3-p1-1084820-handle-selfupdate-during-autoupgrade-correctly

With this PR we will show also errors getting the list of update repositories when self_update has been explicitly enabled.

Test units are missing, and if the approach is OK will also update the documentation of errors handling.

## Manual tests

For the manual tests a Report has been added but it is not part of the PR.

### No enabled explicitly

![notshownerrors](https://user-images.githubusercontent.com/7056681/37643464-89ff4cb0-2c18-11e8-8c10-76ab20196165.jpg)

### Enable with linuxrc `self_update=1`

![errorsshown](https://user-images.githubusercontent.com/7056681/37643608-fe2e6bca-2c18-11e8-8dc8-98cd44bfce0d.jpg)

### Enable in the AY profile `/general/self_update`

![errorsshownay](https://user-images.githubusercontent.com/7056681/37643575-e0f19e4c-2c18-11e8-8bfb-d3a80fe7a516.jpg)


