### PR TITLE
Use the Docker image built by OBS in Travis

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM yastdevel/ruby
+FROM registry.opensuse.org/yast/head/containers/yast-ruby
 COPY . /usr/src/app
 


### PR DESCRIPTION
- Experimentally use the Docker image built by OBS (https://build.opensuse.org/package/show/YaST:Head/ci-ruby-container)
- Sources: https://github.com/yast/ci-ruby-container\
- See https://trello.com/c/sVVOXYbx/878-5-build-the-docker-images-for-travis-in-obs

## Advantages

- The image is rebuilt immediately when the RPM packages are built
- Does not wait for publishing the packages, does not wait for full rebuild (only for the needed packages)
- No extra accounts/permissions for the Docker Hub (just use your OBS account)
- The build in OBS is faster (6-7 minutes), that means the new package should be available in the Docker image in less than 15 minutes after merging a PR (for leaf packages)
- No need for extra Jenkins jobs periodically triggering the image rebuilds at the Docker Hub
