### PR TITLE
Stop using obsolete XVersion; check textdomain presence

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -2,6 +2,7 @@
 Wed Aug  7 12:16:15 UTC 2019 - Martin Vidner <mvidner@suse.com>
 
 - Stop using the obsolete XVersion API (bsc#1144627)
+- Detect missing textdomain during testing (bsc#1130822)
 - 4.2.9
 
 -------------------------------------------------------------------

--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Aug  7 12:16:15 UTC 2019 - Martin Vidner <mvidner@suse.com>
+
+- Stop using the obsolete XVersion API (bsc#1144627)
+- 4.2.9
+
+-------------------------------------------------------------------
 Mon Aug  5 08:43:21 UTC 2019 - David Diaz <dgonzalez@suse.com>
 
 - Improve the detection of a forced base product

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.2.8
+Version:        4.2.9
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/src/lib/installation/clients/inst_complex_welcome.rb
+++ b/src/lib/installation/clients/inst_complex_welcome.rb
@@ -50,6 +50,10 @@ module Yast
 
     BETA_FILE = "/README.BETA".freeze
 
+    def initialize
+      textdomain "installation"
+    end
+
     # Main client method
     def main
       if FileUtils.Exists(BETA_FILE) && !GetInstArgs.going_back
@@ -58,8 +62,6 @@ module Yast
 
       # bnc#206706
       return :auto if Mode.auto
-
-      textdomain "installation"
 
       Yast::Wizard.EnableAbortButton
 

--- a/src/lib/installation/clients/inst_system_analysis.rb
+++ b/src/lib/installation/clients/inst_system_analysis.rb
@@ -33,10 +33,12 @@ module Yast
   class InstSystemAnalysisClient < Client
     include Yast::Logger
 
+    def initialize
+      textdomain "installation"
+    end
+
     def main
       Yast.import "UI"
-
-      textdomain "installation"
 
       # Require here to break dependency cycle (bsc#1070996)
       require "autoinstall/activate_callbacks"

--- a/startup/YaST2.Second-Stage
+++ b/startup/YaST2.Second-Stage
@@ -25,8 +25,6 @@
 # Ignoring SIGHUP seems easiest workaround here
 trap "" SIGHUP
 
-. /etc/YaST2/XVersion
-
 #=============================================
 # Functions...
 #---------------------------------------------
@@ -85,9 +83,8 @@ for i in \
 	/usr/lib/info/              \
 	/usr/local/info/            \
 	/usr/local/lib/info/        \
-	$Xinfodir                 \
-	$Xlibdir/info/            \
-	$Xlibdir/xemacs/info/     \
+	/usr/info                 \
+	/usr/lib/xemacs/info/     \
 	/var/adm/packages
 do
 	test -d $i && touch $i 2> /dev/null
@@ -95,7 +92,6 @@ done
 for i in \
 	/usr/share/info             \
 	/usr/man /usr/share/man     \
-	$Xmandir                  \
 	/usr/openwin/man            \
 	/usr/lib/perl5/man          \
 	/usr/lib/teTeX/man          \

--- a/startup/YaST2.call
+++ b/startup/YaST2.call
@@ -27,8 +27,6 @@
 #
 #set -x
 
-. /etc/YaST2/XVersion
-
 #=============================================
 # Functions...
 #---------------------------------------------
@@ -78,8 +76,7 @@ function prepare_for_x11 () {
 	#---------------------------------------------
 	if [ ! -z "$NEED_XSERVER" ];then
 		export DISPLAY=:0
-		[ -z $Xstartpath ] || ln -snf $Xbindir/XFree86 /var/X11R6/bin/X
-		$Xexecutable -br -nolisten tcp -deferglyphs 16 2>/dev/tty8 1>&2 vt07 &
+		Xorg -noreset -br -nolisten tcp -deferglyphs 16 2>/dev/tty8 1>&2 vt07 &
 		xserver_pid=$!
 		wait_for_x11
 		if [ "$server_running" = 1 ];then
@@ -460,7 +457,6 @@ set_syslog ; set_proxy
 #---------------------------------------------
 # 2.1) setup PATH
 PATH=$ybindir:$PATH
-[ -z Xstartpath ] || PATH=/var/X11R6/bin:$PATH
 
 #=============================================
 # 2.3) obtain RAM size in Kb
@@ -520,9 +516,9 @@ fi
 
 # 3.1.5) Check for xorg.conf...
 if [ ! -f /etc/X11/xorg.conf ] ; then
-    if [ -f $Xorgconftempl ] ; then
-	log "\tCopying $Xorgconftempl to /etc/X11/xorg.conf"
-	cp $Xorgconftempl /etc/X11/xorg.conf
+    if [ -f /etc/X11/xorg.conf.template ] ; then
+	log "\tCopying /etc/X11/xorg.conf.template to /etc/X11/xorg.conf"
+	cp /etc/X11/xorg.conf.template /etc/X11/xorg.conf
     fi
 fi
 
@@ -572,7 +568,7 @@ if [ ! -f /etc/icewm/preferences.yast2 ];then
 	MEDIUM[2]=0
 fi
 # 3.3.2) Check for VNC X-Server binary
-if [ ! -x $Xbindir/Xvnc ] ; then
+if [ ! -x /usr/bin/Xvnc ] ; then
 	log "\tNo Xvnc server installed -> Medium VNC disabled"
 	MEDIUM[2]=0
 fi

--- a/startup/common/vnc.sh
+++ b/startup/common/vnc.sh
@@ -16,7 +16,6 @@
 # STATUS        : $Id$
 #----------------
 
-. /etc/YaST2/XVersion
 # set python path for websockify
 # (only present and needed in the inst-sys)
 if [ -r /root/.profile ]; then
@@ -30,7 +29,7 @@ setupVNCAuthentication () {
 # password file.
 #
 	VNCPASS_EXCEPTION=0
-	VNCPASS=$Xbindir/vncpasswd.arg
+	VNCPASS=/usr/bin/vncpasswd.arg
 	if [ ! -e /root/.vnc/passwd.yast ]; then
 		rm -rf /root/.vnc && mkdir -p /root/.vnc
 		$VNCPASS /root/.vnc/passwd.yast "$VNCPassword"
@@ -84,7 +83,7 @@ startVNCServer () {
 	[ -z "$VNCSize" ] && VNCSize=1024x768
 
 	# For -noreset see BNC #351338
-	$Xbindir/Xvnc $Xvncparam :0 \
+	/usr/bin/Xvnc :0 \
 		-noreset \
 		-rfbauth /root/.vnc/passwd.yast \
 		-desktop "Installation" \
@@ -93,7 +92,7 @@ startVNCServer () {
                 -dpi 96 \
 		-rfbwait 120000 \
 		-rfbport 5901 \
-		-fp $Xfontdir/misc/,$Xfontdir/uni/,$Xfontdir/truetype/ \
+		-fp /usr/share/fonts/misc/,/usr/share/fonts/uni/,/usr/share/fonts/truetype/ \
 	>/var/log/YaST2/vncserver.log 2>&1 &
 	xserver_pid=$!
 

--- a/test/ssh_config_test.rb
+++ b/test/ssh_config_test.rb
@@ -34,6 +34,7 @@ describe Installation::SshConfig do
     let(:root4_dir) { FIXTURES_DIR.join("root4") }
 
     before do
+      textdomain "installation"
       # The ssh_host private key file is more recent than any other file
       allow(File).to receive(:atime) do |path|
         path =~ /ssh_host_key$/ ? recent_root1_atime : old_root1_atime

--- a/test/ssh_config_test.rb
+++ b/test/ssh_config_test.rb
@@ -55,7 +55,7 @@ describe Installation::SshConfig do
 
     it "uses name and version when PRETTY_NAME is missing in /etc/os-release" do
       root3 = described_class.from_dir(root3_dir)
-      expect(root3.system_name).to eq _("SUSE 10")
+      expect(root3.system_name).to eq "SUSE 10"
     end
 
     it "stores all the keys and files with their names" do

--- a/test/ssh_import_auto_test.rb
+++ b/test/ssh_import_auto_test.rb
@@ -11,6 +11,7 @@ describe ::Installation::SSHImportAutoClient do
   let(:args) { [] }
 
   before do
+    textdomain "installation"
     allow(Yast::WFM).to receive(:Args).and_return([func, args])
     allow(Yast::Mode).to receive(:mode).and_return(mode)
   end

--- a/test/ssh_importer_presenter_test.rb
+++ b/test/ssh_importer_presenter_test.rb
@@ -16,6 +16,8 @@ describe ::Installation::SshImporterPresenter do
     let(:copy_config) { false }
 
     before do
+      textdomain "installation"
+
       importer.configurations.clear
       importer.reset
       importer.add_config(FIXTURES_DIR.join(config), "dev")

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,6 +5,8 @@ ENV["Y2DIR"] = y2dirs.unshift(srcdir).join(":")
 # make sure we run the tests in English locale
 # (some tests check the output which is marked for translation)
 ENV["LC_ALL"] = "en_US.UTF-8"
+# fail fast if a class does not declare textdomain (bsc#1130822)
+ENV["Y2STRICTTEXTDOMAIN"] = "1"
 
 require "yast"
 require "yast/rspec"


### PR DESCRIPTION
It was useful in 2006 when X.org 6 and X.org 7 had different places for files
- https://bugzilla.suse.com/show_bug.cgi?id=1144627

textdomain:
- https://bugzilla.suse.com/show_bug.cgi?id=1130822