### PR TITLE
Unified "repositories" label (bsc#1123679)

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Mar  7 11:55:36 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
+
+- Unified "repositories" label (bsc#1123679)
+- 4.1.42
+
+-------------------------------------------------------------------
 Thu Mar  7 08:10:33 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
 
 - Retranslate also the side bar steps when changing the language

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.1.41
+Version:        4.1.42
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/installation/clients/inst_upgrade_urls.rb
+++ b/src/lib/installation/clients/inst_upgrade_urls.rb
@@ -216,8 +216,7 @@ module Yast
 
     def CreateListTableUI
       Wizard.SetContents(
-        # TRANSLATORS: dialog caption
-        _("Previously Used Repositories"),
+        dialog_title,
         VBox(
           # TRANSLATORS: dialog text, possibly multiline,
           # Please, do not use more than 50 characters per line.
@@ -612,8 +611,7 @@ module Yast
 
     def SetAddRemoveSourcesUI
       Wizard.SetContents(
-        # TRANSLATORS: dialog caption
-        _("Previously Used Repositories"),
+        dialog_title,
         VBox(
           # TRANSLATORS: Progress text
           Label(_("Adding and removing repositories..."))
@@ -670,8 +668,7 @@ module Yast
       end
 
       Progress.New(
-        # TRANSLATORS: dialog caption
-        _("Previously Used Repositories"),
+        dialog_title,
         _("Adding and removing repositories..."),
         steps_nr,
         actions_todo,
@@ -1360,6 +1357,18 @@ module Yast
         )
       end
       new_url
+    end
+
+    # Build the dialog title (depending on the current UI)
+    # @return [String] the translated title
+    def dialog_title
+      if UI.TextMode
+        # TRANSLATORS: dialog title (short form for text mode)
+        _("Previously Used Repositories")
+      else
+        # TRANSLATORS: dialog title (long form for GUI, but still keep as short as possible)
+        _("Previously Used Repositories (Products, Extensions, Modules, Other Repositories)")
+      end
     end
   end
 end


### PR DESCRIPTION
- Unify the "repositories" and "add-on product" labels
- https://bugzilla.suse.com/show_bug.cgi?id=1123679
- 4.1.42

## Questions?

- The new text is too long for text mode, should we use a shorter text in text mode? The original `Previously Used Repositories` should be good enough. (Keep in mind that in some languages the translation might be even longer so a longer part might be clipped off.)

## Screenshots

#### Graphical

Full label:

![old_repos_at_upgrade](https://user-images.githubusercontent.com/907998/53733863-95b74f80-3e82-11e9-8d02-eaab37995e30.png)


#### Text Mode

Shorter label to fit on the screen:

![old_repos_at_upgrade_text](https://user-images.githubusercontent.com/907998/53959974-576d9a80-40e5-11e9-9ed2-bbf1fd301bbc.png)
