### PR TITLE
Don't hard-code the role text color

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Apr 16 12:50:00 UTC 2018 - mvidner@suse.com
+
+- Don't hard-code the role text color (bsc#1087399).
+- 4.0.48
+
+-------------------------------------------------------------------
 Mon Apr 16 11:08:57 UTC 2018 - jreidinger@suse.com
 
 - Ensure proper patterns are selected when going back to system

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.0.47
+Version:        4.0.48
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/installation/select_system_role.rb
+++ b/src/lib/installation/select_system_role.rb
@@ -288,8 +288,7 @@ module Installation
         bullet = selected ? BUTTON_ON : BUTTON_OFF
       end
       widget = "#{bullet} #{CGI.escape_html(label)}"
-      color = installation ? "white" : "black"
-      enabled_widget = "<a style='text-decoration:none; color:#{color}' href=\"#{id}\">#{widget}</a>"
+      enabled_widget = "<a class='dontlooklikealink' href=\"#{id}\">#{widget}</a>"
       "<p>#{enabled_widget}</p>"
     end
   end


### PR DESCRIPTION
- [bsc#1087399](https://bugzilla.suse.com/show_bug.cgi?id=1087399)
- https://trello.com/c/VasiMQRM/1401-2-bug-1087399-sle-hardcodes-text-color-making-kubic-white-on-white

Requires matching changes:

- https://github.com/yast/yast-theme/pull/85 so that SLE15 keeps looking the same
- https://github.com/openSUSE/branding/pull/90 so that Kubic looks decent

Screenshot of Kubic:
![roles-styled-kubic](https://user-images.githubusercontent.com/102056/38819696-61520282-419c-11e8-8301-be5487384e9c.png)


Screenshot of SLE4SAP: nothing interesting, it looks like before, which it should:
![roles-styled](https://user-images.githubusercontent.com/102056/38814663-4f4501f2-4192-11e8-8d8e-6d78fa5ec500.png)
