### PR TITLE
Skip the roles' selection dialog

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Sep 25 15:11:15 UTC 2018 - dgonzalez@suse.com
+
+- Skip the roles' dialog selection when there is only one available
+  (fate#324713)
+- 4.1.19
+
+-------------------------------------------------------------------
 Tue Sep 25 13:34:50 UTC 2018 - dgonzalez@suse.com
 
 - Fix syntax error (bsc#1109659)

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.1.18
+Version:        4.1.19
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
When there is only one role available, directly applies it and skip the dialog.

Related to https://trello.com/c/uzNWUsjG/337-fate-324713-optimize-system-role-handling-dont-show-system-role-dialog-when-only-one-or-none-system-role-is-available
