### PR TITLE
do not stop haveged process (bsc#1140171)

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Sep 25 08:02:58 UTC 2019 - Steffen Winterfeldt <snwint@suse.com>
+
+- do not stop haveged process (bsc#1140171)
+- 3.4.0
+
+-------------------------------------------------------------------
 Fri Mar 15 13:22:58 UTC 2019 - snwint@suse.com
 
 - revert SSH textmode patches (bsc#1129375, bsc#1047470)

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation
-Version:        3.3.0.3
+Version:        3.4.0
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/installation/clients/umount_finish.rb
+++ b/src/lib/installation/clients/umount_finish.rb
@@ -345,7 +345,6 @@ module Yast
 
       Builtins.y2milestone("Saving the current randomness state...")
 
-      service_bin = "/usr/sbin/haveged"
       random_path = "/dev/urandom"
       store_to = Builtins.sformat(
         "%1/var/lib/misc/random-seed",
@@ -376,10 +375,6 @@ module Yast
         )
         @ret = false
       end
-
-      # stop the random number generator service
-      Builtins.y2milestone("Stopping %1 service", service_bin)
-      LocalCommand(Builtins.sformat("killproc -TERM %1", service_bin))
 
       nil
     end


### PR DESCRIPTION
## Problem

https://bugzilla.suse.com/show_bug.cgi?id=1140171

At the end of the installation, some processes might lock up when fips is enabled.

## Solution

Do not kill haveged.

It's needed to avoid security relevant processes to lock up due to insufficient randomness.

## See also

- related change in inst-sys: https://github.com/openSUSE/installation-images/pull/333
- Scrum card: https://trello.com/c/PiMSEWGo