### PR TITLE
Update hard-coded fallback path to licenses directory 

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Mar 12 15:48:13 UTC 2019 - David Díaz <dgonzalez@suse.com>
+
+- Update the hard-coded fallback path for licenses directory
+  (fate#324053, jsc#SLE-4173)
+- 4.1.43
+
+-------------------------------------------------------------------
 Fri Mar  8 16:08:48 UTC 2019 - José Iván López González <jlopez@suse.com>
 
 - Fix patterns and packages selection when going back to the system

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.1.42
+Version:        4.1.43
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/installation/clients/inst_license.rb
+++ b/src/lib/installation/clients/inst_license.rb
@@ -102,7 +102,7 @@ module Yast
             )
             # fallback - hard-coded
           else
-            @directory = "/etc/YaST2/licenses/base/"
+            @directory = "/usr/share/licenses/product/base/"
             Builtins.y2warning(
               "No 'base_product_license_directory' set, using %1",
               @directory


### PR DESCRIPTION
After the changes made for fate#324053 / jsc#SLE-4173, the license for the base product will be located at `/usr/share/licenses/product/base` instead of `/etc/YaST2/licenses/base`.

---

Related to https://github.com/yast/yast-yast2/pull/907