### PR TITLE
Copy new storage-inst/ subdir to target at the end of the installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM yastdevel/ruby
+FROM yastdevel/ruby:sle15
 COPY . /usr/src/app
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,7 @@
 require "yast/rake"
 
+Yast::Tasks.submit_to :sle15
+
 Yast::Tasks.configuration do |conf|
   # lets ignore license check for now
   conf.skip_license_check << /.*/

--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Apr 24 11:41:26 UTC 2018 - mvidner@suse.com
+
+- Fixed "vnc.sh: /root/.profile: No such file or directory"
+  (bsc#1089623).
+- 4.0.51
+
+-------------------------------------------------------------------
 Thu Apr 19 13:05:23 UTC 2018 - lslezak@suse.cz
 
 - Log more details when unmounting the target partition fails

--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Apr 25 06:03:53 UTC 2018 - igonzalezsosa@suse.com
+
+- Fix text direction for RTL languages in the installer settings
+  screen (bsc#1089846).
+- 4.0.52
+
+-------------------------------------------------------------------
 Tue Apr 24 11:41:26 UTC 2018 - mvidner@suse.com
 
 - Fixed "vnc.sh: /root/.profile: No such file or directory"

--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Apr 27 15:07:15 UTC 2018 - igonzalezsosa@suse.com
+
+- Do not warn too soon about missing disks during autoinstallation
+  (bsc#1091033)
+- 4.0.55
+
+-------------------------------------------------------------------
 Fri Apr 27 13:22:53 UTC 2018 - lslezak@suse.cz
 
 - Better handle the restore scripts when YaST is aborted or

--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed May  2 15:44:18 UTC 2018 - shundhammer@suse.com
+
+- Copy new /var/log/YaST2/storage-inst/ subdir to target at the
+  end of the installation (part of fate #318196)
+- 4.0.56
+
+-------------------------------------------------------------------
 Fri Apr 27 15:07:15 UTC 2018 - igonzalezsosa@suse.com
 
 - Do not warn too soon about missing disks during autoinstallation

--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Apr 25 10:43:58 UTC 2018 - jreidinger@suse.com
+
+- fix regression to show again iscsi configuration for disk-less
+  setup  (bsc#1090753)
+- 4.0.53
+
+-------------------------------------------------------------------
 Wed Apr 25 06:03:53 UTC 2018 - igonzalezsosa@suse.com
 
 - Fix text direction for RTL languages in the installer settings

--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Fri Apr 27 13:22:53 UTC 2018 - lslezak@suse.cz
+
+- Better handle the restore scripts when YaST is aborted or
+  crashes (bsc#1089643)
+- Delete the .repo files accidentally saved into inst-sys
+  (fixes problems when restarting YaST after abort or crash)
+- 4.0.54
+
+-------------------------------------------------------------------
 Wed Apr 25 10:43:58 UTC 2018 - jreidinger@suse.com
 
 - fix regression to show again iscsi configuration for disk-less

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.0.55
+Version:        4.0.56
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.0.52
+Version:        4.0.53
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -47,9 +47,9 @@ BuildRequires:  yast2 >= 4.0.72
 # Yast::Packages.check_remote_installation_packages
 BuildRequires:	yast2-packager >= 4.0.9
 
-# Y2Storage::StorageManager#activate and #probe as boolean
-BuildRequires: yast2-storage-ng >= 4.0.114
-Requires:      yast2-storage-ng >= 4.0.114
+# Y2Storage::StorageManager#devices_for_installation?
+BuildRequires: yast2-storage-ng >= 4.0.168
+Requires:      yast2-storage-ng >= 4.0.168
 
 # TextHelpers#div_with_direction
 Requires:       yast2 >= 4.0.72

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.0.53
+Version:        4.0.54
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.0.50
+Version:        4.0.51
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.0.51
+Version:        4.0.52
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -42,8 +42,8 @@ BuildRequires:  yast2-xml
 BuildRequires:  rubygem(rspec)
 BuildRequires:  rubygem(yast-rake)
 
-# Mandatory language in Product#release_notes
-BuildRequires:  yast2 >= 4.0.49
+# TextHelpers#div_with_direction
+BuildRequires:  yast2 >= 4.0.72
 # Yast::Packages.check_remote_installation_packages
 BuildRequires:	yast2-packager >= 4.0.9
 
@@ -51,8 +51,8 @@ BuildRequires:	yast2-packager >= 4.0.9
 BuildRequires: yast2-storage-ng >= 4.0.114
 Requires:      yast2-storage-ng >= 4.0.114
 
-# Mandatory language in Product#release_notes
-Requires:       yast2 >= 4.0.49
+# TextHelpers#div_with_direction
+Requires:       yast2 >= 4.0.72
 
 # Language::GetLanguageItems and other API
 # Language::Set (handles downloading the translation extensions)

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.0.54
+Version:        4.0.55
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/include/installation/inst_inc_all.rb
+++ b/src/include/installation/inst_inc_all.rb
@@ -26,6 +26,9 @@
 #
 # $Id$
 #
+
+require "y2storage"
+
 module Yast
   module InstallationInstIncAllInclude
     def initialize_installation_inst_inc_all(_include_target)
@@ -42,11 +45,6 @@ module Yast
       Yast.import "Installation"
       Yast.import "Stage"
       Yast.import "Mode"
-# storage-ng
-# rubocop:disable Style/BlockComments
-=begin
-      Yast.import "Storage"
-=end
     end
 
     def SetInitializingUI
@@ -243,11 +241,7 @@ module Yast
       # disable disks activation if not needed
       iscsi = Linuxrc.InstallInf("WithiSCSI") == "1"
       fcoe = Linuxrc.InstallInf("WithFCoE") == "1"
-      # storage-ng
-      no_disk = false
-=begin
-      no_disk = Builtins.isempty(Storage.GetDetectedDiskPaths)
-=end
+      no_disk = !::Y2Storage::StorageManager.instance.devices_for_installation?
 
       if !((Arch.s390 && !Arch.is_zkvm) || iscsi || fcoe || no_disk)
         Builtins.y2milestone("Disabling disk activation module")

--- a/src/lib/installation/clients/inst_system_analysis.rb
+++ b/src/lib/installation/clients/inst_system_analysis.rb
@@ -189,29 +189,21 @@ module Yast
         drivers_info = ""
       end
 
-      if devicegraph.empty?
-        if Mode.auto
-          Report.Warning(
+      # This error message is only shown when no disks where found during a normal
+      # installation. The autoinstallation case will be handled later by AutoYaST at
+      # https://github.com/yast/yast-autoinstallation/blob/8e414637d8157462bee5e1ee29c5d2e747754670/src/modules/AutoinstStorage.rb#L334
+      if devicegraph.empty? && !Mode.auto?
+        Report.Error(
+          Builtins.sformat(
             # TRANSLATORS: Error pop-up
             _(
               "No hard disks were found for the installation.\n" \
-              "During an automatic installation, they might be detected later.\n" \
-              "(especially on S/390 or iSCSI systems)\n"
-            )
+              "Please check your hardware!\n" \
+              "%1\n"
+            ),
+            drivers_info
           )
-        else
-          Report.Error(
-            Builtins.sformat(
-              # TRANSLATORS: Error pop-up
-              _(
-                "No hard disks were found for the installation.\n" \
-                "Please check your hardware!\n" \
-                "%1\n"
-              ),
-              drivers_info
-            )
-          )
-        end
+        )
 
         return false
       end

--- a/src/lib/installation/copy_logs_finish.rb
+++ b/src/lib/installation/copy_logs_finish.rb
@@ -47,6 +47,8 @@ module Installation
     end
 
     PREFIX_SIZE = "y2log-".size
+    STORAGE_DUMP_DIR = "storage-inst".freeze
+
     def write
       log_files = Yast::WFM.Read(Yast::Path.new(".local.dir"), Yast::Directory.logdir)
 
@@ -70,38 +72,48 @@ module Installation
           )
           # call gzip with -f to avoid stuck during race condition when log
           # rotator also gzip file and gzip then wait for input (bnc#897091)
-          compress_cmd = "gzip -f #{target_path}"
-          log.debug "Compress command: #{compress_cmd}"
-          Yast::WFM.Execute(LOCAL_BASH, compress_cmd)
+          shell_cmd("/usr/bin/gzip -f '#{target_path}'")
         when /\Ay2log-\d+\.gz\z/
           target_no = file[/y2log-(\d+)/, 1].to_i + 1
           copy_log_to_target(file, "y2log-#{target_no}.gz")
         when "zypp.log"
           # Save zypp.log from the inst-sys
           copy_log_to_target(file, "zypp.log-1") # not y2log, y2log-*
+        when "pbl.log"
+          copy_log_to_target("pbl_log", "pbl-instsys.log")
+        when STORAGE_DUMP_DIR
+          copy_storage_inst_subdir
         else
           copy_log_to_target(file)
         end
       end
-
-      copy_cmd = "/bin/cp /var/log/pbl.log '#{Yast::Installation.destdir}/#{Yast::Directory.logdir}/pbl-instsys.log'"
-      log.debug "Copy command: #{copy_cmd}"
-      Yast::WFM.Execute(LOCAL_BASH, copy_cmd)
 
       nil
     end
 
   private
 
-    def copy_log_to_target(src_file, dst_file = src_file)
-      dir = Yast::Directory.logdir
-      src_path = "#{dir}/#{src_file}"
-      dst_path = "#{Yast::Installation.destdir}/#{dir}/#{dst_file}"
-      command = "/bin/cp #{src_path} #{dst_path}"
+    def copy_log_to_target(src_file, dest_file = src_file)
+      shell_cmd("/bin/cp '#{src_dir}/#{src_file}' '#{dest_dir}/#{dest_file}'")
+    end
 
-      log.info "copy log with '#{command}'"
+    def copy_storage_inst_subdir
+      return if dest_dir == "/"
+      shell_cmd("/bin/rm -rf '#{dest_dir}/#{STORAGE_DUMP_DIR}'")
+      shell_cmd("/bin/cp -r '#{src_dir}/#{STORAGE_DUMP_DIR}' '#{dest_dir}/#{STORAGE_DUMP_DIR}'")
+    end
 
-      Yast::WFM.Execute(LOCAL_BASH, command)
+    def src_dir
+      Yast::Directory.logdir
+    end
+
+    def dest_dir
+      Yast::Installation.destdir + Yast::Directory.logdir
+    end
+
+    def shell_cmd(cmd)
+      log.info("Executing #{cmd}")
+      Yast::WFM.Execute(LOCAL_BASH, cmd)
     end
   end
 end

--- a/src/lib/installation/proposal_runner.rb
+++ b/src/lib/installation/proposal_runner.rb
@@ -268,7 +268,7 @@ module Installation
       @submodules_presentation.each do |mod|
         @proposal << (@html[mod] || "")
       end
-      display_proposal(@proposal)
+      display_proposal(div_with_direction(@proposal))
       submod_descriptions_and_build_menu
     end
 
@@ -478,7 +478,7 @@ module Installation
           proposal = presentation_modules.reduce("") do |res, mod|
             res << (@html[mod] || "")
           end
-          display_proposal(proposal)
+          display_proposal(div_with_direction(proposal))
         end
       end
 

--- a/src/lib/installation/select_system_role.rb
+++ b/src/lib/installation/select_system_role.rb
@@ -22,6 +22,7 @@ require "yast"
 require "ui/installation_dialog"
 require "installation/services"
 require "installation/system_role"
+require "ui/text_helpers"
 
 Yast.import "GetInstArgs"
 Yast.import "Packages"
@@ -32,6 +33,8 @@ Yast.import "ProductFeatures"
 
 module Installation
   class SelectSystemRole < ::UI::InstallationDialog
+    include UI::TextHelpers
+
     class << self
       # once the user selects a role, remember it in case they come back
       attr_accessor :original_role_id
@@ -254,7 +257,7 @@ module Installation
       VBox(
         Left(Label(intro_text)),
         VSpacing(2),
-        RichText(Id(:roles_richtext), role_rt_radios.join("\n"))
+        RichText(Id(:roles_richtext), div_with_direction(role_rt_radios.join("\n")))
       )
     end
 
@@ -283,7 +286,10 @@ module Installation
       installation = ENV["Y2STYLE"] == "installation.qss"
       if installation
         image = selected ? "inst_radio-button-checked.png" : "inst_radio-button-unchecked.png"
-        bullet = "<img src=\"#{IMAGE_DIR}/#{image}\"></img>"
+        # NOTE: due to a Qt bug, the first image does not get rendered properly. So we are
+        # rendering it twice (one with height and width set to "0").
+        bullet = "<img src=\"#{IMAGE_DIR}/#{image}\" height=\"0\" width=\"0\"></img>" \
+                 "<img src=\"#{IMAGE_DIR}/#{image}\"></img>"
       else
         bullet = selected ? BUTTON_ON : BUTTON_OFF
       end

--- a/startup/First-Stage/F09-start
+++ b/startup/First-Stage/F09-start
@@ -17,6 +17,10 @@ callHooks preFirstCall
 # Using /dev/null - If there is nothing to do, let it fail silently
 SUSEConnect --cleanup > /dev/null 2>&1
 
+# delete the repositories accidentally saved into inst-sys
+# they make troubles when restarting YaST
+rm -fv /etc/zypp/repos.d/*.repo
+
 #=============================================
 # 9.1) check for driver update mode
 #---------------------------------------------

--- a/startup/YaST2.call
+++ b/startup/YaST2.call
@@ -277,7 +277,9 @@ function ssh_reboot_message()
 function restore_backup () {
   # restores backup if it is available
     if [ -d /mnt/var/adm/backup/system-upgrade ]; then
+	log "\tStarting restore scripts"
         for i in /mnt/var/adm/backup/system-upgrade/restore-*.sh; do
+	    log "\tStarting $i"
             sh $i /mnt
         done
     fi
@@ -334,6 +336,7 @@ function start_yast () {
 		tee /var/log/YaST2/gdb-log
 	    Y2_EXIT_CODE=$?
 	fi
+	log "\tY2_EXIT_CODE: $Y2_EXIT_CODE"
 
 	Y2_ABORT_MESSAGE="YaST seems to be aborted abnormally !"
 	Y2_OK_MESSAGE="YaST procedure ended successfully"
@@ -344,7 +347,6 @@ function start_yast () {
 		cat /etc/yast.inf | grep -q -i "Aborted: 1"
 		if [ $? = 0 ];then
 			log "\t$Y2_ABORT_MESSAGE"
-                        restore_backup
 		fi
 	else
 		#=============================================
@@ -656,6 +658,13 @@ if [ "$server_running" = 1 ];then
 	while kill -0 $xserver_pid 2>/dev/null ; do
 		sleep 1
 	done
+fi
+
+if [ -s /etc/yast.inf ];then
+        # aborted, restore the upgrade backup
+        grep -q -i "^Aborted:[ \t]*1" /etc/yast.inf && restore_backup
+        # no abort, not reboot status => YaST crashed, restore the upgrade backup
+        grep -q -i -v -e "^Aborted:" -e "^Root:" /etc/yast.inf && restore_backup
 fi
 
 #=============================================

--- a/startup/common/vnc.sh
+++ b/startup/common/vnc.sh
@@ -18,7 +18,10 @@
 
 . /etc/YaST2/XVersion
 # set python path for websockify
-. /root/.profile
+# (only present and needed in the inst-sys)
+if [ -r /root/.profile ]; then
+        . /root/.profile
+fi
 
 #----[ setupVNCAuthentication ]------#
 setupVNCAuthentication () {

--- a/test/copy_logs_finish_test.rb
+++ b/test/copy_logs_finish_test.rb
@@ -8,6 +8,8 @@ describe ::Installation::CopyLogsFinish do
   describe "#write" do
     before do
       allow(Yast::WFM).to receive(:Execute)
+      # Set the target dir to /mnt
+      allow(Yast::WFM).to receive(:Args).and_return("initial")
     end
 
     def mock_log_dir(files)
@@ -21,7 +23,7 @@ describe ::Installation::CopyLogsFinish do
     it "copies logs from instalation to target system" do
       mock_log_dir(["y2start.log"])
 
-      expect_to_run(/cp .*y2start.log .*y2start.log/)
+      expect_to_run(/cp .*y2start.log.*y2start.log/)
 
       subject.write
     end
@@ -29,7 +31,7 @@ describe ::Installation::CopyLogsFinish do
     it "rotates y2log" do
       mock_log_dir(["y2log-1.gz"])
 
-      expect_to_run(/cp .*y2log-1.gz .*y2log-2.gz/)
+      expect_to_run(/cp .*y2log-1.gz.*\/mnt\/.*y2log-2.gz/)
 
       subject.write
     end
@@ -37,12 +39,12 @@ describe ::Installation::CopyLogsFinish do
     it "compresses y2log if not already done" do
       mock_log_dir(["y2log-1"])
 
-      expect_to_run(/gzip .*y2log-2/) #-2 due to rotation
+      expect_to_run(/gzip .*\/mnt\/.*y2log-2/) #-2 due to rotation
 
       subject.write
     end
 
-    it "does not stuck during compress if file already exists (bnc#897091)" do
+    it "does not get stuck during compress if file already exists (bnc#897091)" do
       mock_log_dir(["y2log-1"])
 
       expect_to_run(/gzip -f/)
@@ -53,7 +55,16 @@ describe ::Installation::CopyLogsFinish do
     it "rotates zypp.log" do
       mock_log_dir(["zypp.log"])
 
-      expect_to_run(/cp .*zypp.log .*zypp.log-1/)
+      expect_to_run(/cp .*zypp.log.*\/mnt\/.*zypp.log-1/)
+
+      subject.write
+    end
+
+    it "copies the storage-inst subdir" do
+      mock_log_dir(["storage-inst"])
+
+      expect_to_run(/rm -rf .*\/mnt\/.*storage-inst/)
+      expect_to_run(/cp -r .*\/mnt\/.*storage-inst/)
 
       subject.write
     end

--- a/test/select_system_role_test.rb
+++ b/test/select_system_role_test.rb
@@ -14,6 +14,7 @@ describe ::Installation::SelectSystemRole do
     end
 
     allow(Yast::UI).to receive(:ChangeWidget)
+    allow(Yast::Language).to receive(:language).and_return("en_US")
 
     Installation::SystemRole.clear # Clear system roles cache
   end


### PR DESCRIPTION
See also https://github.com/yast/yast-storage-ng/pull/609

This copies `/var/log/YaST2/storage-inst` to the target at the end of the installation.

Any old directory in the target system with that name is removed before so we don't get confused by upgrade after upgrade after upgrade when users submit y2logs with a bug report.

This is also a minor cleanup of that code; it had become quite messy over time.
Now all shell commands are properly logged, and there is less duplication in the code.