### PR TITLE
System roles: make the radio buttons match other dialogs, using images

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Mar 23 09:57:56 UTC 2018 - mvidner@suse.com
+
+- System roles: make the radio buttons match other dialogs,
+  using images (bsc#1084674)
+- 4.0.42
+
+-------------------------------------------------------------------
 Tue Mar 20 16:10:24 UTC 2018 - mvidner@suse.com
 
 - Make many system roles fit in the dialog (using a RichText

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.0.41
+Version:        4.0.42
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/installation/select_system_role.rb
+++ b/src/lib/installation/select_system_role.rb
@@ -76,7 +76,7 @@ module Installation
       @selected_role_id = self.class.original_role_id
       @selected_role_id ||= roles.first && roles.first.id if SystemRole.default?
 
-      HSquash(ReplacePoint(Id(:rp), role_buttons(selected_role_id: @selected_role_id)))
+      HCenter(ReplacePoint(Id(:rp), role_buttons(selected_role_id: @selected_role_id)))
     end
 
     def create_dialog

--- a/src/lib/installation/select_system_role.rb
+++ b/src/lib/installation/select_system_role.rb
@@ -257,14 +257,21 @@ module Installation
       "#{enabled_widget}<br>"
     end
 
+    IMAGE_DIR = "/usr/share/YaST2/theme/current/wizard".freeze
+
     BUTTON_ON = "◉".freeze # U+25C9 Fisheye
     BUTTON_OFF = "○".freeze # U+25CB White Circle
 
     def richtext_radiobutton_gui(id:, label:, selected:)
-      check = selected ? BUTTON_ON : BUTTON_OFF
-      widget = "#{check} #{label}"
       # check for installation style, which is dark, FIXME: find better way
       installation = ENV["Y2STYLE"] == "installation.qss"
+      if installation
+        image = selected ? "inst_radio-button-checked.png" : "inst_radio-button-unchecked.png"
+        bullet = "<img src=\"#{IMAGE_DIR}/#{image}\"></img>"
+      else
+        bullet = selected ? BUTTON_ON : BUTTON_OFF
+      end
+      widget = "#{bullet} #{label}"
       color = installation ? "white" : "black"
       enabled_widget = "<a style='text-decoration:none; color:#{color}' href=\"#{id}\">#{widget}</a>"
       "<p>#{enabled_widget}</p>"

--- a/src/lib/installation/select_system_role.rb
+++ b/src/lib/installation/select_system_role.rb
@@ -17,6 +17,7 @@
 #  To contact SUSE about this file by physical or electronic mail,
 #  you may find current contact information at www.suse.com
 
+require "cgi"
 require "yast"
 require "ui/installation_dialog"
 require "installation/services"
@@ -229,7 +230,7 @@ module Installation
                                   label:    role.label,
                                   selected: role.id == selected_role_id)
 
-        description = description.gsub("\n", "<br>\n")
+        description = CGI.escape_html(description).gsub("\n", "<br>\n")
         # extra empty paragraphs for better spacing
         "<p></p>#{rb}<p></p><ul>#{description}</ul>"
       end
@@ -252,7 +253,7 @@ module Installation
 
     def richtext_radiobutton_tui(id:, label:, selected:)
       check = selected ? "(x)" : "( )"
-      widget = "#{check} #{label}"
+      widget = "#{check} #{CGI.escape_html(label)}"
       enabled_widget = "<a href=\"#{id}\">#{widget}</a>"
       "#{enabled_widget}<br>"
     end
@@ -271,7 +272,7 @@ module Installation
       else
         bullet = selected ? BUTTON_ON : BUTTON_OFF
       end
-      widget = "#{bullet} #{label}"
+      widget = "#{bullet} #{CGI.escape_html(label)}"
       color = installation ? "white" : "black"
       enabled_widget = "<a style='text-decoration:none; color:#{color}' href=\"#{id}\">#{widget}</a>"
       "<p>#{enabled_widget}</p>"


### PR DESCRIPTION
A fixup of #671
 https://trello.com/c/WmjvFAZP/1370-5-system-roles-dialog-with-8-roles

![six-roles-gui-rb2](https://user-images.githubusercontent.com/102056/37832838-13080b08-2eaa-11e8-8b21-9dd70b91f922.png)
![six-roles-tui-rb2](https://user-images.githubusercontent.com/102056/37832843-16e2a4ea-2eaa-11e8-9d73-43aadc925133.png)

