### PR TITLE
 Fix the forced base product selection (3/3)

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Aug  5 08:43:21 UTC 2019 - David Diaz <dgonzalez@suse.com>
+
+- Improve the detection of a forced base product
+  (bsc#1124590, bsc#1143943).
+- 4.2.8
+
+-------------------------------------------------------------------
 Thu Jul 25 11:52:07 UTC 2019 - David Diaz <dgonzalez@suse.com>
 
 - Avoid to lost the focus in the proposal installation summary when

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -75,7 +75,8 @@ Requires:       yast2-proxy
 # Systemd default target and services. This version supports
 # writing settings in the first installation stage.
 Requires:       yast2-services-manager >= 3.2.1
-Requires:       yast2 >= 4.1.42
+# Y2Packager::Product.forced_base_product
+Requires:       yast2 >= 4.2.17
 Requires:       yast2-network >= 4.0.13
 # for AbortException and handle direct abort
 Requires:       yast2-ruby-bindings >= 4.0.6

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.2.7
+Version:        4.2.8
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/src/lib/installation/clients/inst_complex_welcome.rb
+++ b/src/lib/installation/clients/inst_complex_welcome.rb
@@ -141,30 +141,20 @@ module Yast
 
     # Return the list of base products available
     #
-    # The list of base products could be
+    # When a base product is being forced, the list will contains only it.
     #
-    #   - Fixed to a single product: which will happen when the base product is
-    #     being forced through the control.xml. Then, only its license will be
-    #     show, nor the product selector.
-    #   - Empty: in update mode, when there are more than 1 product, this method
-    #     will return an empty list because the dialog will not show the license (we
-    #     do not know which product we are upgrading yet) nor the product selector
-    #     (as you cannot change the product during upgrade).
-    #   - Complete: containing all whe available base products.
+    # In update mode, when there are more than 1 product, this method will return an empty
+    # list because the dialog will not show the license (we do not know which product we are
+    # upgrading yet) nor the product selector (as you cannot change the product during upgrade).
     #
-    # @return [Array<Y2Packager::Product>] List of available base products;
-    # a list containing only the forced product if any; empty list in update mode.
+    # @return [Array<Y2Packager::Product>] List of available base products; if any, a list
+    # containing only the forced base product; empty list in update mode.
     def products
       return @products if @products
 
-      @products =
-        if Y2Packager::Product.forced_base_product
-          [Y2Packager::Product.forced_base_product]
-        elsif Mode.update && available_base_products.size > 1
-          []
-        else
-          available_base_products
-        end
+      @products = Array(Y2Packager::Product.forced_base_product || available_base_products)
+      @products = [] if Mode.update && @products.size > 1
+      @products
     end
 
     # Returns all available base products


### PR DESCRIPTION
## Problem

Recently, the `select_product` option was added to the control file to allow **forcing** the base product selection when having multiple products in a single repository (see https://github.com/yast/yast-installation/pull/790).

But seems that the feature was not fully implemented and the installer only avoids displaying the product selector, but not marking the forced product as selected, raising an internal error when trying to access to `#installation_package`.

* https://bugzilla.suse.com/show_bug.cgi?id=1143943
* https://trello.com/c/YuiJfYBt/1201-ostumbleweed-p1-1143943-build-20190801-undefined-method-installationpackage

## Solution

To select the **foced** product properly.

:warning: **Requires `yast2 4.2.17` - https://github.com/yast/yast-yast2/pull/954**

## Additional notes

See https://github.com/yast/yast-yast2/pull/954 for more information and screenshots.
