### PR TITLE
Skip role selection dialog when there is only one role available (:back direction)

### DIFF
--- a/src/lib/installation/select_system_role.rb
+++ b/src/lib/installation/select_system_role.rb
@@ -62,8 +62,9 @@ module Installation
         # If coming back, we have to run the additional dialogs first...
         clients = additional_clients_for(previous_role_id)
         direction = run_clients(clients, going_back: true)
-        # ... and only run the main dialog (super) if we are *still* going back
-        return direction unless direction == :back
+        # ...and only run the main dialog (super) if there is more than one role (fate#324713) and we
+        # are *still* going back
+        return direction if single_role? || direction != :back
       end
 
       if single_role?

--- a/src/lib/installation/select_system_role.rb
+++ b/src/lib/installation/select_system_role.rb
@@ -64,8 +64,11 @@ module Installation
         direction = run_clients(clients, going_back: true)
         # ... and only run the main dialog (super) if we are *still* going back
         return direction unless direction == :back
-      elsif single_role?
+      end
+
+      if single_role?
         # Apply the role and skip the dialog when there is only one (fate#324713)
+        log.info "Only one role available, applying it and skipping the dialog"
         clear_role
         return select_role(roles.first.id)
       end

--- a/src/lib/installation/select_system_role.rb
+++ b/src/lib/installation/select_system_role.rb
@@ -37,7 +37,7 @@ module Installation
 
     class << self
       # once the user selects a role, remember it in case they come back
-      attr_accessor :original_role_id
+      attr_accessor :previous_role_id
     end
 
     NON_OVERLAY_ATTRIBUTES = [
@@ -60,7 +60,7 @@ module Installation
 
       if Yast::GetInstArgs.going_back
         # If coming back, we have to run the additional dialogs first...
-        clients = additional_clients_for(self.class.original_role_id)
+        clients = additional_clients_for(previous_role_id)
         direction = run_clients(clients, going_back: true)
         # ... and only run the main dialog (super) if we are *still* going back
         return direction unless direction == :back
@@ -85,7 +85,7 @@ module Installation
     end
 
     def dialog_content
-      @selected_role_id = self.class.original_role_id
+      @selected_role_id = previous_role_id
       @selected_role_id ||= roles.first && roles.first.id if SystemRole.default?
 
       HCenter(ReplacePoint(Id(:rp), role_buttons(selected_role_id: @selected_role_id)))
@@ -127,6 +127,10 @@ module Installation
 
   private
 
+    def previous_role_id
+      self.class.previous_role_id
+    end
+
     # checks if there is only one role available
     def single_role?
       roles.size == 1
@@ -140,23 +144,19 @@ module Installation
     #
     # @return [:next,:back,:abort] which direction the additional dialogs exited
     def select_role(role_id)
-      if role_id.nil? # no role selected (bsc#1078809)
-        # An Error popup
-        msg = _("Select one of the available roles to continue.")
-        Yast::Popup.Error(msg)
+      if role_id.nil?
+        # no role selected (bsc#1078809)
+        Yast::Popup.Error(_("Select one of the available roles to continue."))
         return :back
       end
 
-      orig_role_id = self.class.original_role_id
-      if !orig_role_id.nil? && orig_role_id != role_id
-        # A Continue-Cancel popup
+      if previous_role_id && previous_role_id != role_id
+        # Changing the role, show a Continue-Cancel popup to user
         msg = _("Changing the system role may undo adjustments you may have done.")
         return :back unless Yast::Popup.ContinueCancel(msg)
       end
-      self.class.original_role_id = role_id
 
-      apply_role(SystemRole.find(role_id))
-
+      apply_role(role_id)
       run_clients(additional_clients_for(role_id))
     end
 
@@ -213,8 +213,11 @@ module Installation
     end
 
     # Applies given role to configuration
-    def apply_role(role)
-      log.info "Applying system role '#{role.id}'"
+    def apply_role(role_id)
+      log.info "Applying system role '#{role_id}'"
+
+      self.class.previous_role_id = role_id
+      role = SystemRole.find(role_id)
       role.overlay_features
       adapt_services(role)
 

--- a/test/select_system_role_test.rb
+++ b/test/select_system_role_test.rb
@@ -22,7 +22,7 @@ describe ::Installation::SelectSystemRole do
   describe "#run" do
     before do
       # reset previous test
-      subject.class.original_role_id = nil
+      subject.class.previous_role_id = nil
 
       allow(Yast::ProductFeatures).to receive(:ClearOverlay)
       allow(Yast::ProductFeatures).to receive(:SetOverlay)
@@ -89,7 +89,7 @@ describe ::Installation::SelectSystemRole do
 
       context "and going back" do
         before do
-          subject.class.original_role_id = "bar"
+          subject.class.previous_role_id = "bar"
           allow(Yast::GetInstArgs).to receive(:going_back).and_return(true)
           allow(Yast::UI).to receive(:UserInput).and_return(:back)
         end
@@ -106,7 +106,7 @@ describe ::Installation::SelectSystemRole do
           let(:additional_dialogs) { "a,b" }
 
           it "shows the last one" do
-            subject.class.original_role_id = "bar"
+            subject.class.previous_role_id = "bar"
 
             allow(Yast::GetInstArgs).to receive(:going_back).and_return(true)
             expect(Yast::WFM).to receive(:CallFunction).with("b", anything).and_return(:next)
@@ -165,7 +165,7 @@ describe ::Installation::SelectSystemRole do
         end
 
         it "shows the last dialog when going back" do
-          subject.class.original_role_id = "bar"
+          subject.class.previous_role_id = "bar"
           allow(Yast::GetInstArgs).to receive(:going_back).and_return(true)
           expect(Yast::Wizard).to_not receive(:SetContents)
           expect(Yast::UI).to_not receive(:UserInput)
@@ -179,7 +179,7 @@ describe ::Installation::SelectSystemRole do
 
       context "when re-selecting the same role" do
         it "just proceeds without a popup" do
-          subject.class.original_role_id = "foo"
+          subject.class.previous_role_id = "foo"
 
           allow(Yast::Wizard).to receive(:SetContents)
           allow(Yast::UI).to receive(:UserInput)
@@ -196,7 +196,7 @@ describe ::Installation::SelectSystemRole do
 
       context "when re-selecting a different role" do
         it "displays a popup, and proceeds if Continue is answered" do
-          subject.class.original_role_id = "bar"
+          subject.class.previous_role_id = "bar"
 
           allow(Yast::Wizard).to receive(:SetContents)
           allow(Yast::UI).to receive(:UserInput)
@@ -212,7 +212,7 @@ describe ::Installation::SelectSystemRole do
         end
 
         it "displays a popup, and does not proceed if Cancel is answered" do
-          subject.class.original_role_id = "bar"
+          subject.class.previous_role_id = "bar"
 
           allow(Yast::Wizard).to receive(:SetContents)
           allow(Yast::UI).to receive(:UserInput)

--- a/test/select_system_role_test.rb
+++ b/test/select_system_role_test.rb
@@ -76,6 +76,10 @@ describe ::Installation::SelectSystemRole do
           subject.run
         end
 
+        it "returns :next" do
+          expect(subject.run).to be(:next)
+        end
+
         context "and there are additional dialogs" do
           let(:additional_dialogs) { "a,b" }
 
@@ -100,6 +104,10 @@ describe ::Installation::SelectSystemRole do
           expect(Yast::UI).to_not receive(:QueryWidget)
 
           subject.run
+        end
+
+        it "returns :back" do
+          expect(subject.run).to be(:back)
         end
 
         context "and there are additional dialogs" do

--- a/test/select_system_role_test.rb
+++ b/test/select_system_role_test.rb
@@ -75,6 +75,16 @@ describe ::Installation::SelectSystemRole do
 
           subject.run
         end
+
+        context "and there are additional dialogs" do
+          let(:additional_dialogs) { "a,b" }
+
+          it "shows the first one" do
+            expect(Yast::WFM).to receive(:CallFunction).with("a", anything).and_return(:next)
+
+            subject.run
+          end
+        end
       end
 
       context "and going back" do
@@ -91,24 +101,18 @@ describe ::Installation::SelectSystemRole do
 
           subject.run
         end
-      end
 
-      context "and it contains additional dialogs" do
-        let(:additional_dialogs) { "a,b" }
+        context "and there are additional dialogs" do
+          let(:additional_dialogs) { "a,b" }
 
-        it "shows the first dialog when going forward" do
-          expect(Yast::WFM).to receive(:CallFunction).with("a", anything).and_return(:next)
+          it "shows the last one" do
+            subject.class.original_role_id = "bar"
 
-          subject.run
-        end
+            allow(Yast::GetInstArgs).to receive(:going_back).and_return(true)
+            expect(Yast::WFM).to receive(:CallFunction).with("b", anything).and_return(:next)
 
-        it "shows the last dialog when going back" do
-          subject.class.original_role_id = "bar"
-
-          allow(Yast::GetInstArgs).to receive(:going_back).and_return(true)
-          expect(Yast::WFM).to receive(:CallFunction).with("b", anything).and_return(:next)
-
-          subject.run
+            subject.run
+          end
         end
       end
     end

--- a/test/select_system_role_test.rb
+++ b/test/select_system_role_test.rb
@@ -56,10 +56,9 @@ describe ::Installation::SelectSystemRole do
         allow(Yast::WFM).to receive(:CallFunction).and_return(:next)
       end
 
-      it "does not display dialog" do
-        expect(Yast::Wizard).to_not receive(:SetContents)
-        expect(Yast::UI).to_not receive(:UserInput)
-        expect(Yast::UI).to_not receive(:QueryWidget)
+      it "(re)sets ProductFeatures" do
+        expect(Yast::ProductFeatures).to receive(:ClearOverlay)
+        expect(Yast::ProductFeatures).to receive(:SetOverlay)
 
         subject.run
       end
@@ -69,9 +68,10 @@ describe ::Installation::SelectSystemRole do
           allow(Yast::UI).to receive(:UserInput).and_return(:next)
         end
 
-        it "sets ProductFeatures" do
-          expect(Yast::ProductFeatures).to receive(:ClearOverlay)
-          expect(Yast::ProductFeatures).to receive(:SetOverlay)
+        it "does not display dialog" do
+          expect(Yast::Wizard).to_not receive(:SetContents)
+          expect(Yast::UI).to_not receive(:UserInput)
+          expect(Yast::UI).to_not receive(:QueryWidget)
 
           subject.run
         end
@@ -84,9 +84,10 @@ describe ::Installation::SelectSystemRole do
           allow(Yast::UI).to receive(:UserInput).and_return(:back)
         end
 
-        it "leaves ProductFeatures" do
-          expect(Yast::ProductFeatures).to receive(:ClearOverlay)
-          expect(Yast::ProductFeatures).to_not receive(:SetOverlay)
+        it "does not display dialog" do
+          expect(Yast::Wizard).to_not receive(:SetContents)
+          expect(Yast::UI).to_not receive(:UserInput)
+          expect(Yast::UI).to_not receive(:QueryWidget)
 
           subject.run
         end


### PR DESCRIPTION
> Related to fate#324713 and [bsc#1112564](https://bugzilla.suse.com/show_bug.cgi?id=1112564), avoid also to show the role
selection dialog user is going back and there is only one role
available.