### PR TITLE
Retranslate the side bar steps (bsc#1128153)

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Mar  7 08:10:33 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
+
+- Retranslate also the side bar steps when changing the language
+  (bsc#1128153)
+- 4.1.41
+
+-------------------------------------------------------------------
 Wed Mar  6 13:01:03 UTC 2019 - jreidinger@suse.com
 
 - Do not change polkit default priviledges during upgrade

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.1.40
+Version:        4.1.41
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/installation/dialogs/complex_welcome.rb
+++ b/src/lib/installation/dialogs/complex_welcome.rb
@@ -21,6 +21,7 @@ require "y2packager/widgets/product_license"
 
 Yast.import "UI"
 Yast.import "Wizard"
+Yast.import "ProductControl"
 
 module Installation
   module Dialogs
@@ -83,6 +84,7 @@ module Installation
         loop do
           res = super
           Yast::Wizard.RetranslateButtons
+          Yast::ProductControl.RetranslateWizardSteps
           break if res != :redraw
         end
 

--- a/test/dialogs/complex_welcome_test.rb
+++ b/test/dialogs/complex_welcome_test.rb
@@ -14,6 +14,18 @@ describe Installation::Dialogs::ComplexWelcome do
     end
   end
 
+  describe "#run" do
+    it "retranslates the buttons and side bar" do
+      # mock displaying the dialog
+      allow(subject).to receive(:should_open_dialog?).and_return(false)
+      allow(subject).to receive(:cwm_show).and_return(:next)
+
+      expect(Yast::Wizard).to receive(:RetranslateButtons)
+      expect(Yast::ProductControl).to receive(:RetranslateWizardSteps)
+      subject.run
+    end
+  end
+
   describe "#content" do
     let(:sles_product) { instance_double("Y2Packager::Product", label: "SLES") }
     let(:language_widget) { Yast::Term.new(:language_widget) }


### PR DESCRIPTION
## The Problem

- The side bar steps were translated only after pressing the `Next` button
- They should be updated immediately after changing the language
- https://bugzilla.suse.com/show_bug.cgi?id=1128153

## The Fix

- A similar issue was fixed in #762 

## Testing

- Added unit test
- Tested manually in Leap 15.1 - the sidebar is updated immediately (see the screencast below)
- Tested manually in SLE15-SP1 - the sidebar is not displayed there, no regression there

## Screencast

![retranslate_dialog](https://user-images.githubusercontent.com/907998/53943815-39407400-40be-11e9-839d-24a1a35295f3.gif)



