### PR TITLE
fixed crash while mounting CD-ROM

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue May 22 11:32:07 CEST 2018 - schubi@suse.de
+
+- Mounting CD: Fixed crash while reporting an error.
+  (bnc#1093847)
+- 3.2.54
+
+-------------------------------------------------------------------
 Mon Apr  9 10:13:38 CEST 2018 - schubi@suse.de
 
  -CaaSP: Showing license confirmation. (Fate#324476)

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation
-Version:        3.2.53
+Version:        3.2.54
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/transfer/file_from_url.rb
+++ b/src/lib/transfer/file_from_url.rb
@@ -268,7 +268,7 @@ module Yast::Transfer
                   # autoyast tried to mount the CD but had no success.
                   @GET_error = Ops.add(
                     @GET_error,
-                    Builtins.sformat(_("Mounting %1 failed."), cdrom)
+                    Builtins.sformat(_("Mounting %1 failed."), cdrom_device)
                   )
                   Builtins.y2warning("Mount failed")
                   ok = false


### PR DESCRIPTION
This is a backport of https://github.com/yast/yast-installation/pull/624 which has been checked in into the
wrong tree and without any update of changes and version.