### PR TITLE
Add missing help for disk activation dialog

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Sep  3 08:38:32 UTC 2018 - dgonzalez@suse.com
+
+- Add missing help for disks activation dialog (bsc#1098563)
+- 4.1.12
+
+-------------------------------------------------------------------
 Fri Aug 24 14:42:15 UTC 2018 - jreidinger@suse.com
 
 - Improve help text for system roles (bsc#1046619)

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.1.11
+Version:        4.1.12
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/installation/clients/inst_disks_activate.rb
+++ b/src/lib/installation/clients/inst_disks_activate.rb
@@ -75,11 +75,6 @@ module Yast
 
       @want_fcoe = Linuxrc.InstallInf("WithFCoE") == "1"
 
-      # dialog caption
-      @caption = _("Disk Activation")
-
-      @help = ""
-
       missing_part = [
         VSpacing(0),
         VSpacing(0)
@@ -169,9 +164,10 @@ module Yast
 
     def show_base_dialog
       Wizard.SetContents(
-        @caption,
+        # TRANSLATORS: dialog caption
+        _("Disk Activation"),
         @contents,
-        @help,
+        help,
         GetInstArgs.enable_back,
         GetInstArgs.enable_next
       )
@@ -203,6 +199,52 @@ module Yast
 
       enable_back ? Wizard.EnableBackButton : Wizard.DisableBackButton
       enable_next ? Wizard.EnableNextButton : Wizard.DisableNextButton
+    end
+
+    def help
+      network_button_help +
+        dasd_button_help +
+        zfcp_button_help +
+        fcoe_button_help +
+        iscsi_button_help
+    end
+
+    def network_button_help
+      # TRANSLATORS: Help text for "Network configuration..." button in the Disks activation dialog
+      _("<h2>Network configuration</h2>" \
+        "Launches the Network configuration dialog.")
+    end
+
+    def dasd_button_help
+      return "" unless @have_dasd
+
+      # TRANSLATORS: Help text for "Configure DASD Disks" button in the Disks activation dialog
+      _("<h2>Configure DASD Disks</h2>" \
+        "Opens the dialog to configure the " \
+        "<b>D</b>irect <b>A</b>ccess <b>S</b>torage <b>D</b>isks.")
+    end
+
+    def zfcp_button_help
+      return "" unless @have_zfcp
+
+      # TRANSLATORS: Help text for "Configure zFCP Disks" button in the Disks activation dialog
+      _("<h2>Configure zFCP Disks</h2>" \
+        "Allows to configure the Fibre Channel Attached SCSI Disks.")
+    end
+
+    def fcoe_button_help
+      return "" unless @want_fcoe
+
+      # TRANSLATORS: Help text for "Configure FCoE Interfaces" button in the Disks activation dialog
+      _("<h2>Configure FCoE Interfaces</h2>" \
+        "Shows the dialog to manage the " \
+        "<b>F</b>ibre <b>C</b>hannel <b>o</b>ver <b>E</b>thernet interfaces.")
+    end
+
+    def iscsi_button_help
+      # TRANSLATORS: Help text for "Configure iSCSI Disks" button in the Disks activation dialog
+      _("<h2>Configure iSCSI Disks</h2>" \
+        "Executes the iSCSI initiator configuration.")
     end
   end
 end

--- a/test/inst_disks_activate_test.rb
+++ b/test/inst_disks_activate_test.rb
@@ -6,61 +6,138 @@ require "installation/clients/inst_disks_activate"
 
 describe Yast::InstDisksActivateClient do
   describe "#main" do
-    let(:probed_disks) { [] }
     let(:s390) { false }
+    let(:dasd_disks) { [] }
+    let(:zfcp_disks) { [] }
 
     before do
       Y2Storage::StorageManager.create_test_instance
 
-      allow(Yast::Linuxrc).to receive(:InstallInf).with("WithFCoE").and_return("0")
       allow(Yast::UI).to receive(:OpenDialog)
       allow(Yast::UI).to receive(:CloseDialog)
       allow(Yast::Popup).to receive(:ConfirmAbort).with(:painless).and_return(true)
       allow(Yast::Arch).to receive(:s390).and_return(s390)
       allow(Yast::GetInstArgs).to receive(:going_back) { going_back }
+      allow(Yast::Linuxrc).to receive(:InstallInf).with("WithFCoE").and_return("0")
+      allow(Yast::UI).to receive(:UserInput).and_return(:abort)
 
       allow(Y2Storage::StorageManager.instance).to receive(:probe)
+
+      allow(Yast::SCR).to receive(:Read).with(path(".probe.disk"))
+        .and_return(dasd_disks)
+      allow(Yast::SCR).to receive(:Read).with(path(".probe.storage"))
+        .and_return(zfcp_disks)
+
+      allow(subject).to receive(:Id)
+      allow(subject).to receive(:PushButton)
 
       stub_const("Yast::Packages", double(GetBaseSourceID: 0))
     end
 
-    context "when architecture is s390" do
-      let(:s390) { true }
-      before do
-        allow(Yast::UI).to receive(:UserInput).and_return(:abort)
-      end
+    it "includes help for Network configuration button" do
+      expect(Yast::Wizard).to receive(:SetContents)
+        .with(anything, anything, /Network configuration/, any_args)
 
-      it "detects DASD disks" do
-        expect(Yast::SCR).to receive(:Read).with(path(".probe.disk"))
-          .and_return(probed_disks)
-        allow(Yast::SCR).to receive(:Read).with(path(".probe.storage"))
-          .and_return(probed_disks)
-        expect(subject).to receive(:show_base_dialog)
-
-        expect(subject.main).to eq(:abort)
-      end
-
-      it "detects zFCP disks" do
-        allow(Yast::SCR).to receive(:Read).with(path(".probe.disk"))
-          .and_return(probed_disks)
-        expect(Yast::SCR).to receive(:Read).with(path(".probe.storage"))
-          .and_return(probed_disks)
-        expect(subject).to receive(:show_base_dialog)
-
-        expect(subject.main).to eq(:abort)
-      end
+      subject.main
     end
 
-    context "when dasd button is clicked" do
-      before do
-        allow(Yast::UI).to receive(:UserInput).and_return(:dasd, :abort)
+    it "includes help for iSCSI disks button" do
+      expect(Yast::Wizard).to receive(:SetContents)
+        .with(anything, anything, /Configure iSCSI Disks/, any_args)
+
+      subject.main
+    end
+
+    context "when architecture is s390" do
+      let(:s390) { true }
+
+      context "and DASD disks are detected" do
+        let(:dasd_disks) { [{ "device" => "DASD" }] }
+
+        before do
+          allow(subject).to receive(:Id).with(:dasd).and_return("dasd_button_id")
+        end
+
+        it "includes button to configure them" do
+          expect(subject).to receive(:PushButton).with("dasd_button_id", any_args)
+
+          subject.main
+        end
+
+        it "includes help for DASD button" do
+          expect(Yast::Wizard).to receive(:SetContents)
+            .with(anything, anything, /Configure DASD/, any_args)
+
+          subject.main
+        end
+
+        context "and DASD button is clicked" do
+          before do
+            allow(Yast::UI).to receive(:UserInput).and_return(:dasd, :abort)
+          end
+
+          it "calls inst_dasd client" do
+            expect(Yast::WFM).to receive(:call).with("inst_dasd")
+            expect(subject).to receive(:show_base_dialog).twice
+
+            subject.main
+          end
+        end
       end
 
-      it "calls inst_dasd client" do
-        expect(Yast::WFM).to receive(:call).with("inst_dasd")
-        expect(subject).to receive(:show_base_dialog).twice
+      context "and zFCP disks are detected" do
+        let(:zfcp_disks) { [{ "device" => "zFCP controller" }] }
 
-        subject.main
+        before do
+          allow(subject).to receive(:Id).with(:zfcp).and_return("zfcp_button_id")
+        end
+
+        it "includes button to configure them" do
+          expect(subject).to receive(:PushButton).with("zfcp_button_id", any_args)
+
+          subject.main
+        end
+
+        it "includes help for zFCP button" do
+          expect(Yast::Wizard).to receive(:SetContents)
+            .with(anything, anything, /Configure zFCP/, any_args)
+
+          subject.main
+        end
+
+        context "and zFCP button is clicked" do
+          before do
+            allow(Yast::UI).to receive(:UserInput).and_return(:zfcp, :abort)
+          end
+
+          it "calls inst_dasd client" do
+            expect(Yast::WFM).to receive(:call).with("inst_zfcp")
+            expect(subject).to receive(:show_base_dialog).twice
+
+            subject.main
+          end
+        end
+      end
+
+      context "and FCoE is available" do
+        before do
+          allow(Yast::Linuxrc).to receive(:InstallInf).with("WithFCoE").and_return("1")
+
+          allow(subject).to receive(:Id).with(:fcoe).and_return("fcoe_button_id")
+        end
+
+        it "includes button to configure it" do
+          expect(subject).to receive(:PushButton).with("fcoe_button_id", any_args)
+
+          subject.main
+        end
+
+        it "includes help for FCoE button" do
+          expect(Yast::Wizard).to receive(:SetContents)
+            .with(anything, anything, /Configure FCoE/, any_args)
+
+          subject.main
+        end
       end
     end
 


### PR DESCRIPTION
Fix https://bugzilla.suse.com/show_bug.cgi?id=1098563 adding simple texts for disk activation help.

Any suggestion to improve it is welcome.

![disk_activation_help](https://user-images.githubusercontent.com/1691872/44976729-fd392480-af5d-11e8-82eb-90246a2f079d.png)
---
Related to https://trello.com/c/t6Rj03h1