### PR TITLE
- disable mdadm auto assembly for installation

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue May 08 12:04:00 CEST 2018 - aschnell@suse.com
+
+- disable mdadm auto assembly for installation (bsc#1090690)
+- 4.0.58
+
+-------------------------------------------------------------------
 Thu May  3 07:34:57 UTC 2018 - lslezak@suse.cz
 
 - Keep the selected product in the desktop selection dialog

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.0.57
+Version:        4.0.58
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -47,9 +47,9 @@ BuildRequires:  yast2 >= 4.0.72
 # Yast::Packages.check_remote_installation_packages
 BuildRequires:	yast2-packager >= 4.0.9
 
-# Y2Storage::StorageManager#devices_for_installation?
-BuildRequires: yast2-storage-ng >= 4.0.168
-Requires:      yast2-storage-ng >= 4.0.168
+# Y2Storage::Inhibitors
+BuildRequires: yast2-storage-ng >= 4.0.175
+Requires:      yast2-storage-ng >= 4.0.175
 
 # TextHelpers#div_with_direction
 Requires:       yast2 >= 4.0.72

--- a/src/lib/installation/clients/inst_system_analysis.rb
+++ b/src/lib/installation/clients/inst_system_analysis.rb
@@ -27,6 +27,7 @@
 
 require "yast"
 require "y2storage"
+require "y2storage/inhibitors"
 
 module Yast
   class InstSystemAnalysisClient < Client
@@ -64,6 +65,7 @@ module Yast
       return :back if GetInstArgs.going_back
 
       @packager_initialized = false
+      @inhibitors = nil
 
       Wizard.SetContents(_("Analyzing the Computer"), Empty(), "", false, false)
       Wizard.SetTitleIcon("yast-controller")
@@ -177,6 +179,8 @@ module Yast
     # @raise [AbortException] if an error is found and the installation must
     #   be aborted because of such error
     def ActionHDDProbe
+      inhibit_storage
+
       init_storage
       devicegraph = storage_manager.probed
 
@@ -252,6 +256,14 @@ module Yast
     end
 
   private
+
+    # Inhibit various storage features, e.g. MD RAID auto assembly
+    def inhibit_storage
+      return if @inhibitors
+
+      @inhibitors = Y2Storage::Inhibitors.new
+      @inhibitors.inhibit
+    end
 
     # Return the activate callbacks for libstorage-ng
     #

--- a/test/lib/clients/inst_system_analysis_test.rb
+++ b/test/lib/clients/inst_system_analysis_test.rb
@@ -47,6 +47,7 @@ describe Yast::InstSystemAnalysisClient do
 
     it "uses default activation callbacks" do
       expect(storage).to receive(:activate).with(nil).and_return true
+      expect(Yast::Execute).to receive(:locally!).with("/sbin/udevadm", "control", "--property=ANACONDA=yes")
       client.ActionHDDProbe
     end
 


### PR DESCRIPTION
For https://trello.com/c/rjLmkP8u/373-sles15-p2-1090690-storage-ng-error-encrypting-a-partition-that-was-part-of-an-md-raid.