### PR TITLE
Support for the offline installation medium (jsc#SLE-7101)

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Oct  1 16:09:07 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
+
+- Support for the offline installation medium (jsc#SLE-7101)
+- 4.2.16
+
+-------------------------------------------------------------------
 Wed Sep 25 08:29:19 UTC 2019 - Steffen Winterfeldt <snwint@suse.com>
 
 - do not stop haveged process (bsc#1140171)

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.2.15
+Version:        4.2.16
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/test/lib/clients/inst_complex_welcome_test.rb
+++ b/test/lib/clients/inst_complex_welcome_test.rb
@@ -69,7 +69,7 @@ describe Yast::InstComplexWelcomeClient do
     allow(Y2Packager::Product).to receive(:selected_base).and_return(product)
     allow(Y2Packager::Product).to receive(:available_base_products).and_return(products)
     allow(Y2Packager::Product).to receive(:forced_base_product).and_return(forced_base_product)
-    allow(Y2Packager::MediumType).to receive(:online?).and_return(false)
+    allow(Y2Packager::MediumType).to receive(:type).and_return(:standard)
   end
 
   describe "#main" do


### PR DESCRIPTION
- Adapt the product selection and initialization for the offline installation medium
- Do not allow changing the selected base product when going back (we would need to remove the previous base product repository which might be tricky if some addons have already been added)
- https://jira.suse.com/browse/SLE-7101
- 4.2.16