### PR TITLE
do NOT remove /mnt/run, it's a mounted directory (bsc#1149011)

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Sep 18 09:21:57 UTC 2019 - Steffen Winterfeldt <snwint@suse.com>
+
+- do NOT remove /mnt/run, it's a mounted directory (bsc#1149011)
+- require yast2-storage-ng >= 4.1.87 (bsc#1136463)
+- 4.1.47
+
+-------------------------------------------------------------------
 Fri May 10 15:07:17 CEST 2019 - schubi@suse.de
 
 - Downloading files: Remounting CD with bind option correctly if

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.1.46
+Version:        4.1.47
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -51,7 +51,7 @@ BuildRequires:	yast2-packager >= 4.1.27
 
 # Y2Storage::Inhibitors including systemd masking
 BuildRequires: yast2-storage-ng >= 4.0.194
-Requires:      yast2-storage-ng >= 4.0.175
+Requires:      yast2-storage-ng >= 4.1.87
 
 # Language::GetLanguageItems and other API
 # Language::Set (handles downloading the translation extensions)

--- a/src/lib/installation/clients/pre_umount_finish.rb
+++ b/src/lib/installation/clients/pre_umount_finish.rb
@@ -53,11 +53,6 @@ module Installation
       # See FATE #303396
       HandleSecondStageRequired()
 
-      # Remove content of /run which has been created by the pre/post
-      # install scripts while RPM installation and not needed anymore.
-      # (bnc#1071745)
-      SCR.Execute(path(".target.bash"), "/usr/bin/rm -rf /run/*")
-
       # Release all sources, they might be still mounted
       Pkg.SourceReleaseAll
 

--- a/test/lib/clients/pre_umount_finish_test.rb
+++ b/test/lib/clients/pre_umount_finish_test.rb
@@ -19,12 +19,6 @@ describe ::Installation::PreUmountFinish do
       subject.write
     end
 
-    it "removes content in /run" do
-      expect(Yast::SCR).to receive(:Execute).with(anything, /rm .*\/run/)
-
-      subject.write
-    end
-
     it "beeps if a bootmessage is available" do
       expect(Yast::Misc).to receive(:boot_msg).and_return("bootmessage")
       expect(Yast::SCR).to receive(:Execute).with(anything, /\/bin\/echo -e /)


### PR DESCRIPTION
## Problem

https://bugzilla.suse.com/show_bug.cgi?id=1149011

At the end of the installation, switching the X server to text console and then back leaves the X server unresponsive to any input. (This workflow is part of openqa collecting logs.)

## Cause

YaST deleted `/mnt/run` at the end of the installation in an attempt to fix [bsc#1071745](https://bugzilla.suse.com/show_bug.cgi?id=1071745).

That's a really bad idea as that is a bind-mounted directory. This way `/run` got cleaned up as well.

The fix is needed in conjunction with [bsc#1136463](https://bugzilla.suse.com/show_bug.cgi?id=1136463).

## See also

Fix in `master`: https://github.com/yast/yast-installation/pull/811.

## Important!

This fix must be submitted together with https://github.com/yast/yast-storage-ng/pull/966.

## Solution

Do not do this.