### PR TITLE
Do not write displaymanager value

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Mar  5 11:12:13 UTC 2019 - José Iván López González <jlopez@suse.com>
+
+- Do not write the displaymanager value (part of bsc#1125040).
+- 4.1.39
+
+-------------------------------------------------------------------
 Tue Mar  5 10:31:35 UTC 2019 - mvidner@suse.com
 
 - Respect Textmode=1 when installing over SSH with a DISPLAY (bsc#1047470)

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.1.38
+Version:        4.1.39
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/installation/clients/desktop_finish.rb
+++ b/src/lib/installation/clients/desktop_finish.rb
@@ -66,7 +66,6 @@ module Yast
 
       log.info "selected desktop #{desktop_map}"
 
-      default_dm = desktop_map["logon"] || ""
       default_wm = desktop_map["desktop"] || ""
       default_cursor = desktop_map["cursor"] || ""
 
@@ -76,20 +75,6 @@ module Yast
         default_cursor
       )
       SCR.Write(path(".sysconfig.windowmanager"), nil)
-
-      dpmng_file = "/etc/sysconfig/displaymanager"
-      # Creates an empty sysconfig file if it doesn't exist
-      if !FileUtils.Exists(dpmng_file) &&
-          FileUtils.Exists("/usr/bin/touch")
-        log.info "Creating file #{dpmng_file}"
-        Yast::Execute.on_target("/usr/bin/touch", dpmng_file)
-      end
-
-      SCR.Write(
-        path(".sysconfig.displaymanager.DISPLAYMANAGER"),
-        default_dm
-      )
-      SCR.Write(path(".sysconfig.displaymanager"), nil)
 
       nil
     end

--- a/test/desktop_finish_test.rb
+++ b/test/desktop_finish_test.rb
@@ -58,9 +58,9 @@ describe Yast::DesktopFinishClient do
       subject.write
     end
 
-    it "writes desktop manager for selected desktop" do
-      expect(Yast::SCR).to receive(:Write)
-        .with(path(".sysconfig.displaymanager.DISPLAYMANAGER"), "gdm")
+    it "does not write the displaymanager (bsc#1125040)" do
+      expect(Yast::SCR).to_not receive(:Write)
+        .with(path(".sysconfig.displaymanager.DISPLAYMANAGER"), anything)
 
       subject.write
     end


### PR DESCRIPTION
## Problem

Editing the `DISPLAYMANAGER` variable in `/etc/sysconfig/displaymanager` does not make effect anymore. Instead, `update-alternatives` should be used to change the default display manager, see [release notes for Leap 15.0](https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/15.0/index.html#general).

The X11 team already [fixed the XDM package](https://build.opensuse.org/request/show/674644) to not include this variable in `/etc/sysconf/displaymanger` file, so `yast2-sysconfig` editor will not show this value anymore.

But `yast2-installation` is still writing the `DISPLAYMANAGER` value in its `desktop_finish` client.

* https://bugzilla.suse.com/show_bug.cgi?id=1125040
* https://trello.com/c/FSAwjaC1/769-1-osdistribution-p3-1125040-install-yast2-alternatives-module-by-default-in-addition-to-yast2-sysconfig
* Related PR: https://github.com/yast/patterns-yast/pull/23

## Solution

`desktop_finish` client has been adapted to not write `DISPLAYMANAGER` value.

## Testing

* Adapted unit test
* Manually tested
