### PR TITLE
Mkdir /etc/YaST2 before copying files to it (#1127182)

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Mar  1 12:12:31 UTC 2019 - mvidner@suse.com
+
+- copy_files_finish: ensure that /mnt/etc/YaST2 exists (bsc#1127182).
+- 4.1.37
+
+-------------------------------------------------------------------
 Thu Feb 14 12:23:31 UTC 2019 - lslezak@suse.cz
 
 - Save the used repositories at the end of installation to not

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.1.36
+Version:        4.1.37
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/installation/clients/copy_files_finish.rb
+++ b/src/lib/installation/clients/copy_files_finish.rb
@@ -293,6 +293,7 @@ module Yast
     def copy_control_file
       log.info "Copying YaST control file"
       destination = File.join(Installation.destdir, Directory.etcdir, "control.xml")
+      ::FileUtils.mkdir_p(File.join(Installation.destdir, Directory.etcdir))
       ::FileUtils.cp(ProductControl.current_control_file, destination)
       ::FileUtils.chmod(0o644, destination)
     end


### PR DESCRIPTION
- https://trello.com/c/Hp7r298L
- https://bugzilla.suse.com/show_bug.cgi?id=1127182

yast2.rpm that normally owns that dir may not be there

I've tested with an unregistered SLES installation (Build178.3) that the bug exists without the fix and disappears with the fix.