### PR TITLE
Use new exception

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Apr  6 17:25:51 UTC 2018 - jlopez@suse.com
+
+- Use AbortException when user aborts (part of fate#318196).
+- 4.0.45
+
+-------------------------------------------------------------------
 Fri Apr  6 12:26:45 UTC 2018 - mvidner@suse.com
 
 - Start web VNC for the installation process (bsc#1078785)

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.0.44
+Version:        4.0.45
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -25,8 +25,8 @@ Source0:        %{name}-%{version}.tar.bz2
 Group:          System/YaST
 License:        GPL-2.0
 Url:            http://github.com/yast/yast-installation
-# new y2start script
-Requires:       yast2-ruby-bindings >= 3.2.10
+# for AbortException and handle direct abort
+Requires:       yast2-ruby-bindings >= 4.0.6
 
 Summary:        YaST2 - Installation Parts
 
@@ -35,6 +35,8 @@ Source2:	YaST2-Firstboot.service
 
 BuildRequires:  update-desktop-files
 BuildRequires:  yast2-devtools >= 3.1.10
+# for AbortException and handle direct abort
+BuildRequires:  yast2-ruby-bindings >= 4.0.6
 # needed for xml agent reading about products
 BuildRequires:  yast2-xml
 BuildRequires:  rubygem(rspec)

--- a/src/lib/installation/clients/inst_system_analysis.rb
+++ b/src/lib/installation/clients/inst_system_analysis.rb
@@ -32,11 +32,6 @@ module Yast
   class InstSystemAnalysisClient < Client
     include Yast::Logger
 
-    # Custom exception class to indicate the user (or the AutoYaST profile)
-    # decided to abort the installation due to a libstorage-ng error
-    class AbortError < RuntimeError
-    end
-
     def main
       Yast.import "UI"
 
@@ -142,7 +137,7 @@ module Yast
         begin
           ret = run_function.call
           Builtins.y2milestone("Function %1 returned %2", run_function, ret)
-        rescue AbortError
+        rescue AbortException
           return :abort
         end
 
@@ -179,7 +174,7 @@ module Yast
 
     #	Hard disks initialization
     #
-    # @raise [AbortError] if an error is found and the installation must
+    # @raise [AbortException] if an error is found and the installation must
     #   be aborted because of such error
     def ActionHDDProbe
       init_storage
@@ -285,7 +280,7 @@ module Yast
     # Reprobing ensures we don't bring bug#806454 back and invalidates cached
     # proposal, so we are also safe from bug#865579.
     #
-    # @raise [AbortError] if an error is found and the installation must
+    # @raise [AbortException] if an error is found and the installation must
     #   be aborted because of such error
     def init_storage
       success = storage_manager.activate(activate_callbacks)
@@ -293,7 +288,7 @@ module Yast
       return if success
 
       log.info "A storage error was raised and the installation must be aborted."
-      raise AbortError, "User aborted"
+      raise AbortException, "User aborted"
     end
 
     # @return [Y2Storage::StorageManager]

--- a/test/lib/clients/inst_system_analysis_test.rb
+++ b/test/lib/clients/inst_system_analysis_test.rb
@@ -66,19 +66,17 @@ describe Yast::InstSystemAnalysisClient do
     context "when activation fails and the error is not recovered" do
       let(:activate_result) { false }
 
-      it "does not probe and raises AbortError" do
+      it "does not probe and raises AbortException" do
         expect(storage).to_not receive(:probe)
-        expect { client.ActionHDDProbe }
-          .to raise_error Yast::InstSystemAnalysisClient::AbortError
+        expect { client.ActionHDDProbe }.to raise_error Yast::AbortException
       end
     end
 
     context "when probing fails and the error is not recovered" do
       let(:probe_result) { false }
 
-      it "raises AbortError" do
-        expect { client.ActionHDDProbe }
-          .to raise_error Yast::InstSystemAnalysisClient::AbortError
+      it "raises AbortException" do
+        expect { client.ActionHDDProbe }.to raise_error Yast::AbortException
       end
     end
   end


### PR DESCRIPTION
Part of PBI: https://trello.com/c/jItiacnG/335-readd-system-wide-lock-in-libstorage-ng

See here definition of new `Yast::AbortException`: https://github.com/yast/yast-ruby-bindings/pull/215  