### PR TITLE
Force the installer to use fbiterm

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Nov 16 11:06:36 UTC 2018 - igonzalezsosa@suse.com
+
+- Prefer fbiterm whenever is possible for textmode installation
+  (fate#325746).
+- 4.1.28
+
+-------------------------------------------------------------------
 Thu Nov 15 15:40:49 CET 2018 - schubi@suse.de
 
 - Dialog complex_welcome: Translate the help button if the language

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.1.27
+Version:        4.1.28
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/include/installation/inst_inc_first.rb
+++ b/src/include/installation/inst_inc_first.rb
@@ -66,8 +66,11 @@ module Yast
         Installation.encoding = "UTF-8"
       end
 
-      UI.SetLanguage(Language.language, Installation.encoding)
-      WFM.SetLanguage(Language.language, "UTF-8")
+      unless Language.SwitchToEnglishIfNeeded(true)
+        UI.SetLanguage(Language.language, Installation.encoding)
+        WFM.SetLanguage(Language.language, "UTF-8")
+      end
+
       UI.RecordMacro(Ops.add(Directory.logdir, "/macro_inst_initial.ycp"))
 
       Builtins.y2milestone("Adjusting first stage modules")

--- a/startup/common/language.sh
+++ b/startup/common/language.sh
@@ -30,25 +30,22 @@ function check_run_fbiterm () {
 	if test "$TERM" = "linux" -a \
 		\( "$TTY" = /dev/console -o "$TTY" != "${TTY#/dev/tty[0-9]}" \);
 	then
-		case "$LANG" in
-		ja*.UTF-8|ko*.UTF-8|zh*.UTF-8)
-		# check whether fbiterm can run on console
-		if test -x /usr/bin/fbiterm && \
-			/usr/bin/fbiterm echo >/dev/null 2>&1;
-		then
-			RUN_FBITERM=1
-		else
-			# use english
-			export LANG=en_US.UTF-8
-			export LC_CTYPE=en_US.UTF-8
-		fi
-		;;
-		ja*|ko*|zh*)
+	    # check whether fbiterm can run on console
+	    if test -x /usr/bin/fbiterm && \
+		    /usr/bin/fbiterm echo >/dev/null 2>&1;
+	    then
+		RUN_FBITERM=1
+	    else
 		# use english
 		export LANG=en_US.UTF-8
 		export LC_CTYPE=en_US.UTF-8
-		;;
-	esac
+	    fi
+
+	    case "$LANG" in
+		ar_EG*|bn_BD*|gu_IN*|hi_IN*|km_KH*|mr_IN*|pa_IN*|ta_IN*|th_TH*)
+		    export LANG=en_US.UTF-8
+		    export LC_CTYPE=en_US.UTF-8
+	    esac
 	fi
 }
 

--- a/startup/common/language.sh
+++ b/startup/common/language.sh
@@ -44,7 +44,7 @@ function check_run_fbiterm () {
 	    case "$LANG" in
 		# These languages are not properly supported by fbiterm causing YaST to crash
 		# (fate#325746).
-		ar*|bn*|gu*|hi*|km*|mr*|pa*|ta_*|th*)
+		ar*|bn*|gu*|hi*|km*|mr*|pa*|ta*|th*)
 		    export LANG=en_US.UTF-8
 		    export LC_CTYPE=en_US.UTF-8
 	    esac

--- a/startup/common/language.sh
+++ b/startup/common/language.sh
@@ -39,6 +39,7 @@ function check_run_fbiterm () {
 		# use english
 		export LANG=en_US.UTF-8
 		export LC_CTYPE=en_US.UTF-8
+		log "\tfbiterm is not available or it does not work in this environment"
 	    fi
 
 	    case "$LANG" in

--- a/startup/common/language.sh
+++ b/startup/common/language.sh
@@ -42,7 +42,9 @@ function check_run_fbiterm () {
 	    fi
 
 	    case "$LANG" in
-		ar_EG*|bn_BD*|gu_IN*|hi_IN*|km_KH*|mr_IN*|pa_IN*|ta_IN*|th_TH*)
+		# These languages are not properly supported by fbiterm causing YaST to crash
+		# (fate#325746).
+		ar*|bn*|gu*|hi*|km*|mr*|pa*|ta_*|th*)
 		    export LANG=en_US.UTF-8
 		    export LC_CTYPE=en_US.UTF-8
 	    esac


### PR DESCRIPTION
Force the installer to use `fbiterm`.

See also yast/yast-country#192 and yast/yast-autoinstallation#477.

## Screenshots

![textmode-jp](https://user-images.githubusercontent.com/15836/48270488-1fee2a80-e432-11e8-9796-0d8af68c6881.png)
![textmode-en](https://user-images.githubusercontent.com/15836/48270489-1fee2a80-e432-11e8-93ed-2260311e89ab.png)