### PR TITLE
Allow to preselect the product

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Mar 19 09:19:10 UTC 2019 - David Díaz <dgonzalez@suse.com>
+
+- Use the select_product attribute from control file to filter
+  availalbe products (bsc#1124590).
+- 4.2.0
+
+-------------------------------------------------------------------
 Fri Mar 15 10:38:35 UTC 2019 - snwint@suse.com
 
 - revert SSH textmode patches (bsc#1129375, bsc#1047470)

--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -2,7 +2,7 @@
 Tue Mar 19 09:19:10 UTC 2019 - David Díaz <dgonzalez@suse.com>
 
 - Use the select_product attribute from control file to filter
-  availalbe products (bsc#1124590).
+  available products (bsc#1124590).
 - 4.2.0
 
 -------------------------------------------------------------------

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.1.45
+Version:        4.2.0
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/installation/clients/inst_complex_welcome.rb
+++ b/src/lib/installation/clients/inst_complex_welcome.rb
@@ -35,6 +35,7 @@ Yast.import "Mode"
 Yast.import "Pkg"
 Yast.import "Popup"
 Yast.import "ProductControl"
+Yast.import "ProductFeatures"
 Yast.import "Stage"
 Yast.import "Timezone"
 Yast.import "Wizard"
@@ -145,14 +146,39 @@ module Yast
     # not know which product we are upgrading yet) nor the product selector
     # (as you cannot change the product during upgrade).
     #
+    # It could return a list with pre-selected product(s), @see #preselected_base_product.
+    #
     # @return [Array<Y2Packager::Product>] List of available base products;
     # empty list in update mode.
     def products
       return @products if @products
 
-      @products = Y2Packager::Product.available_base_products
+      @products = preselected_base_product || available_base_products
       @products = [] if Mode.update && @products.size > 1
       @products
+    end
+
+    # Returns, if any, the preselected base product (bsc#1124590)
+    #
+    # A product can be pre-selected using the `select_product` element in the software section
+    # in the control file.
+    #
+    # @return [nil, Array<Y2Packager::Product>] nil when no preselected product in control file,
+    #                                           a list containing the preselected base product, or
+    #                                           empty list if preselected product is not available
+    def preselected_base_product
+      preselected_product = ProductFeatures.GetStringFeature("software", "select_product")
+
+      return if preselected_product.empty?
+
+      available_base_products.select { |product| product.name == preselected_product }
+    end
+
+    # Returns all available base products
+    #
+    # @return [Array<Y2Packager::Product>] List of available base products
+    def available_base_products
+      @available_base_products ||= Y2Packager::Product.available_base_products
     end
 
     # Determine whether some product is available or not

--- a/src/lib/installation/clients/inst_complex_welcome.rb
+++ b/src/lib/installation/clients/inst_complex_welcome.rb
@@ -167,11 +167,22 @@ module Yast
     #                                           a list containing the preselected base product, or
     #                                           empty list if preselected product is not available
     def preselected_base_product
-      preselected_product = ProductFeatures.GetStringFeature("software", "select_product")
+      selected_product_name = ProductFeatures.GetStringFeature("software", "select_product")
 
-      return if preselected_product.empty?
+      return if selected_product_name.empty?
 
-      available_base_products.select { |product| product.name == preselected_product }
+      log.info("control.xml wants to preselect the #{selected_product_name} product")
+
+      filtered_base_products = available_base_products.select do |product|
+        product.name == selected_product_name
+      end
+      discarded_base_products = available_base_products - filtered_base_products
+
+      if !discarded_base_products.empty?
+        log.info("Ignoring the other available products: #{discarded_base_products.map(&:name)}")
+      end
+
+      filtered_base_products
     end
 
     # Returns all available base products


### PR DESCRIPTION
## Problem

Having multiple products in a single repository (i.e. openSUSE and Kubic), `system-installation()` could provide the "wrong" one during a network installation, ending with conflicts between product and patterns.

- https://bugzilla.suse.com/show_bug.cgi?id=1124590
- https://trello.com/c/RPnSpewA/808-3-tw-kubic-1124590-optionally-hardcode-the-product-name-in-the-controlxml

## Solution

Originally proposed by @lslezak, 

> to hardcode the product name in the control.xml 

So, the installer would select the right product **without asking to user**.

## Testing

- *Added a new unit test*

## Related PRs

- https://github.com/yast/yast-installation-control/pull/79

