### PR TITLE
Fix "installation settings" support for RTL languages

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Apr 25 06:03:53 UTC 2018 - igonzalezsosa@suse.com
+
+- Fix text direction for RTL languages in the installer settings
+  screen (bsc#1089846).
+- 4.0.52
+
+-------------------------------------------------------------------
 Tue Apr 24 11:41:26 UTC 2018 - mvidner@suse.com
 
 - Fixed "vnc.sh: /root/.profile: No such file or directory"

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.0.51
+Version:        4.0.52
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -42,8 +42,8 @@ BuildRequires:  yast2-xml
 BuildRequires:  rubygem(rspec)
 BuildRequires:  rubygem(yast-rake)
 
-# Mandatory language in Product#release_notes
-BuildRequires:  yast2 >= 4.0.49
+# TextHelpers#div_with_direction
+BuildRequires:  yast2 >= 4.0.72
 # Yast::Packages.check_remote_installation_packages
 BuildRequires:	yast2-packager >= 4.0.9
 
@@ -51,8 +51,8 @@ BuildRequires:	yast2-packager >= 4.0.9
 BuildRequires: yast2-storage-ng >= 4.0.114
 Requires:      yast2-storage-ng >= 4.0.114
 
-# Mandatory language in Product#release_notes
-Requires:       yast2 >= 4.0.49
+# TextHelpers#div_with_direction
+Requires:       yast2 >= 4.0.72
 
 # Language::GetLanguageItems and other API
 # Language::Set (handles downloading the translation extensions)

--- a/src/lib/installation/proposal_runner.rb
+++ b/src/lib/installation/proposal_runner.rb
@@ -268,7 +268,7 @@ module Installation
       @submodules_presentation.each do |mod|
         @proposal << (@html[mod] || "")
       end
-      display_proposal(@proposal)
+      display_proposal(div_with_direction(@proposal))
       submod_descriptions_and_build_menu
     end
 
@@ -478,7 +478,7 @@ module Installation
           proposal = presentation_modules.reduce("") do |res, mod|
             res << (@html[mod] || "")
           end
-          display_proposal(proposal)
+          display_proposal(div_with_direction(proposal))
         end
       end
 

--- a/src/lib/installation/select_system_role.rb
+++ b/src/lib/installation/select_system_role.rb
@@ -22,6 +22,7 @@ require "yast"
 require "ui/installation_dialog"
 require "installation/services"
 require "installation/system_role"
+require "ui/text_helpers"
 
 Yast.import "GetInstArgs"
 Yast.import "Packages"
@@ -32,6 +33,8 @@ Yast.import "ProductFeatures"
 
 module Installation
   class SelectSystemRole < ::UI::InstallationDialog
+    include UI::TextHelpers
+
     class << self
       # once the user selects a role, remember it in case they come back
       attr_accessor :original_role_id
@@ -254,7 +257,7 @@ module Installation
       VBox(
         Left(Label(intro_text)),
         VSpacing(2),
-        RichText(Id(:roles_richtext), role_rt_radios.join("\n"))
+        RichText(Id(:roles_richtext), div_with_direction(role_rt_radios.join("\n")))
       )
     end
 
@@ -283,7 +286,10 @@ module Installation
       installation = ENV["Y2STYLE"] == "installation.qss"
       if installation
         image = selected ? "inst_radio-button-checked.png" : "inst_radio-button-unchecked.png"
-        bullet = "<img src=\"#{IMAGE_DIR}/#{image}\"></img>"
+        # NOTE: due to a Qt bug, the first image does not get rendered properly. So we are
+        # rendering it twice (one with height and width set to "0").
+        bullet = "<img src=\"#{IMAGE_DIR}/#{image}\" height=\"0\" width=\"0\"></img>" \
+                 "<img src=\"#{IMAGE_DIR}/#{image}\"></img>"
       else
         bullet = selected ? BUTTON_ON : BUTTON_OFF
       end

--- a/test/select_system_role_test.rb
+++ b/test/select_system_role_test.rb
@@ -14,6 +14,7 @@ describe ::Installation::SelectSystemRole do
     end
 
     allow(Yast::UI).to receive(:ChangeWidget)
+    allow(Yast::Language).to receive(:language).and_return("en_US")
 
     Installation::SystemRole.clear # Clear system roles cache
   end


### PR DESCRIPTION
* Related to https://github.com/yast/yast-yast2/pull/730 and https://github.com/yast/yast-packager/pull/348.

## Before

![qt-ar-installation-settings-pre](https://user-images.githubusercontent.com/15836/39228888-25ee95bc-4858-11e8-848d-7127ee170bbd.png)

Main problems: the 'plus' signs in the list of patterns and the alignment of other elements like 'Kdump' title or 'SSH' settings.

## After

![qt-ar-installation-settings](https://user-images.githubusercontent.com/15836/39228769-ae4c125a-4857-11e8-8b3a-649e2b751e15.png)

![qt-en-installation-settings](https://user-images.githubusercontent.com/15836/39228776-b36c1b72-4857-11e8-8804-143575cf3515.png)

![qt-ar-system-role-selection](https://user-images.githubusercontent.com/15836/39243596-e21aedee-4885-11e8-8e54-2f6e90d2ef03.png)

## SLE 12 (for comparison)

![qt-ar-installation-settings-sle12](https://user-images.githubusercontent.com/15836/39229416-a2f93eca-485a-11e8-8c59-80355e01992b.png)
