### PR TITLE
Improved saving y2logs during installation (bsc#1118643)

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu Dec  6 12:59:03 UTC 2018 - lslezak@suse.cz
+
+- Improved saving y2logs during installation to use the /mnt/tmp
+  space instead of the RAM disk to avoid possible crash (out of
+  memory) (bsc#1118643)
+- 4.1.31
+
+-------------------------------------------------------------------
 Sat Nov 24 19:40:43 UTC 2018 - Stasiek Michalski <hellcp@mailbox.org>
 
 - Provide icon with module (boo#1109310)

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.1.30
+Version:        4.1.31
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/installation/clients/save_y2logs.rb
+++ b/src/lib/installation/clients/save_y2logs.rb
@@ -17,8 +17,14 @@ module Yast
           Yast::Directory.logdir
         )
 
+        # use the target /tmp when available to save memory
+        target_tmp = File.join(Yast::Installation.destdir, "tmp")
+        tmpdir = File.exist?(target_tmp) ? target_tmp : "/tmp"
+
         WFM.Execute(Yast::Path.new(".local.bash"),
-          "/usr/sbin/save_y2logs '#{target_path}/yast-installation-logs.tar.xz'")
+          # set TMPDIR for `mktemp -d` so it uses the target disk, not inst-sys RAM disk
+          # https://github.com/yast/yast-yast2/blob/482eecb6064e2a904864fdab17e8c4bed41065ff/scripts/save_y2logs#L72
+          "TMPDIR=#{tmpdir} /usr/sbin/save_y2logs '#{target_path}/yast-installation-logs.tar.xz'")
       end
     end
   end


### PR DESCRIPTION
- Use the `/mnt/tmp` space instead of the RAM disk to avoid possible crash (out of memory)
- Tested manually in installed system with `TMPDIR=/tmp/tmp /usr/sbin/save_y2logs`, it used `/tmp/tmp` for saving the temporary data (like `dmesg` and jounal).
- It might not fix the YaST crash but let's try...
- 4.1.31