### PR TITLE
Respect Textmode=1 when installing over SSH with a DISPLAY (bsc#1047470)

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Mar  5 10:31:35 UTC 2019 - mvidner@suse.com
+
+- Respect Textmode=1 when installing over SSH with a DISPLAY (bsc#1047470)
+- 4.1.38
+
+-------------------------------------------------------------------
 Fri Mar  1 12:12:31 UTC 2019 - mvidner@suse.com
 
 - copy_files_finish: ensure that /mnt/etc/YaST2 exists (bsc#1127182).

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.1.37
+Version:        4.1.38
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/startup/YaST2.call
+++ b/startup/YaST2.call
@@ -232,13 +232,16 @@ function check_network () {
 		log "\tNo network interface found, fatal error"
 		fatalError
 	fi
-	if [ ! -z "$DISPLAY" ];then
+	if [ "$Textmode" = 1 ];then
+		log "\tTextmode selected for network install"
+		Y2_MODE=ncurses
+	elif [ ! -z "$DISPLAY" ];then
 		log "\tDisplay: $DISPLAY found for network install"
 		Y2_MODE=qt
-	fi
-	if ! check_qt ; then
-	    log "\tQt plugin check failed falling back to ncurses"
-	    Y2_MODE=ncurses
+		if ! check_qt ; then
+			log "\tQt plugin check failed falling back to ncurses"
+			Y2_MODE=ncurses
+		fi
 	fi
 }
 


### PR DESCRIPTION
https://trello.com/c/XddgyRZS
https://bugzilla.suse.com/show_bug.cgi?id=1047470

The fix is: in `check_network`, which is called for SSH installations, only check `$DISPLAY` when `Textmode` is not set. 

Additional small fix: no need to check the qt plugin if we haven't selected it in the first place. Note that some logical combinations don't assign `Y2_MODE`. That is fine because for SSH, it is preset to ncurses before calling this function.