### PR TITLE
Make sure pkg target is alive as long as needed

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Apr 24 13:26:07 UTC 2019 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Make sure pkg target is active as long as still needed (bsc#1128385)
+- 4.2.3
+
+-------------------------------------------------------------------
 Thu Apr  4 08:10:42 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
 
 - Removed BuildRequires: yast2-ntp-client (causing dependency cycle)

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.2.2
+Version:        4.2.3
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/installation/clients/inst_finish.rb
+++ b/src/lib/installation/clients/inst_finish.rb
@@ -352,7 +352,6 @@ module Yast
         "kernel",
         "x11",
         "proxy",
-        "pkg",
         "scc",
         "driver_update1",
         # bnc #340733
@@ -389,7 +388,8 @@ module Yast
         "roles",
         "services",
         "services-manager",
-        "configuration_management"
+        "configuration_management",
+        "pkg"   # Some _finish clients might still need Pkg calls (e.g. users) (bsc#1128385)
       ].freeze
 
     def save_settings_steps

--- a/src/lib/installation/clients/inst_finish.rb
+++ b/src/lib/installation/clients/inst_finish.rb
@@ -389,7 +389,7 @@ module Yast
         "services",
         "services-manager",
         "configuration_management",
-        "pkg"   # Some _finish clients might still need Pkg calls (e.g. users) (bsc#1128385)
+        "pkg" # Some _finish clients might still need Pkg calls (e.g. users) (bsc#1128385)
       ].freeze
 
     def save_settings_steps


### PR DESCRIPTION
# Trello

https://trello.com/c/gjV8SydY

# Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1128385#c4
(the "reopen" case starting at comment #4)


# Failing openQA Tests

https://openqa.opensuse.org/tests/913479
https://openqa.opensuse.org/tests/913480


# Problem

No autologin even with a full-fledged KDE Plasma or GNOME desktop.

# Cause

Pkg target already shut down (`Pkg::TargetFinish`), i.e. no packages known to libzypp on the target system, i.e. also no display manager that supports autologin, so no autologin configuration is written.

# Fix

Change the order in `inst_finish.rb`: Make sure `pkg` is _after_ `users`.

# Test

Manual test with the ISO from the OpenQA test case plus the changed `inst_finish.rb` bind-mounted.