### PR TITLE
- adapted testsuite to change in yast2-storage-ng (bsc#1073633)

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Jun 27 13:14:47 CEST 2018 - aschnell@suse.com
+
+- adapted testsuite to change in yast2-storage-ng (bsc#1073633)
+- 4.0.66
+
+-------------------------------------------------------------------
 Mon Jun 11 11:30:44 UTC 2018 - knut.anderssen@suse.com
 
 - Firstboot.service: Shutdown on failure preventing the service to

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.0.65
+Version:        4.0.66
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -47,8 +47,8 @@ BuildRequires:  yast2 >= 4.0.72
 # Yast::Packages.check_remote_installation_packages
 BuildRequires:	yast2-packager >= 4.0.9
 
-# Y2Storage::Inhibitors
-BuildRequires: yast2-storage-ng >= 4.0.175
+# Y2Storage::Inhibitors including systemd masking
+BuildRequires: yast2-storage-ng >= 4.0.194
 Requires:      yast2-storage-ng >= 4.0.175
 
 # TextHelpers#div_with_direction

--- a/test/lib/clients/inst_system_analysis_test.rb
+++ b/test/lib/clients/inst_system_analysis_test.rb
@@ -48,7 +48,8 @@ describe Yast::InstSystemAnalysisClient do
 
     it "uses default activation callbacks" do
       expect(storage).to receive(:activate).with(nil).and_return true
-      expect(Yast::Execute).to receive(:locally!).with("/sbin/udevadm", "control", "--property=ANACONDA=yes")
+      expect(Yast::Execute).to receive(:locally!).with("/sbin/udevadm", "control", "--property=ANACONDA=yes").ordered
+      expect(Yast::Execute).to receive(:locally!).with("/usr/lib/YaST2/bin/mask-systemd-units", "--mask").ordered
       client.ActionHDDProbe
     end
 


### PR DESCRIPTION
For https://trello.com/c/kkmPuoxR/94-3-1073633-l3-system-auto-mounts-ext4-partition-on-xen-pv-device-after-fs-resize-causes-yast-error.