### PR TITLE
do not stop haveged process (bsc#1140171)

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Sep 25 08:29:19 UTC 2019 - Steffen Winterfeldt <snwint@suse.com>
+
+- do not stop haveged process (bsc#1140171)
+- 4.2.15
+
+-------------------------------------------------------------------
 Fri Sep 20 13:39:18 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
 
 - Support for the online installation medium (jsc#SLE-7214)

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.2.14
+Version:        4.2.15
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/src/lib/installation/clients/pre_umount_finish.rb
+++ b/src/lib/installation/clients/pre_umount_finish.rb
@@ -97,7 +97,6 @@ module Installation
       poolsize
     end
 
-    SERVICE_BIN = "/usr/sbin/haveged".freeze
     RANDOM_PATH = "/dev/urandom".freeze
     # Preserves the current randomness state, BNC #692799
     def preserve_randomness_state
@@ -118,10 +117,6 @@ module Installation
       else
         log.info "Cannot store #{RANDOM_PATH} state to #{store_to}"
       end
-
-      # stop the random number generator service
-      log.info "Stopping #{SERVICE_BIN} service"
-      local_command("/sbin/killproc -TERM '#{String.Quote(SERVICE_BIN)}'")
     end
   end
 end

--- a/test/lib/clients/pre_umount_finish_test.rb
+++ b/test/lib/clients/pre_umount_finish_test.rb
@@ -41,7 +41,6 @@ describe ::Installation::PreUmountFinish do
 
       it "does not preserve randomness state" do
         expect(Yast::WFM).not_to receive(:Execute).with(anything, /dd/)
-        expect(Yast::WFM).not_to receive(:Execute).with(anything, /killproc -TERM/)
 
         subject.write
       end
@@ -54,7 +53,6 @@ describe ::Installation::PreUmountFinish do
 
       it "does preserve randomness state" do
         expect(Yast::WFM).to receive(:Execute).with(anything, /dd/)
-        expect(Yast::WFM).to receive(:Execute).with(anything, /killproc -TERM/)
 
         subject.write
       end


### PR DESCRIPTION
## Problem

https://bugzilla.suse.com/show_bug.cgi?id=1140171

At the end of the installation, some processes might lock up when fips is enabled.

## Solution

Do not kill haveged.

It's needed to avoid security relevant processes to lock up due to insufficient randomness.

## See also

- same in SLE-12-SP5 branch: https://github.com/yast/yast-installation/pull/817
- related change in inst-sys: https://github.com/openSUSE/installation-images/pull/334
- Scrum card: https://trello.com/c/PiMSEWGo