### PR TITLE
Fix unmounting logging

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu May 10 13:10:41 UTC 2018 - igonzalezsosa@suse.com
+
+- Log errors when umounting filesystems after installation/upgrade
+  (related to bsc#1090018).
+- 4.0.59 
+
+-------------------------------------------------------------------
 Tue May 08 12:04:00 CEST 2018 - aschnell@suse.com
 
 - disable mdadm auto assembly for installation (bsc#1090690)

--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,8 +1,8 @@
 -------------------------------------------------------------------
 Thu May 10 13:10:41 UTC 2018 - igonzalezsosa@suse.com
 
-- Log errors when umounting filesystems after installation/upgrade
-  (related to bsc#1090018).
+- Log a warning when umounting a filesystem fails after
+  installation/upgrade (related to bsc#1090018).
 - 4.0.59 
 
 -------------------------------------------------------------------

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.0.58
+Version:        4.0.59
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
This patch fixes the `umount_finish` client logging.

Related to bug report: https://bugzilla.suse.com/show_bug.cgi?id=1090018
Trello card: https://trello.com/c/1fXAxYLv/