### PR TITLE
Log more details when unmounting fails (to debug bsc#1090018)

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Apr 19 13:05:23 UTC 2018 - lslezak@suse.cz
+
+- Log more details when unmounting the target partition fails
+  (to debug bsc#1090018)
+- 4.0.50
+
+-------------------------------------------------------------------
 Tue Apr 17 12:37:12 UTC 2018 - igonzalezsosa@suse.com
 
 - Installer Updates does not overwrite Driver Updates

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.0.49
+Version:        4.0.50
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/installation/clients/umount_finish.rb
+++ b/src/lib/installation/clients/umount_finish.rb
@@ -159,13 +159,14 @@ module Yast
             WFM.Execute(path(".local.umount"), umount_this)
           )
           if umount_result != true
-            begin
-              # the details are printed on STDERR, redirect it
-              fuser = `LC_ALL=C fuser -v -m #{Shellwords.escape(umount_this)} 2>&1`
-              log.warn("Running processes using #{umount_this}: #{fuser}")
-            rescue Errno::ENOENT
-              log.warn("Calling fuser failed, probably not installed")
-            end
+            # run "fuser" to get the details about open files
+            # (the details are printed on STDERR, redirect it)
+            fuser = begin
+                      `LC_ALL=C fuser -v -m #{Shellwords.escape(umount_this)} 2>&1`
+                    rescue
+                      "fuser failed: #{$ERROR_INFO}"
+                    end
+            log.warn("Running processes using #{umount_this}: #{fuser}")
             # bnc #395034
             # Don't remount them read-only!
             if Builtins.contains(

--- a/src/lib/installation/clients/umount_finish.rb
+++ b/src/lib/installation/clients/umount_finish.rb
@@ -159,9 +159,13 @@ module Yast
             WFM.Execute(path(".local.umount"), umount_this)
           )
           if umount_result != true
-            # the details are printed on STDERR, redirect it
-            fuser = `LC_ALL=C fuser -v -m #{Shellwords.escape(umount_this)} 2>&1`
-            log.warn("Running processes using #{umount_this}: #{fuser}")
+            begin
+              # the details are printed on STDERR, redirect it
+              fuser = `LC_ALL=C fuser -v -m #{Shellwords.escape(umount_this)} 2>&1`
+              log.warn("Running processes using #{umount_this}: #{fuser}")
+            rescue Errno::ENOENT
+              log.warn("Calling fuser failed, probably not installed")
+            end
             # bnc #395034
             # Don't remount them read-only!
             if Builtins.contains(

--- a/src/lib/installation/clients/umount_finish.rb
+++ b/src/lib/installation/clients/umount_finish.rb
@@ -30,6 +30,7 @@
 
 require "y2storage"
 require "pathname"
+require "shellwords"
 
 module Yast
   class UmountFinishClient < Client
@@ -158,6 +159,9 @@ module Yast
             WFM.Execute(path(".local.umount"), umount_this)
           )
           if umount_result != true
+            # the details are printed on STDERR, redirect it
+            fuser = `LC_ALL=C fuser -v -m #{Shellwords.escape(umount_this)} 2>&1`
+            log.warn("Running processes using #{umount_this}: #{fuser}")
             # bnc #395034
             # Don't remount them read-only!
             if Builtins.contains(

--- a/src/lib/installation/clients/umount_finish.rb
+++ b/src/lib/installation/clients/umount_finish.rb
@@ -163,8 +163,8 @@ module Yast
             # (the details are printed on STDERR, redirect it)
             fuser = begin
                       `LC_ALL=C fuser -v -m #{Shellwords.escape(umount_this)} 2>&1`
-                    rescue
-                      "fuser failed: #{$ERROR_INFO}"
+                    rescue => e
+                      "fuser failed: #{e}"
                     end
             log.warn("Running processes using #{umount_this}: #{fuser}")
             # bnc #395034


### PR DESCRIPTION
- Unmounting `/mnt` fails with "umount: /mnt: target is busy" error
- See https://bugzilla.suse.com/show_bug.cgi?id=1090018
- I have no idea why it fails, likely some `%post` script started a process or maybe YaST keeps some file opened
- To help with debugging log the `fuser` output to see which process use that mount point
- 4.0.50