### PR TITLE
Keep the selected product in the desktop selection dialog (bsc#1088660)

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu May  3 07:34:57 UTC 2018 - lslezak@suse.cz
+
+- Keep the selected product in the desktop selection dialog
+  (bsc#1088660)
+- 4.0.57
+
+-------------------------------------------------------------------
 Wed May  2 15:44:18 UTC 2018 - shundhammer@suse.com
 
 - Copy new /var/log/YaST2/storage-inst/ subdir to target at the

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.0.56
+Version:        4.0.57
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/installation/clients/inst_complex_welcome.rb
+++ b/src/lib/installation/clients/inst_complex_welcome.rb
@@ -194,7 +194,7 @@ module Yast
     # @return [Boolean] true if a product has been selected and license
     # agreement confirmed when required; false otherwise
     def product_selection_finished?
-      if selected_product.nil?
+      if selected_product.nil? && products.size > 1
         Yast::Popup.Error(_("Please select a product to install."))
         return false
       elsif license_confirmation_required? && !selected_product.license_confirmed?

--- a/src/lib/installation/clients/inst_complex_welcome.rb
+++ b/src/lib/installation/clients/inst_complex_welcome.rb
@@ -194,7 +194,8 @@ module Yast
     # @return [Boolean] true if a product has been selected and license
     # agreement confirmed when required; false otherwise
     def product_selection_finished?
-      if selected_product.nil? && products.size > 1
+      if selected_product.nil?
+        return true if products.size <= 1
         Yast::Popup.Error(_("Please select a product to install."))
         return false
       elsif license_confirmation_required? && !selected_product.license_confirmed?

--- a/src/lib/installation/widgets/system_roles_radio_buttons.rb
+++ b/src/lib/installation/widgets/system_roles_radio_buttons.rb
@@ -52,7 +52,8 @@ module Installation
         CustomPatterns.show = value == "custom"
         store_orig
 
-        Yast::Packages.Reset([])
+        # keep the selected products
+        Yast::Packages.Reset([:product])
         if value == "custom"
           # for custom role do not use any desktop
           Yast::DefaultDesktop.SetDesktop(nil)


### PR DESCRIPTION
- Fixes the problem with unselected product when going back - the selected products must not be reset
- See https://bugzilla.suse.com/show_bug.cgi?id=1088660
- Less strict check for selecting the product - do not ask to select a product when there is only one product available, the selection widget is hidden in that case anyway
- Tested manually
- 4.0.56