### PR TITLE
Fix packages and patterns selection

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Mar  8 16:08:48 UTC 2019 - José Iván López González <jlopez@suse.com>
+
+- Fix patterns and packages selection when going back to the system
+  role selection (bsc#1126517).
+- 4.1.42
+
+-------------------------------------------------------------------
 Thu Mar  7 08:10:33 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
 
 - Retranslate also the side bar steps when changing the language

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.1.41
+Version:        4.1.42
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/test/select_system_role_test.rb
+++ b/test/select_system_role_test.rb
@@ -24,7 +24,9 @@ describe ::Installation::SelectSystemRole do
     before do
       allow(Yast::ProductFeatures).to receive(:ClearOverlay)
       allow(Yast::ProductFeatures).to receive(:SetOverlay)
+      allow(Yast::Packages).to receive(:Reset)
       allow(Yast::Packages).to receive(:SelectSystemPatterns)
+      allow(Yast::Packages).to receive(:SelectSystemPackages)
       allow(Installation::SystemRole).to receive(:current)
     end
 


### PR DESCRIPTION
## Problem

The installation summary shows a list of patterns to install, but if you go back until the Role Selection screen and then go forward again without changing the role, the list of patterns shown by the installation summary changes (there are much less patterns).

* https://bugzilla.suse.com/show_bug.cgi?id=1126517
* https://trello.com/c/OrkgoQYI/795-important-osdistribution-p2-1126517-patterns-are-not-selected-anymore-when-going-back-to-the-system-role-selection-screen

## Solution

The packages/patterns automatically selected by the solver should be deselected before calling the solver again. Otherwise, the solver does not select the same list of patterns (a bug with the solver?).

## Testing

* Tested manually.
