### PR TITLE
do NOT remove /mnt/run, it's a mounted directory (bsc#1149011)

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Sep 11 13:17:21 UTC 2019 - Steffen Winterfeldt <snwint@suse.com>
+
+- do NOT remove /mnt/run, it's a mounted directory (bsc#1149011)
+- 4.2.13
+
+-------------------------------------------------------------------
 Wed Aug 28 11:08:18 CEST 2019 - schubi@suse.de
 
 - Set X-SuSE-YaST-AutoInstResource in desktop file (bsc#144894).

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.2.12
+Version:        4.2.13
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/src/lib/installation/clients/pre_umount_finish.rb
+++ b/src/lib/installation/clients/pre_umount_finish.rb
@@ -53,11 +53,6 @@ module Installation
       # See FATE #303396
       HandleSecondStageRequired()
 
-      # Remove content of /run which has been created by the pre/post
-      # install scripts while RPM installation and not needed anymore.
-      # (bnc#1071745)
-      SCR.Execute(path(".target.bash"), "/usr/bin/rm -rf /run/*")
-
       # Release all sources, they might be still mounted
       Pkg.SourceReleaseAll
 

--- a/test/lib/clients/pre_umount_finish_test.rb
+++ b/test/lib/clients/pre_umount_finish_test.rb
@@ -19,12 +19,6 @@ describe ::Installation::PreUmountFinish do
       subject.write
     end
 
-    it "removes content in /run" do
-      expect(Yast::SCR).to receive(:Execute).with(anything, /rm .*\/run/)
-
-      subject.write
-    end
-
     it "beeps if a bootmessage is available" do
       expect(Yast::Misc).to receive(:boot_msg).and_return("bootmessage")
       expect(Yast::SCR).to receive(:Execute).with(anything, /\/bin\/echo -e /)


### PR DESCRIPTION
## Problem

https://bugzilla.suse.com/show_bug.cgi?id=1149011

At the end of the installation, switching the X server to text console and then back leaves the X server unresponsive to any input. (This workflow is part of openqa collecting logs.)

## Cause

YaST deleted `/mnt/run` at the end of the installation in an attempt to fix [bsc#1071745](https://bugzilla.suse.com/show_bug.cgi?id=1071745).

That's a really bad idea as that is a bind-mounted directory. This way `/run` got cleaned up as well.

The fix is needed in conjunction with [bsc#1136463](https://bugzilla.suse.com/show_bug.cgi?id=1136463).

## Solution

Do not do this.