### PR TITLE
Remember the selected role (related to FATE#325834), fixed testsuite

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Oct 25 08:02:13 UTC 2018 - lslezak@suse.cz
+
+- Remember the selected role (related to FATE#325834)
+- 4.1.22
+
+-------------------------------------------------------------------
 Tue Oct 23 14:17:49 CEST 2018 - schubi@suse.de
 
 - Saving y2logs after the installation has been finished.

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.1.21
+Version:        4.1.22
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/installation/select_system_role.rb
+++ b/src/lib/installation/select_system_role.rb
@@ -217,6 +217,7 @@ module Installation
     def apply_role(role_id)
       log.info "Applying system role '#{role_id}'"
 
+      SystemRole.select(role_id)
       self.class.previous_role_id = role_id
       role = SystemRole.find(role_id)
       role.overlay_features

--- a/src/lib/installation/system_role.rb
+++ b/src/lib/installation/system_role.rb
@@ -130,6 +130,8 @@ module Installation
       # @see current
       def select(role_id)
         @current_role = find(role_id)
+        log.info("Selected role: #{current}")
+        current_role
       end
 
       # Returns the current role id

--- a/test/lib/clients/inst_system_analysis_test.rb
+++ b/test/lib/clients/inst_system_analysis_test.rb
@@ -43,6 +43,7 @@ describe Yast::InstSystemAnalysisClient do
       allow(storage).to receive(:activate).and_return activate_result
       allow(storage).to receive(:probe).and_return probe_result
       allow(Yast::Mode).to receive(:auto).and_return(auto)
+      allow(Yast::Execute).to receive(:locally!)
       stub_const("Y2Autoinstallation::ActivateCallbacks", callbacks_class)
     end
 

--- a/test/select_system_role_test.rb
+++ b/test/select_system_role_test.rb
@@ -13,6 +13,7 @@ describe ::Installation::SelectSystemRole do
       "Lorem Ipsum #{s}"
     end
 
+    allow(Installation::SystemRole).to receive(:select)
     allow(Yast::UI).to receive(:ChangeWidget)
     allow(Yast::Language).to receive(:language).and_return("en_US")
 
@@ -59,6 +60,12 @@ describe ::Installation::SelectSystemRole do
       it "(re)sets ProductFeatures" do
         expect(Yast::ProductFeatures).to receive(:ClearOverlay)
         expect(Yast::ProductFeatures).to receive(:SetOverlay)
+
+        subject.run
+      end
+
+      it "remembers the role as selected" do
+        expect(Installation::SystemRole).to receive(:select).with("bar")
 
         subject.run
       end


### PR DESCRIPTION
- The selected role was not remembered, `Installation::SystemRole.current` returned `nil` even after selecting a role.
- This makes troubles with the role finish clients, they are not executed because the finish client thinks nothing was selected:
  ```
  [Ruby] installation/system_role.rb:175 There is no role selected so nothing to do
  ```
- Fixed a problem with a missing mock, running `rake test:unit` executed the `/usr/lib/YaST2/bin/mask-systemd-units` command resulting in displaying this dialog (sorry, Czech only):
![systemd_popup](https://user-images.githubusercontent.com/907998/47485302-25e2e980-d83e-11e8-9e00-49a45c7aa2a0.png)
- Fixed by mocking all `Yast::Execute.locally!` calls
- 4.1.21