### PR TITLE
Fix path to media/build info file

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Sep  4 13:34:17 UTC 2018 - dgonzalez@suse.com
+
+- Use /media.1/media instead the /media.1/build (bsc#1062297)
+- 4.1.13
+
+-------------------------------------------------------------------
 Mon Sep  3 08:38:32 UTC 2018 - dgonzalez@suse.com
 
 - Add missing help for disks activation dialog (bsc#1098563)

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.1.12
+Version:        4.1.13
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/test/copy_files_finish_test.rb
+++ b/test/copy_files_finish_test.rb
@@ -148,18 +148,40 @@ describe Yast::CopyFilesFinishClient do
       subject.write
     end
 
-    it "copies build file" do
-      allow(Yast::Pkg).to receive(:SourceProvideOptionalFile).with(1, 1, "/media.1/build")
-        .and_return("/media.1/build")
+    it "copies media file to /media" do
+      allow(Yast::Pkg).to receive(:SourceProvideOptionalFile)
+        .with(1, 1, "/media.1/media")
+        .and_return("/media.1/media")
 
-      expect(::FileUtils).to receive(:cp).with("/media.1/build", "/mnt/etc/YaST2/build")
+      expect(::FileUtils).to receive(:cp).with("/media.1/media", "/mnt/etc/YaST2/media")
 
       subject.write
     end
 
-    it "ensures proper permission on copied build file" do
-      allow(Yast::Pkg).to receive(:SourceProvideOptionalFile).with(1, 1, "/media.1/build")
-        .and_return("/media.1/build")
+    it "copies media file to /build (backward compatibility)" do
+      allow(Yast::Pkg).to receive(:SourceProvideOptionalFile)
+        .with(1, 1, "/media.1/media")
+        .and_return("/media.1/media")
+
+      expect(::FileUtils).to receive(:cp).with("/media.1/media", "/mnt/etc/YaST2/build")
+
+      subject.write
+    end
+
+    it "ensures proper permission on copied /media file" do
+      allow(Yast::Pkg).to receive(:SourceProvideOptionalFile)
+        .with(1, 1, "/media.1/media")
+        .and_return("/media.1/media")
+
+      expect(::FileUtils).to receive(:chmod).with(0o644, "/mnt/etc/YaST2/media")
+
+      subject.write
+    end
+
+    it "ensures proper permission on copied /build file (backward compatibility)" do
+      allow(Yast::Pkg).to receive(:SourceProvideOptionalFile)
+        .with(1, 1, "/media.1/media")
+        .and_return("/media.1/media")
 
       expect(::FileUtils).to receive(:chmod).with(0o644, "/mnt/etc/YaST2/build")
 


### PR DESCRIPTION
From https://bugzilla.suse.com/show_bug.cgi?id=1062297

> after installation I could not find /etc/YaST2/build


> There is no more /build - it has been integrated into /media. And yast needs to copy it in place of /build

~~This RFC is to know your point of view about what to do with the destination of `/media.1/media` in the installed system:~~

~~* Keep as it is: `/build`~~
~~* Change to `/media`~~
~~* Copy to both: `/media` and `/build` (does have sense???)~~

This PR change the source from `/media.1/build` to `/media.1/media` and destination to `/media`, but also keeping `/build` for backward compatibility with other (not adapted yet) tools, as @lslezak suggested in #yast IRC channel.


---

Related to https://trello.com/c/O0F6RkaQ
