### PR TITLE
Keep focus in the RichText widget for the proposal installation summary

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu Jul 25 11:52:07 UTC 2019 - David Diaz <dgonzalez@suse.com>
+
+- Avoid to lost the focus in the proposal installation summary when
+  the user makes changes using the available options on it
+  (bsc#1142353).
+- 4.2.7
+
+-------------------------------------------------------------------
 Mon Jun 17 13:37:35 UTC 2019 - José Iván López González <jlopez@suse.com>
 
 - Copy multipath config files into the target system.

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.2.6
+Version:        4.2.7
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/src/lib/installation/proposal_runner.rb
+++ b/src/lib/installation/proposal_runner.rb
@@ -199,6 +199,10 @@ module Installation
     def input_loop
       loop do
         richtext_normal_cursor(Id(:proposal))
+
+        # Keep focus in the RichText widget (bsc#1142353)
+        Yast::UI.SetFocus(Id(:proposal))
+
         # bnc #431567
         # Some proposal module can change it while called
         assign_next_button


### PR DESCRIPTION
## Problem

In the text mode, the proposal summary lost the focus when user makes changes using the available options (for example, toggling the firewall settings). The focus is changed to the <kbd>Change...</kbd> combobox.

* https://bugzilla.suse.com/show_bug.cgi?id=1142353

## Solution

Set the focus in the mentioned area (which is a `RichText`) each time that the `input_loop` start again.

## Drawback

The first time that the user arrives to this dialog, the focus is captured by the first available option inside the summary (`Software` in the screenshot attached), instead of the `Release Notes` _button_.

## Tests

Tested manually, via driver update.

## Screenshots

![Screenshot_SLE-15_2019-07-25_16:14:14](https://user-images.githubusercontent.com/1691872/61886640-fad61500-aef7-11e9-8fdc-da44ad2ebd02.png)

<p align="center"><sub>The installation summary, with the focus in the Software option</sub></p>


