### PR TITLE
Copy storage-ng XML / YAML devicegraph dump files to installation target system

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed May  2 15:44:18 UTC 2018 - shundhammer@suse.com
+
+- Copy new /var/log/YaST2/storage-inst/ subdir to target at the
+  end of the installation (part of fate #318196)
+- 4.0.56
+
+-------------------------------------------------------------------
 Fri Apr 27 15:07:15 UTC 2018 - igonzalezsosa@suse.com
 
 - Do not warn too soon about missing disks during autoinstallation

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.0.55
+Version:        4.0.56
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/installation/copy_logs_finish.rb
+++ b/src/lib/installation/copy_logs_finish.rb
@@ -108,7 +108,7 @@ module Installation
     end
 
     def dest_dir
-      Yast::Installation.destdir + Yast::Directory.logdir
+      File.join(Yast::Installation.destdir, Yast::Directory.logdir)
     end
 
     def shell_cmd(cmd)

--- a/test/copy_logs_finish_test.rb
+++ b/test/copy_logs_finish_test.rb
@@ -31,7 +31,7 @@ describe ::Installation::CopyLogsFinish do
     it "rotates y2log" do
       mock_log_dir(["y2log-1.gz"])
 
-      expect_to_run(/cp .*y2log-1.gz.*\/mnt\/.*y2log-2.gz/)
+      expect_to_run(/cp .*y2log-1.gz.*y2log-2.gz/)
 
       subject.write
     end
@@ -39,7 +39,7 @@ describe ::Installation::CopyLogsFinish do
     it "compresses y2log if not already done" do
       mock_log_dir(["y2log-1"])
 
-      expect_to_run(/gzip .*\/mnt\/.*y2log-2/) #-2 due to rotation
+      expect_to_run(/gzip .*y2log-2/) #-2 due to rotation
 
       subject.write
     end
@@ -55,7 +55,7 @@ describe ::Installation::CopyLogsFinish do
     it "rotates zypp.log" do
       mock_log_dir(["zypp.log"])
 
-      expect_to_run(/cp .*zypp.log.*\/mnt\/.*zypp.log-1/)
+      expect_to_run(/cp .*zypp.log.*zypp.log-1/)
 
       subject.write
     end
@@ -63,8 +63,8 @@ describe ::Installation::CopyLogsFinish do
     it "copies the storage-inst subdir" do
       mock_log_dir(["storage-inst"])
 
-      expect_to_run(/rm -rf .*\/mnt\/.*storage-inst/)
-      expect_to_run(/cp -r .*\/mnt\/.*storage-inst/)
+      expect_to_run(/rm -rf .*storage-inst/)
+      expect_to_run(/cp -r .*storage-inst/)
 
       subject.write
     end

--- a/test/copy_logs_finish_test.rb
+++ b/test/copy_logs_finish_test.rb
@@ -8,6 +8,8 @@ describe ::Installation::CopyLogsFinish do
   describe "#write" do
     before do
       allow(Yast::WFM).to receive(:Execute)
+      # Set the target dir to /mnt
+      allow(Yast::WFM).to receive(:Args).and_return("initial")
     end
 
     def mock_log_dir(files)
@@ -21,7 +23,7 @@ describe ::Installation::CopyLogsFinish do
     it "copies logs from instalation to target system" do
       mock_log_dir(["y2start.log"])
 
-      expect_to_run(/cp .*y2start.log .*y2start.log/)
+      expect_to_run(/cp .*y2start.log.*y2start.log/)
 
       subject.write
     end
@@ -29,7 +31,7 @@ describe ::Installation::CopyLogsFinish do
     it "rotates y2log" do
       mock_log_dir(["y2log-1.gz"])
 
-      expect_to_run(/cp .*y2log-1.gz .*y2log-2.gz/)
+      expect_to_run(/cp .*y2log-1.gz.*\/mnt\/.*y2log-2.gz/)
 
       subject.write
     end
@@ -37,12 +39,12 @@ describe ::Installation::CopyLogsFinish do
     it "compresses y2log if not already done" do
       mock_log_dir(["y2log-1"])
 
-      expect_to_run(/gzip .*y2log-2/) #-2 due to rotation
+      expect_to_run(/gzip .*\/mnt\/.*y2log-2/) #-2 due to rotation
 
       subject.write
     end
 
-    it "does not stuck during compress if file already exists (bnc#897091)" do
+    it "does not get stuck during compress if file already exists (bnc#897091)" do
       mock_log_dir(["y2log-1"])
 
       expect_to_run(/gzip -f/)
@@ -53,7 +55,16 @@ describe ::Installation::CopyLogsFinish do
     it "rotates zypp.log" do
       mock_log_dir(["zypp.log"])
 
-      expect_to_run(/cp .*zypp.log .*zypp.log-1/)
+      expect_to_run(/cp .*zypp.log.*\/mnt\/.*zypp.log-1/)
+
+      subject.write
+    end
+
+    it "copies the storage-inst subdir" do
+      mock_log_dir(["storage-inst"])
+
+      expect_to_run(/rm -rf .*\/mnt\/.*storage-inst/)
+      expect_to_run(/cp -r .*\/mnt\/.*storage-inst/)
 
       subject.write
     end


### PR DESCRIPTION
See also https://github.com/yast/yast-storage-ng/pull/609

This copies `/var/log/YaST2/storage-inst` to the target at the end of the installation.

Any old directory in the target system with that name is removed before so we don't get confused by upgrade after upgrade after upgrade when users submit y2logs with a bug report.

This is also a minor cleanup of that code; it had become quite messy over time.
Now all shell commands are properly logged, and there is less duplication in the code.