### PR TITLE
Undo the change done in 4.2.7

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Aug 14 13:33:56 UTC 2019 - David Diaz <dgonzalez@suse.com>
+
+- Undo the change introduced in 4.2.7 because forcing the focus
+  is not a solution: now the it's always caught by the installation
+  summary after every action (related to bsc#1142353).
+- 4.2.10
+
+-------------------------------------------------------------------
 Wed Aug  7 12:16:15 UTC 2019 - Martin Vidner <mvidner@suse.com>
 
 - Stop using the obsolete XVersion API (bsc#1144627)

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.2.9
+Version:        4.2.10
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/src/lib/installation/proposal_runner.rb
+++ b/src/lib/installation/proposal_runner.rb
@@ -199,10 +199,6 @@ module Installation
     def input_loop
       loop do
         richtext_normal_cursor(Id(:proposal))
-
-        # Keep focus in the RichText widget (bsc#1142353)
-        Yast::UI.SetFocus(Id(:proposal))
-
         # bnc #431567
         # Some proposal module can change it while called
         assign_next_button


### PR DESCRIPTION
## Problem

The [change introduced in `4.2.7`](https://github.com/yast/yast-installation/pull/806/commits/28e689991946abfb5bc89ca5d25b82cc635d876f) improves nothing. Even worst, now the focus it is always caught by the proposal installation summary, even when the user choose an action from the `Change...` _actions button_.

## Solution

Undo the change and wait 

> for the innovation and renovation regarding LibYUI and the YaST UI — https://lizards.opensuse.org/2019/08/14/yast-sprint-82/

---

Related to https://github.com/yast/yast-installation/pull/806

