### PR TITLE
Fixed broken rollback when upgrading via SSH (bsc#1089643)

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Jun  6 14:21:02 UTC 2018 - lslezak@suse.cz
+
+- Fixed possibly broken system after aborting upgrade running
+  over SSH (caused by a partially finished rollback) (bsc#1089643)
+- 4.0.64
+
+-------------------------------------------------------------------
 Thu May 31 10:17:19 UTC 2018 - jreidinger@suse.com
 
 - Fix crash caused by previous fix when multipath is not available

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.0.63
+Version:        4.0.64
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/startup/YaST2.call
+++ b/startup/YaST2.call
@@ -358,10 +358,6 @@ function start_yast () {
 		start_yast_and_reboot
 		start_yast_again
 	fi
-	if [ $SELECTED_MEDIUM = "SSH" ] && [ ! "$VNC" = 1 ];then
-		ssh_reboot_message
-		echo $Y2_EXIT_CODE > /tmp/YaST2_ssh_installation_finished
-	fi
 	log "\tReset memory allocation: overcommit_memory=$overcommit"
 	echo $overcommit > /proc/sys/vm/overcommit_memory
 }
@@ -665,6 +661,14 @@ if [ -s /etc/yast.inf ];then
         grep -q -i "^Aborted:[ \t]*1" /etc/yast.inf && restore_backup
         # no abort, not reboot status => YaST crashed, restore the upgrade backup
         grep -q -i -v -e "^Aborted:" -e "^Root:" /etc/yast.inf && restore_backup
+fi
+
+if [ $SELECTED_MEDIUM = "SSH" ] && [ ! "$VNC" = 1 ];then
+	ssh_reboot_message
+	# the inst-sys is waiting for the /tmp/YaST2_ssh_installation_finished file and
+	# when found the ssh daemon is killed, so create this file as the very last step!!
+	# (https://github.com/openSUSE/installation-images/blob/c57181329ab7040369da705c5b0ddd78e2960bf0/data/root/etc/inst_setup#L221-L229)
+	echo $Y2_EXIT_CODE > /tmp/YaST2_ssh_installation_finished
 fi
 
 #=============================================


### PR DESCRIPTION
- See https://bugzilla.suse.com/show_bug.cgi?id=1089643#c64
- Fixed possibly broken system after aborting upgrade running over SSH (caused by a partially finished rollback)
  ```console
  *** Starting YaST2 ***
  var/lib/rpm/
  var/lib/rpm/.rpm.lock
  var/lib/rpm/Packages
  Connection to s390vsw051.suse.de closed by remote host.
  Connection to s390vsw051.suse.de closed.
  ```
- The SSH daemon was killed too early, before the rollback was finished - the fix is to kill it at the very end of the script
- Added a comment why the file needs to be created at the end
- Tested manually
  ```console
  ...
  Restoring the registration status at /mnt, this might take several minutes...
  > Beginning registration rollback. This can take some time...
  Connection to dhcp253 closed by remote host.
  Connection to dhcp253 closed.
  ```
- 4.0.64