### PR TITLE
Copy Multipath config files

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Jun 17 13:37:35 UTC 2019 - José Iván López González <jlopez@suse.com>
+
+- Copy multipath config files into the target system.
+- Related to bsc#1133045.
+- 4.2.6
+
+-------------------------------------------------------------------
 Sat Jun  8 01:49:48 UTC 2019 - Stasiek Michalski <hellcp@mailbox.org>
 
 - Use new schema of desktop files (boo#1084864)

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.2.5
+Version:        4.2.6
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/src/lib/installation/clients/copy_files_finish.rb
+++ b/src/lib/installation/clients/copy_files_finish.rb
@@ -251,20 +251,21 @@ module Yast
       )
     end
 
+    # See {https://www.suse.com/support/kb/doc/?id=7001133}
+    MULTIPATH_CONFIG_FILES = [
+      "/etc/multipath.conf",
+      "/etc/multipath/bindings",
+      "/etc/multipath/wwids"
+    ].freeze
+
+    private_constant :MULTIPATH_CONFIG_FILES
+
     def copy_multipath
       # Only in install, as update should keep its old config
       return unless Mode.installation
 
       # Copy multipath stuff (bnc#885628, bsc#1133045)
-      #
-      # See {https://www.suse.com/support/kb/doc/?id=7001133}
-      multipath_config_files = [
-        "/etc/multipath.conf",
-        "/etc/multipath/bindings",
-        "/etc/multipath/wwids"
-      ]
-
-      multipath_config_files.each do |config_file|
+      MULTIPATH_CONFIG_FILES.each do |config_file|
         next unless File.exist?(config_file)
 
         log.info "Copying multipath config file: '#{config_file}'"

--- a/src/lib/installation/clients/copy_files_finish.rb
+++ b/src/lib/installation/clients/copy_files_finish.rb
@@ -1,23 +1,23 @@
 # encoding: utf-8
 
-# ------------------------------------------------------------------------------
-# Copyright (c) 2006-2012 Novell, Inc. All Rights Reserved.
+# Copyright (c) [2006-2019] SUSE LLC
 #
+# All Rights Reserved.
 #
-# This program is free software; you can redistribute it and/or modify it under
-# the terms of version 2 of the GNU General Public License as published by the
-# Free Software Foundation.
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
 #
 # This program is distributed in the hope that it will be useful, but WITHOUT
-# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
-# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
 #
-# You should have received a copy of the GNU General Public License along with
-# this program; if not, contact Novell, Inc.
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
 #
-# To contact Novell about this file by physical or electronic mail, you may find
-# current contact information at www.novell.com.
-# ------------------------------------------------------------------------------
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
 
 require "fileutils"
 require "installation/ssh_importer"
@@ -252,16 +252,26 @@ module Yast
     end
 
     def copy_multipath
-      # Copy multipath stuff (bnc#885628)
       # Only in install, as update should keep its old config
       return unless Mode.installation
 
-      multipath_config = "/etc/multipath/wwids"
-      if File.exist?(multipath_config)
-        log.info "Copying multipath blacklist '#{multipath_config}'"
-        target_path = File.join(Installation.destdir, multipath_config)
-        ::FileUtils.mkdir_p(File.dirname(target_path))
-        ::FileUtils.cp(multipath_config, target_path)
+      # Copy multipath stuff (bnc#885628, bsc#1133045)
+      #
+      # See {https://www.suse.com/support/kb/doc/?id=7001133}
+      multipath_config_files = [
+        "/etc/multipath.conf",
+        "/etc/multipath/bindings",
+        "/etc/multipath/wwids"
+      ]
+
+      multipath_config_files.each do |config_file|
+        next unless File.exist?(config_file)
+
+        log.info "Copying multipath config file: '#{config_file}'"
+        target_path = File.join(Installation.destdir, config_file)
+        target_dir = File.dirname(target_path)
+        ::FileUtils.mkdir_p(target_dir) unless File.exist?(target_dir)
+        ::FileUtils.cp(config_file, target_path)
       end
     end
 

--- a/test/copy_files_finish_test.rb
+++ b/test/copy_files_finish_test.rb
@@ -1,3 +1,25 @@
+#!/usr/bin/env rspec
+# encoding: utf-8
+
+# Copyright (c) [2018-2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
 require_relative "./test_helper.rb"
 
 require "installation/clients/copy_files_finish"
@@ -94,9 +116,12 @@ describe Yast::CopyFilesFinishClient do
       allow(Yast::Mode).to receive(:installation).and_return(true)
       allow(::FileUtils).to receive(:cp)
       allow(::FileUtils).to receive(:mkdir_p)
-      allow(::File).to receive(:exist?).with("/etc/multipath/wwids").and_return(true)
+      allow(::File).to receive(:exist?).with(/^\/etc\/multipath/).and_return(true)
+      allow(::File).to receive(:exist?).with(/^\/mnt\/etc\/multipath/).and_return(false)
 
       expect(::FileUtils).to receive(:mkdir_p).with("/mnt/etc/multipath")
+      expect(::FileUtils).to receive(:cp).with("/etc/multipath.conf", "/mnt/etc/multipath.conf")
+      expect(::FileUtils).to receive(:cp).with("/etc/multipath/bindings", "/mnt/etc/multipath/bindings")
       expect(::FileUtils).to receive(:cp).with("/etc/multipath/wwids", "/mnt/etc/multipath/wwids")
 
       subject.write


### PR DESCRIPTION
## Problem

When using the multipath optioin *user_friendly_names* during installation, the following config files must also be copied to the installed system: */etc/multipath.conf* and */etc/multipath/bindings*. Otherwise, names persistence is not guarantee.

* https://www.suse.com/support/kb/doc/?id=7001133

Needed for:
* https://bugzilla.suse.com/show_bug.cgi?id=1133045
* https://trello.com/c/3re8LvvF/1049-autoyast-hw-probing-behavior-vs-scripts

## Solution

Client *inst_files_finish* has been adapted to copy multipath config files into the target system.
  