### PR TITLE
Removed BuildRequires: yast2-ntp-client (causing dependency cycle)

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Apr  4 08:10:42 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
+
+- Removed BuildRequires: yast2-ntp-client (causing dependency cycle)
+  (related to the previous fix bsc#1129095)
+- 4.2.2
+
+-------------------------------------------------------------------
 Fri Mar 29 12:58:51 UTC 2019 - David Diaz <dgonzalez@suse.com>
 
 - Add a new installation dialog which allows to setup the NTP

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.2.1
+Version:        4.2.2
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -93,9 +93,6 @@ Requires:	yast2-users >= 3.2.8
 # storage-ng based version
 BuildRequires:	yast2-country >= 3.3.1
 Requires:	yast2-country >= 3.3.1
-
-# NtpSetup dialog (bsc#1129095)
-BuildRequires: yast2-ntp-client
 
 # Pkg::SourceProvideSignedFile Pkg::SourceProvideDigestedFile
 # pkg-bindings are not directly required

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -34,6 +34,8 @@ stub_module("Packages")
 stub_module("ProductLicense")
 stub_module("Profile")
 stub_module("ProfileLocation")
+# we cannot depend on this module (circular dependency)
+stub_module("NtpClient")
 
 if ENV["COVERAGE"]
   require "simplecov"


### PR DESCRIPTION
- `BuildRequires: yast2-ntp-client` caused a dependency cycle and must be removed.
- It was needed only for the unit tests, can be replaced by a stub module
- The disadvantage is that RSpec then cannot verify if the mocked methods really exist, but there is probably no better and simple solution