### PR TITLE
More aggresive inst-sys cleaner (bsc#1118643)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,4 @@ script:
   # see https://github.com/yast/docker-yast-ruby/blob/master/yast-travis-ruby
   - docker run -it -e TRAVIS=1 -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" yast-installation-image yast-travis-ruby
   - docker run -it yast-installation-image rake check:doc
+  - docker run -it yast-installation-image shellcheck startup/First-Stage/F08-logging

--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -5,6 +5,9 @@ Fri Dec  7 14:45:24 UTC 2018 - lslezak@suse.cz
   when running in graphical mode with less than 1GB RAM
   (in text mode keep the current limit 640MB), this avoids
   crashes on low memory systems (bsc#1118643)
+- Also adapted the computing the default y2log size - use
+  smaller size in low memory systems, on the other hand limit the
+  maximum size to avoid huge log files
 - 4.1.32
 
 -------------------------------------------------------------------

--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Fri Dec  7 14:45:24 UTC 2018 - lslezak@suse.cz
+
+- More aggresive inst-sys cleaner, clean the libzypp cache
+  when running in graphical mode with less than 1GB RAM
+  (in text mode keep the current limit 640MB), this avoids
+  crashes on low memory systems (bsc#1118643)
+- 4.1.32
+
+-------------------------------------------------------------------
 Thu Dec  6 12:59:03 UTC 2018 - lslezak@suse.cz
 
 - Improved saving y2logs during installation to use the /mnt/tmp

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.1.31
+Version:        4.1.32
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/installation/instsys_cleaner.rb
+++ b/src/lib/installation/instsys_cleaner.rb
@@ -29,13 +29,15 @@ module Installation
 
     Yast.import "Mode"
     Yast.import "Stage"
+    Yast.import "UI"
 
     # memory limit for removing the kernel modules from inst-sys (1GB)
     KERNEL_MODULES_WATERLINE = 1 << 30
     KERNEL_MODULES_MOUNT_POINT = "/parts/mp_0000".freeze
 
-    # memory limit for removing the libzypp metadata cache (640MB)
-    LIBZYPP_WATERLINE = 640 << 20
+    # memory limit for removing the libzypp metadata cache (<640MB in text mode, <1GB in GUI)
+    LIBZYPP_WATERLINE_TUI = 640 << 20
+    LIBZYPP_WATERLINE_GUI = 1 << 30
     # the cache in inst-sys, the target system cache is at /mnt/...,
     # in upgrade mode the target cache is kept
     LIBZYPP_CACHE_PATH = "/var/cache/zypp/raw".freeze
@@ -47,16 +49,21 @@ module Installation
       "*-deltainfo.xml.gz",
       "*-primary.xml.gz",
       "*-susedata.xml.gz",
+      "*-susedata.*.xml.gz",
       "*-susedinfo.xml.gz",
       "*-updateinfo.xml.gz",
       # product licenses (already confirmed)
       "*-license-*.tar.gz",
       # application meta data
       "*-appdata.xml.gz",
-      "appdata-icons.tar.gz",
+      "*-appdata-icons.tar.gz",
       "appdata-ignore.xml.gz",
       "appdata-screenshots.tar"
     ].freeze
+
+    def self.libzypp_waterline
+      Yast::UI.TextMode ? LIBZYPP_WATERLINE_TUI : LIBZYPP_WATERLINE_GUI
+    end
 
     # Remove some files in inst-sys to have more free space if the system
     # has too low memory. If the system has enough memory keep everything in place.
@@ -74,7 +81,7 @@ module Installation
 
       # run the cleaning actions depending on the available memory
       unmount_kernel_modules if memory < KERNEL_MODULES_WATERLINE
-      cleanup_zypp_cache if memory < LIBZYPP_WATERLINE
+      cleanup_zypp_cache if memory < libzypp_waterline
     end
 
     ########################## Internal methods ################################

--- a/startup/First-Stage/F08-logging
+++ b/startup/First-Stage/F08-logging
@@ -6,23 +6,41 @@ log "======================="
 # 8) setup default logfile size
 #---------------------------------------------
 
-# log size defined by user
-Y2MAXLOGSIZE_INITIAL=$Y2MAXLOGSIZE
+# min default log size: 1MB
+Y2LOG_DEFAULT_MIN_SIZE=1000
 
-test -z "$Y2MAXLOGSIZE" && export Y2MAXLOGSIZE=100
-test -z "$Y2MAXLOGNUM"  && export Y2MAXLOGNUM=5
+# the max default log size depends on the environment
+# NOTE: y2-core defines 10MB default in installed system
+if [ -z "$Y2DEBUG" ]; then
+    # max default log size: 20MB
+    Y2LOG_DEFAULT_MAX_SIZE=20000
+else
+    # with Y2DEBUG allow bigger log: 40MB
+    Y2LOG_DEFAULT_MAX_SIZE=40000
+fi
 
 #=============================================
-# 8.1) setup logfile size as 1/3 of FreeRam
+# 8.1) setup logfile size as 1/4 of FreeRam
+#      but not more/less than the limits
 #---------------------------------------------
 
-# log size not defined by user
-if [ -z "$Y2MAXLOGSIZE_INITIAL" ]; then
-    USE=`awk '/^MemFree:/{ n=2 ; printf "%d\n", $n/3 }' /proc/meminfo`
-    if [ "$USE" -gt "$Y2MAXLOGSIZE" ];then
-	    export Y2MAXLOGSIZE=$USE
+if [ -z "$Y2MAXLOGSIZE" ]; then
+    USE=$(awk '/^MemFree:/{ n=2 ; printf "%d\n", $n/4 }' /proc/meminfo)
+    log "\tComputed default log size: $USE kB"
+    # more than the minimum default
+    if [ "$USE" -gt "$Y2LOG_DEFAULT_MIN_SIZE" ]; then
+        # more than the maximum default
+        if [ "$USE" -gt "$Y2LOG_DEFAULT_MAX_SIZE" ]; then
+	        export Y2MAXLOGSIZE=$Y2LOG_DEFAULT_MAX_SIZE
+        else
+	        export Y2MAXLOGSIZE=$USE
+        fi
+    else
+        export Y2MAXLOGSIZE=$Y2LOG_DEFAULT_MIN_SIZE
     fi
 fi
+
+test -z "$Y2MAXLOGNUM" && export Y2MAXLOGNUM=5
 
 # fate#302166: store y2debug messages and log them on crash
 export Y2DEBUGONCRASH=1

--- a/test/instsys_cleaner_test.rb
+++ b/test/instsys_cleaner_test.rb
@@ -4,9 +4,6 @@ require_relative "./test_helper"
 
 require "installation/instsys_cleaner"
 
-def stub_logging
-end
-
 describe Installation::InstsysCleaner do
   describe ".make_clean" do
     context "in the initial stage" do
@@ -18,13 +15,14 @@ describe Installation::InstsysCleaner do
         allow(Yast::Execute).to receive(:locally).with("df", "-m")
         allow(Yast::Execute).to receive(:locally).with("free", "-m")
         allow(File).to receive(:size).and_return(0)
+        allow(Dir).to receive(:[]).and_return([])
+        allow(Yast::UI).to receive(:TextMode).and_return(true)
       end
 
-      context "removes the libzypp cache if the memory is less than 640MB" do
+      context "a bit less than 640MB memory in text mode" do
         before do
           # 512MB - 1B
           expect(Yast2::HwDetection).to receive(:memory).and_return((512 << 20) - 1)
-          allow(Dir).to receive(:[]).and_return([])
           allow(described_class).to receive(:unmount_kernel_modules)
         end
 
@@ -33,11 +31,41 @@ describe Installation::InstsysCleaner do
           described_class.make_clean
         end
 
-        it "removes only the known files" do
+        it "removes the known files from the libzypp cache" do
           file = "/var/cache/zypp/raw/SLES15-15-0/repodata/1234567890abcdef-appdata.xml.gz"
           expect(Dir).to receive(:[]).with("/var/cache/zypp/raw/**/*-appdata.xml.gz")
             .and_return([file])
           expect(FileUtils).to receive(:rm).with(file)
+          described_class.make_clean
+        end
+      end
+
+      context "a bit less than 1GB memory in graphical mode" do
+        before do
+          # 1GB - 1B
+          expect(Yast2::HwDetection).to receive(:memory).and_return((1 << 30) - 1)
+          allow(described_class).to receive(:unmount_kernel_modules)
+          allow(Yast::UI).to receive(:TextMode).and_return(false)
+        end
+
+        it "removes the known files from the libzypp cache" do
+          file = "/var/cache/zypp/raw/SLES15-15-0/repodata/1234567890abcdef-appdata.xml.gz"
+          expect(Dir).to receive(:[]).with("/var/cache/zypp/raw/**/*-appdata.xml.gz")
+            .and_return([file])
+          expect(FileUtils).to receive(:rm).with(file)
+          described_class.make_clean
+        end
+      end
+
+      context "a bit less than 1GB memory in text mode" do
+        before do
+          # 1GB - 1B
+          expect(Yast2::HwDetection).to receive(:memory).and_return((1 << 30) - 1)
+          allow(described_class).to receive(:unmount_kernel_modules)
+        end
+
+        fit "does not remove the libzypp cache" do
+          expect(described_class).to_not receive(:cleanup_zypp_cache)
           described_class.make_clean
         end
       end


### PR DESCRIPTION
- Clean the libzypp cache when running in graphical mode with less than 1GB RAM (in text mode keep the current limit 640MB), this avoids crashes on low memory systems.
- Updated the glob list, the `appdata-icons.tar.gz` file now also has a hash prefix, just like the other files. (See the [repo data](https://download.opensuse.org/distribution/leap/15.1/repo/oss/repodata/) for Leap 15.1.)

- 4.1.32