### PR TITLE
Save the used repositories at the end of installation (bsc#953522)

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Feb 14 12:23:31 UTC 2019 - lslezak@suse.cz
+
+- Save the used repositories at the end of installation to not
+  offer the driver packages again (bsc#953522)
+- 4.1.36
+
+-------------------------------------------------------------------
 Fri Feb  1 13:13:31 CET 2019 - schubi@suse.de
 
 - Copying SSH keys from a privious installation into the new one:

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.1.35
+Version:        4.1.36
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -46,8 +46,8 @@ BuildRequires:  rubygem(yast-rake)
 BuildRequires:  yast2 >= 4.1.42
 Requires:       yast2 >= 4.1.42
 
-# Y2Packager::SelfUpdateAddonRepo
-BuildRequires:	yast2-packager >= 4.1.5
+# Y2Packager::KnownRepositories
+BuildRequires:	yast2-packager >= 4.1.27
 
 # Y2Storage::Inhibitors including systemd masking
 BuildRequires: yast2-storage-ng >= 4.0.194
@@ -63,8 +63,8 @@ Requires:	yast2-pkg-bindings >= 3.1.33
 # Mouse-related scripts moved to yast2-mouse
 Conflicts:	yast2-mouse < 2.18.0
 
-# Y2Packager::SelfUpdateAddonRepo
-Requires:	yast2-packager >= 4.1.5
+# Y2Packager::KnownRepositories
+Requires:	yast2-packager >= 4.1.27
 
 # use in startup scripts
 Requires:	initviocons

--- a/src/lib/installation/clients/inst_extrasources.rb
+++ b/src/lib/installation/clients/inst_extrasources.rb
@@ -19,6 +19,8 @@
 # current contact information at www.novell.com.
 # ------------------------------------------------------------------------------
 
+require "y2packager/known_repositories"
+
 Yast.import "UI"
 Yast.import "Pkg"
 Yast.import "GetInstArgs"
@@ -68,6 +70,10 @@ module Yast
         Builtins.y2error("Cannot connect to the Packager")
         return :auto
       end
+
+      # save the list of installation repositories before adding the extra repos
+      # https://github.com/yast/yast-packager/wiki/Selecting-the-Driver-Packages
+      save_system_packages_repos
 
       @already_registered = RegisteredUrls()
 
@@ -520,6 +526,15 @@ module Yast
       Builtins.y2milestone("User input: %1", r)
 
       r == :yes
+    end
+
+    # save the known repositories to not offer again installing the driver packages
+    # (they should be already installed in the initial installation, if user deselected
+    # them they should not be offered again)
+    def save_system_packages_repos
+      known_repos = Y2Packager::KnownRepositories.new
+      known_repos.update
+      known_repos.write
     end
   end
 end


### PR DESCRIPTION
## Problem

To avoid selecting the driver packages again if user deselected them during installation we need to mark the installation repositories as "known".

See more details in the links below.

## Notes

Travis fails because of the new dependency, the package builds fine locally.

## References 

- https://github.com/yast/yast-packager/wiki/Selecting-the-Driver-Packages
- https://bugzilla.suse.com/show_bug.cgi?id=953522
- https://github.com/yast/yast-packager/pull/401
