### PR TITLE
Decreasing required memory

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,5 +1,5 @@
 -------------------------------------------------------------------
-Thu Nov 15 08:59:40 UTC 2019 - schubi@suse.de
+Fri Nov 15 08:59:40 UTC 2019 - schubi@suse.de
 
 - Using Y2Packager::Resolvable.any? and Y2Packager::Resolvable.find
   in order to decrease the required memory (bsc#1132650).

--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -2,7 +2,8 @@
 Fri Nov 15 08:59:40 UTC 2019 - schubi@suse.de
 
 - Using Y2Packager::Resolvable.any? and Y2Packager::Resolvable.find
-  in order to decrease the required memory (bsc#1132650).
+  in order to decrease the required memory (bsc#1132650,
+  bsc#1140037).
 - 4.2.24
 
 -------------------------------------------------------------------

--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Oct 31 17:26:16 CET 2019 - schubi@suse.de
+
+- Using Y2Packager::Resolvable.any? and Y2Packager::Resolvable.find
+  in order to decrease the required memory (bsc#1132650).
+- 4.2.19
+
+-------------------------------------------------------------------
 Tue Oct 11 09:24:17 CEST 2019 - schubi@suse.de
 
 - Adapted to new Keyboard handling.

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.2.18
+Version:        4.2.19
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/src/lib/installation/clients/inst_addon_update_sources.rb
+++ b/src/lib/installation/clients/inst_addon_update_sources.rb
@@ -27,6 +27,9 @@
 # Assumptions:
 # - the sources will be saved afterwards
 # (this means that running this client alone will not work)
+
+require "y2packager/resolvable"
+
 module Yast
   class InstAddonUpdateSourcesClient < Client
     def main
@@ -152,10 +155,10 @@ module Yast
     # @return the installation sources to be added
     def UpdateUrls
       urls = {}
-      products = Pkg.ResolvableProperties("", :product, "")
+      products = Y2Packager::Resolvable.find(kind: :product)
 
       Builtins.foreach(products) do |p|
-        Builtins.foreach(Ops.get_list(p, "update_urls", [])) do |u|
+        Builtins.foreach((p.update_urls || [])) do |u|
           # bnc #542792
           # Repository name must be generated from product details
           Ops.set(
@@ -163,16 +166,8 @@ module Yast
             u,
             Builtins.sformat(
               _("Updates for %1 %2"),
-              Ops.get_locale(
-                p,
-                "display_name",
-                Ops.get_locale(
-                  p,
-                  "name",
-                  Ops.get_locale(p, "summary", _("Unknown Product"))
-                )
-              ),
-              Ops.get_string(p, "version", "")
+              (p.display_name || p.name || p.summary || _("Unknown Product")),
+              p.version
             )
           )
           # alias should be simple (bnc#768624)
@@ -182,11 +177,7 @@ module Yast
             String.Replace(
               Ops.add(
                 "update-",
-                Ops.get_string(
-                  p,
-                  "display_name",
-                  Ops.get_string(p, "name", "repo")
-                )
+                (p.display_name || p.name || "repo")
               ),
               " ",
               "-"

--- a/src/lib/installation/clients/inst_addon_update_sources.rb
+++ b/src/lib/installation/clients/inst_addon_update_sources.rb
@@ -158,26 +158,29 @@ module Yast
       products = Y2Packager::Resolvable.find(kind: :product)
 
       Builtins.foreach(products) do |p|
-        Builtins.foreach((p.update_urls || [])) do |u|
+        Builtins.foreach(p.update_urls) do |u|
           # bnc #542792
           # Repository name must be generated from product details
+          p_name =
+            [p.display_name, p.name, p.summary, _("Unknown Product")].reject(&:empty?).first
           Ops.set(
             urls,
             u,
             Builtins.sformat(
               _("Updates for %1 %2"),
-              (p.display_name || p.name || p.summary || _("Unknown Product")),
+              p_name,
               p.version
             )
           )
           # alias should be simple (bnc#768624)
+          p_alias = [p.display_name, p.name, "repo"].reject(&:empty?).first
           Ops.set(
             @aliases,
             u,
             String.Replace(
               Ops.add(
                 "update-",
-                (p.display_name || p.name || "repo")
+                p_alias
               ),
               " ",
               "-"

--- a/src/lib/installation/clients/inst_extrasources.rb
+++ b/src/lib/installation/clients/inst_extrasources.rb
@@ -408,7 +408,6 @@ module Yast
         "Checking whether repository %1 is an update repo...",
         repo
       )
-      ret = false
 
       # check if there is a patch available in the repository
       ret = Y2Packager::Resolvable.any?(kind: :patch, source: repo)

--- a/src/lib/installation/clients/inst_extrasources.rb
+++ b/src/lib/installation/clients/inst_extrasources.rb
@@ -453,11 +453,11 @@ module Yast
       # only package names (without version)
       names_only = true
       Pkg.GetPackages(:selected, names_only).each do |pkg|
-        Pkg.ResolvableProperties(pkg, :package, "").each do |p|
-          source = p["source"]
-          next unless p["status"] == :selected && repos.include?(source)
+        Y2Packager::Resolvable.find(kind: :package, name: pkg).each do |p|
+          source = p.source
+          next unless p.status == :selected && repos.include?(source)
 
-          package = "#{p["name"]}-#{p["version"]}.#{p["arch"]}"
+          package = "#{p.name}-#{p.version}.#{p.arch}"
           log.info("Found upgrade to install: #{package}")
           packages << package
           ret << source unless ret.include?(source)

--- a/src/lib/installation/clients/inst_extrasources.rb
+++ b/src/lib/installation/clients/inst_extrasources.rb
@@ -453,9 +453,11 @@ module Yast
       # only package names (without version)
       names_only = true
       Pkg.GetPackages(:selected, names_only).each do |pkg|
-        Y2Packager::Resolvable.find(kind: :package, name: pkg).each do |p|
+        Y2Packager::Resolvable.find(kind:   :package,
+                                    name:   pkg,
+                                    status: :selected).each do |p|
           source = p.source
-          next unless p.status == :selected && repos.include?(source)
+          next unless repos.include?(source)
 
           package = "#{p.name}-#{p.version}.#{p.arch}"
           log.info("Found upgrade to install: #{package}")

--- a/src/lib/installation/clients/inst_extrasources.rb
+++ b/src/lib/installation/clients/inst_extrasources.rb
@@ -20,6 +20,7 @@
 # ------------------------------------------------------------------------------
 
 require "y2packager/known_repositories"
+require "y2packager/resolvable"
 
 Yast.import "UI"
 Yast.import "Pkg"
@@ -410,16 +411,7 @@ module Yast
       ret = false
 
       # check if there is a patch available in the repository
-      Builtins.foreach(Pkg.ResolvableProperties("", :patch, "")) do |patch|
-        if Ops.get_integer(patch, "source", -1) == repo
-          Builtins.y2milestone(
-            "Found patch %1 in the repository",
-            Ops.get_string(patch, "name", "")
-          )
-          ret = true
-          raise Break
-        end
-      end
+      ret = Y2Packager::Resolvable.any?(kind: :patch, source: repo)
 
       Builtins.y2milestone("Repository %1 is update repo: %2", repo, ret)
 

--- a/src/lib/installation/clients/inst_modules_extensions.rb
+++ b/src/lib/installation/clients/inst_modules_extensions.rb
@@ -1,5 +1,6 @@
 require "yast"
 require "y2packager/product"
+require "y2packager/resolvable"
 
 Yast.import "GetInstArgs"
 Yast.import "Pkg"
@@ -32,7 +33,7 @@ module Installation
 
         extension_packages.select! do |list|
           pkg_name = list.first
-          dependencies[pkg_name] = Yast::Pkg.ResolvableDependencies(pkg_name, :package, "").first["deps"]
+          dependencies[pkg_name] = Y2Packager::Resolvable.find(kind: :package).first.deps
 
           product_provides = dependencies[pkg_name].find_all do |d|
             d["provides"] && d["provides"].match(/#{Regexp.escape(PROVIDES_PRODUCT)}/)

--- a/src/lib/installation/clients/inst_modules_extensions.rb
+++ b/src/lib/installation/clients/inst_modules_extensions.rb
@@ -34,10 +34,10 @@ module Installation
         extension_packages.select! do |list|
           pkg_name = list.first
           packages = Y2Packager::Resolvable.find(kind: :package, name: pkg_name)
-          if packages && packages.size > 0
-            dependencies[pkg_name] = packages.first.deps
+          dependencies[pkg_name] = if packages && !packages.empty?
+            packages.first.deps
           else
-            dependencies[pkg_name] = []
+            []
           end
 
           product_provides = dependencies[pkg_name].find_all do |d|
@@ -58,7 +58,7 @@ module Installation
           extension_provide = dependencies[pkg_name].find do |d|
             d["provides"] && d["provides"].match(/#{Regexp.escape(PROVIDES_KEY)}/)
           end
-          if extension_provide && extension_provide["provides"] && extension_provide["provides"].size > 0
+          if extension_provide && extension_provide["provides"] && !extension_provide["provides"].empty?
             module_name = extension_provide["provides"][/#{Regexp.escape(PROVIDES_KEY)}\s*=\s*(\S+)/, 1]
             log.info "extension for module #{module_name} in package #{pkg_name}"
           end

--- a/src/lib/installation/clients/inst_modules_extensions.rb
+++ b/src/lib/installation/clients/inst_modules_extensions.rb
@@ -33,7 +33,12 @@ module Installation
 
         extension_packages.select! do |list|
           pkg_name = list.first
-          dependencies[pkg_name] = Y2Packager::Resolvable.find(kind: :package).first.deps
+          packages = Y2Packager::Resolvable.find(kind: :package, name: pkg_name)
+          if packages && packages.size > 0
+            dependencies[pkg_name] = packages.first.deps
+          else
+            dependencies[pkg_name] = []
+          end
 
           product_provides = dependencies[pkg_name].find_all do |d|
             d["provides"] && d["provides"].match(/#{Regexp.escape(PROVIDES_PRODUCT)}/)
@@ -53,9 +58,10 @@ module Installation
           extension_provide = dependencies[pkg_name].find do |d|
             d["provides"] && d["provides"].match(/#{Regexp.escape(PROVIDES_KEY)}/)
           end
-
-          module_name = extension_provide["provides"][/#{Regexp.escape(PROVIDES_KEY)}\s*=\s*(\S+)/, 1]
-          log.info "extension for module #{module_name} in package #{pkg_name}"
+          if extension_provide && extension_provide["provides"] && extension_provide["provides"].size > 0
+            module_name = extension_provide["provides"][/#{Regexp.escape(PROVIDES_KEY)}\s*=\s*(\S+)/, 1]
+            log.info "extension for module #{module_name} in package #{pkg_name}"
+          end
 
           pkg_name
         end

--- a/src/lib/installation/clients/inst_modules_extensions.rb
+++ b/src/lib/installation/clients/inst_modules_extensions.rb
@@ -34,11 +34,7 @@ module Installation
         extension_packages.select! do |list|
           pkg_name = list.first
           packages = Y2Packager::Resolvable.find(kind: :package, name: pkg_name)
-          dependencies[pkg_name] = if packages && !packages.empty?
-            packages.first.deps
-          else
-            []
-          end
+          dependencies[pkg_name] = !packages.empty? ? packages.first.deps : []
 
           product_provides = dependencies[pkg_name].find_all do |d|
             d["provides"] && d["provides"].match(/#{Regexp.escape(PROVIDES_PRODUCT)}/)

--- a/src/lib/installation/clients/inst_modules_extensions.rb
+++ b/src/lib/installation/clients/inst_modules_extensions.rb
@@ -34,7 +34,7 @@ module Installation
         extension_packages.select! do |list|
           pkg_name = list.first
           packages = Y2Packager::Resolvable.find(kind: :package, name: pkg_name)
-          dependencies[pkg_name] = !packages.empty? ? packages.first.deps : []
+          dependencies[pkg_name] = packages.empty? ? [] : packages.first.deps
 
           product_provides = dependencies[pkg_name].find_all do |d|
             d["provides"] && d["provides"].match(/#{Regexp.escape(PROVIDES_PRODUCT)}/)

--- a/src/lib/installation/clients/inst_prepare_image.rb
+++ b/src/lib/installation/clients/inst_prepare_image.rb
@@ -52,7 +52,7 @@ module Yast
 
       @patterns_to_install = Builtins.maplist(@all_patterns) do |one_patern|
         if one_patern.status == :selected ||
-           one_patern.status == :installed
+            one_patern.status == :installed
           next one_patern.name
         else
           next ""

--- a/src/lib/installation/clients/inst_prepare_image.rb
+++ b/src/lib/installation/clients/inst_prepare_image.rb
@@ -26,6 +26,9 @@
 #		Lukas Ocilka <locilka@suse.cz>
 #
 # $Id$
+
+require "y2packager/resolvable"
+
 module Yast
   class InstPrepareImageClient < Client
     def main
@@ -45,12 +48,12 @@ module Yast
       # set repo to get images from
       ImageInstallation.SetRepo(Ops.get(Packages.theSources, 0, 0))
 
-      @all_patterns = Pkg.ResolvableProperties("", :pattern, "")
+      @all_patterns = Y2Packager::Resolvable.find(kind: :pattern)
 
       @patterns_to_install = Builtins.maplist(@all_patterns) do |one_patern|
-        if Ops.get_symbol(one_patern, "status", :unknown) == :selected ||
-            Ops.get_symbol(one_patern, "status", :unknown) == :installed
-          next Ops.get_string(one_patern, "name", "")
+        if (one_patern.status || :unknown) == :selected ||
+            one_patern.status || :unknown) == :installed
+          next one_patern.name
         else
           next ""
         end

--- a/src/lib/installation/clients/inst_prepare_image.rb
+++ b/src/lib/installation/clients/inst_prepare_image.rb
@@ -52,7 +52,7 @@ module Yast
 
       @patterns_to_install = Builtins.maplist(@all_patterns) do |one_patern|
         if (one_patern.status || :unknown) == :selected ||
-            one_patern.status || :unknown) == :installed
+           (one_patern.status || :unknown) == :installed
           next one_patern.name
         else
           next ""

--- a/src/lib/installation/clients/inst_prepare_image.rb
+++ b/src/lib/installation/clients/inst_prepare_image.rb
@@ -51,8 +51,8 @@ module Yast
       @all_patterns = Y2Packager::Resolvable.find(kind: :pattern)
 
       @patterns_to_install = Builtins.maplist(@all_patterns) do |one_patern|
-        if (one_patern.status || :unknown) == :selected ||
-            (one_patern.status || :unknown) == :installed
+        if one_patern.status == :selected ||
+           one_patern.status == :installed
           next one_patern.name
         else
           next ""

--- a/src/lib/installation/clients/inst_prepare_image.rb
+++ b/src/lib/installation/clients/inst_prepare_image.rb
@@ -52,7 +52,7 @@ module Yast
 
       @patterns_to_install = Builtins.maplist(@all_patterns) do |one_patern|
         if (one_patern.status || :unknown) == :selected ||
-           (one_patern.status || :unknown) == :installed
+            (one_patern.status || :unknown) == :installed
           next one_patern.name
         else
           next ""

--- a/src/lib/installation/update_repository.rb
+++ b/src/lib/installation/update_repository.rb
@@ -150,12 +150,12 @@ module Installation
     def packages
       return @packages unless @packages.nil?
       add_repo
-      @packages = Y2Packager::Resolvable.find(kind: :package, source: repo_id).sort_by! { |a| a.name }
-      log.info "Found #{@packages.size} packages: #{@packages.map{ |a| a.name }}"
+      @packages = Y2Packager::Resolvable.find(kind: :package, source: repo_id).sort_by!(&:name)
+      log.info "Found #{@packages.size} packages: #{@packages.map(&:name)}"
       # remove packages which are used as addons, these should not be applied to the inst-sys
       addon_pkgs = Y2Packager::SelfUpdateAddonFilter.packages(repo_id)
       @packages.reject! { |p| addon_pkgs.include?(p.name) }
-      log.info "Using #{@packages.size} packages: #{@packages.map{ |a| a.name }}"
+      log.info "Using #{@packages.size} packages: #{@packages.map(&:name)}"
       @packages
     end
 

--- a/src/lib/installation/update_repository.rb
+++ b/src/lib/installation/update_repository.rb
@@ -284,7 +284,7 @@ module Installation
 
     # Fetch and build a squashfs filesytem for a given package
     #
-    # @param package [Hash] Package to retrieve
+    # @param package [Y2Packager::Resolvable] Package to retrieve
     # @param dir     [Pathname] Path to store the squashed filesystems
     # @return [Pathname] Path where the file is stored
     #

--- a/src/lib/installation/update_repository.rb
+++ b/src/lib/installation/update_repository.rb
@@ -144,7 +144,7 @@ module Installation
     # which should be used in an add-on and not applied to the inst-sys are ignored.
     # The packages are sorted by name (alphabetical order).
     #
-    # @return [Array<Hash>] List of packages to install
+    # @return [Array<Y2Packager::Resolvable>] List of packages to install
     #
     # @see Y2Packager::Resolvable
     def packages

--- a/src/lib/installation/update_repository.rb
+++ b/src/lib/installation/update_repository.rb
@@ -150,7 +150,7 @@ module Installation
     def packages
       return @packages unless @packages.nil?
       add_repo
-      @packages = Y2Packager::Resolvable.find(kind: :package, :source repo_id).sort_by! { |a| a.name }
+      @packages = Y2Packager::Resolvable.find(kind: :package, source: repo_id).sort_by! { |a| a.name }
       log.info "Found #{@packages.size} packages: #{@packages.map{ |a| a.name }}"
       # remove packages which are used as addons, these should not be applied to the inst-sys
       addon_pkgs = Y2Packager::SelfUpdateAddonFilter.packages(repo_id)

--- a/src/modules/ImageInstallation.rb
+++ b/src/modules/ImageInstallation.rb
@@ -1227,23 +1227,23 @@ module Yast
         resolvable_properties = Y2Packager::Resolvable.find(kind: one_type)
         Ops.set(@objects_state, one_type, {})
         remove_resolvables = Builtins.filter(resolvable_properties) do |one_object|
-          (one_object.status || :unknown) == :removed
+          one_object.status == :removed
         end
         Ops.set(@objects_state, [one_type, "remove"], remove_resolvables)
         @generic_set_progress.call(id, nil) if !@generic_set_progress.nil?
         install_resolvables = Builtins.filter(resolvable_properties) do |one_object|
-          (one_object.status || :unknown) == :selected
+          one_object.status == :selected
         end
         Ops.set(@objects_state, [one_type, "install"], install_resolvables)
         @generic_set_progress.call(id, nil) if !@generic_set_progress.nil?
         taboo_resolvables = Builtins.filter(resolvable_properties) do |one_object|
-          (one_object.status || :unknown) == :available &&
+          one_object.status == :available &&
             one_object.locked == true
         end
         Ops.set(@objects_state, [one_type, "taboo"], taboo_resolvables)
         @generic_set_progress.call(id, nil) if !@generic_set_progress.nil?
         lock_resolvables = Builtins.filter(resolvable_properties) do |one_object|
-          (one_object.status || :unknown) == :installed &&
+          one_object.status == :installed &&
             one_object.locked == true
         end
         Ops.set(@objects_state, [one_type, "lock"], lock_resolvables)
@@ -1289,7 +1289,7 @@ module Yast
 
       # Leave only already installed (and matching the same architecture)
       resolvable_properties = Builtins.filter(resolvable_properties) do |one_resolvable|
-        (one_resolvable.status || :unknown) == :installed &&
+        one_resolvable.status == :installed &&
           one_resolvable.arch == arch
       end
 
@@ -1376,8 +1376,8 @@ module Yast
         one_already_installed_resolvable = {}
         Builtins.foreach(resolvable_properties) do |one_resolvable|
           # We are interested in the already installed resolvables only
-          if (one_resolvable.status || :unknown) != :installed &&
-              (one_resolvable.status || :unknown) != :selected
+          if one_resolvable.status != :installed &&
+             one_resolvable.status != :selected
             next
           end
           one_already_installed_resolvable = {

--- a/src/modules/ImageInstallation.rb
+++ b/src/modules/ImageInstallation.rb
@@ -1377,7 +1377,7 @@ module Yast
         Builtins.foreach(resolvable_properties) do |one_resolvable|
           # We are interested in the already installed resolvables only
           if one_resolvable.status != :installed &&
-             one_resolvable.status != :selected
+              one_resolvable.status != :selected
             next
           end
           one_already_installed_resolvable = {

--- a/src/modules/ImageInstallation.rb
+++ b/src/modules/ImageInstallation.rb
@@ -1238,13 +1238,13 @@ module Yast
         @generic_set_progress.call(id, nil) if !@generic_set_progress.nil?
         taboo_resolvables = Builtins.filter(resolvable_properties) do |one_object|
           (one_object.status || :unknown) == :available &&
-          one_object.locked == true
+            one_object.locked == true
         end
         Ops.set(@objects_state, [one_type, "taboo"], taboo_resolvables)
         @generic_set_progress.call(id, nil) if !@generic_set_progress.nil?
         lock_resolvables = Builtins.filter(resolvable_properties) do |one_object|
           (one_object.status || :unknown) == :installed &&
-          one_object.locked == true
+            one_object.locked == true
         end
         Ops.set(@objects_state, [one_type, "lock"], lock_resolvables)
         @generic_set_progress.call(id, nil) if !@generic_set_progress.nil?
@@ -1274,8 +1274,8 @@ module Yast
       arch = Ops.get_string(one_object.value, "arch", "")
       # Query for all packages of the same version
       resolvable_properties = Y2Packager::Resolvable.find(
-        kind: one_type.value,
-        name: one_object.value.name,
+        kind:    one_type.value,
+        name:    one_object.value.name,
         version: one_object.value.version
       )
 
@@ -1283,18 +1283,18 @@ module Yast
         Builtins.y2milestone(
           "Looking for %1 returned %2",
           one_object.value,
-          resolvable_properties.map { |r| r.name }
+          resolvable_properties.map(&:name)
         )
       end
 
       # Leave only already installed (and matching the same architecture)
       resolvable_properties = Builtins.filter(resolvable_properties) do |one_resolvable|
         (one_resolvable.status || :unknown) == :installed &&
-        one_resolvable.arch == arch
+          one_resolvable.arch == arch
       end
 
       if ThisIsADebugMode()
-        Builtins.y2milestone("Resolvables installed: %1", resolvable_properties.map { |r| r.name })
+        Builtins.y2milestone("Resolvables installed: %1", resolvable_properties.map(&:name))
       end
 
       ret = nil
@@ -1358,10 +1358,8 @@ module Yast
         @generic_set_progress.call(id, nil) if !@generic_set_progress.nil?
         # List of all packages selected for installation (just names)
         selected_for_installation_pkgnames = Builtins.maplist(
-          Ops.get(@objects_state, [one_type, "install"], [])
-        ) do |one_resolvable|
-          one_resolvable.name
-        end
+          Ops.get(@objects_state, [one_type, "install"], []), &:name
+        )
         # All packages selected to be installed
         # [ $[ "arch" : ... , "name" : ... , "version" : ... ], ... ]
         selected_for_installation = Builtins.maplist(

--- a/test/lib/clients/inst_extrasources_test.rb
+++ b/test/lib/clients/inst_extrasources_test.rb
@@ -9,7 +9,7 @@ describe Yast::InstExtrasourcesClient do
       source = 42
       expect(Yast::Pkg).to receive(:GetPackages).and_return(["foo"])
       expect(Y2Packager::Resolvable).to receive(:find)
-        .with(kind: :package, name: "foo", :status=>:selected)
+        .with(kind: :package, name: "foo", status: :selected)
         .and_return([Y2Packager::Resolvable.new(
           "kind" => :package, "name" => "foo", "version" => "1.0", "arch" => "x86_64",
           "status" => :selected, "source" => source

--- a/test/lib/clients/inst_extrasources_test.rb
+++ b/test/lib/clients/inst_extrasources_test.rb
@@ -12,7 +12,8 @@ describe Yast::InstExtrasourcesClient do
         .with(kind: :package, name: "foo")
         .and_return([Y2Packager::Resolvable.new(
           "kind" => :package, "name" => "foo", "version" => "1.0", "arch" => "x86_64",
-          "status" => :selected, "source" => source)])
+          "status" => :selected, "source" => source
+        )])
       expect(subject.UpgradesAvailable([source])).to eq("packages"     => ["foo-1.0.x86_64"],
                                                         "repositories" => [source])
     end

--- a/test/lib/clients/inst_extrasources_test.rb
+++ b/test/lib/clients/inst_extrasources_test.rb
@@ -8,9 +8,11 @@ describe Yast::InstExtrasourcesClient do
     it "returns available package updates" do
       source = 42
       expect(Yast::Pkg).to receive(:GetPackages).and_return(["foo"])
-      expect(Yast::Pkg).to receive(:ResolvableProperties).with("foo", :package, "")
-        .and_return(["name" => "foo", "version" => "1.0", "arch" => "x86_64",
-          "status" => :selected, "source" => source])
+      expect(Y2Packager::Resolvable).to receive(:find)
+        .with(kind: :package, name: "foo")
+        .and_return([Y2Packager::Resolvable.new(
+          "kind" => :package, "name" => "foo", "version" => "1.0", "arch" => "x86_64",
+          "status" => :selected, "source" => source)])
       expect(subject.UpgradesAvailable([source])).to eq("packages"     => ["foo-1.0.x86_64"],
                                                         "repositories" => [source])
     end

--- a/test/lib/clients/inst_extrasources_test.rb
+++ b/test/lib/clients/inst_extrasources_test.rb
@@ -9,7 +9,7 @@ describe Yast::InstExtrasourcesClient do
       source = 42
       expect(Yast::Pkg).to receive(:GetPackages).and_return(["foo"])
       expect(Y2Packager::Resolvable).to receive(:find)
-        .with(kind: :package, name: "foo")
+        .with(kind: :package, name: "foo", :status=>:selected)
         .and_return([Y2Packager::Resolvable.new(
           "kind" => :package, "name" => "foo", "version" => "1.0", "arch" => "x86_64",
           "status" => :selected, "source" => source

--- a/test/lib/inst_modules_extensions_test.rb
+++ b/test/lib/inst_modules_extensions_test.rb
@@ -5,18 +5,18 @@ require "installation/clients/inst_modules_extensions"
 
 describe ::Installation::Clients::InstModulesExtensions do
   describe "#run" do
-    let(:deps_package_a) { [{ "deps" => [{ "provides" => "installer_module_extension() = module_a" }] }] }
-    let(:deps_package_b) { [{ "deps" => [{ "provides" => "installer_module_extension() = module_b" }] }] }
+    let(:deps_package_a) {{ "deps" => [{ "provides" => "installer_module_extension() = module_a" }] }}
+    let(:deps_package_b) {{ "deps" => [{ "provides" => "installer_module_extension() = module_b" }] }}
     let(:product) { Y2Packager::Product.new(name: "SLES") }
 
     before do
       allow(Yast::Pkg).to receive(:PkgQueryProvides).and_return([["package_a"], ["package_b"]])
 
-      allow(Yast::Pkg).to receive(:ResolvableDependencies).with("package_a", :package, "")
-        .and_return(deps_package_a)
+      allow(Y2Packager::Resolvable).to receive(:find).with(kind: :package, name: "package_a")
+        .and_return([Y2Packager::Resolvable.new(deps_package_a)])
 
-      allow(Yast::Pkg).to receive(:ResolvableDependencies).with("package_b", :package, "")
-        .and_return(deps_package_b)
+      allow(Y2Packager::Resolvable).to receive(:find).with(kind: :package, name: "package_b")
+        .and_return([Y2Packager::Resolvable.new(deps_package_b)])
 
       allow(Yast::WorkflowManager).to receive(:merge_modules_extensions)
 
@@ -43,12 +43,12 @@ describe ::Installation::Clients::InstModulesExtensions do
 
     context "when all roles are specified for a different product" do
       let(:deps_package_a) do
-        [{ "deps" => [{ "provides" => "installer_module_extension() = module_b" },
-                      { "provides" => "extension_for_product() = SLED" }] }]
+        { "deps" => [{ "provides" => "installer_module_extension() = module_b" },
+                      { "provides" => "extension_for_product() = SLED" }] }
       end
       let(:deps_package_b) do
-        [{ "deps" => [{ "provides" => "installer_module_extension() = module_a" },
-                      { "provides" => "extension_for_product() = SLED" }] }]
+        { "deps" => [{ "provides" => "installer_module_extension() = module_a" },
+                      { "provides" => "extension_for_product() = SLED" }] }
       end
 
       it "does not merge installation workflow for the module extension packages" do
@@ -60,8 +60,8 @@ describe ::Installation::Clients::InstModulesExtensions do
 
     context "when only one role is specified for a different product" do
       let(:deps_package_a) do
-        [{ "deps" => [{ "provides" => "installer_module_extension() = module_b" },
-                      { "provides" => "extension_for_product() = SLED" }] }]
+        { "deps" => [{ "provides" => "installer_module_extension() = module_b" },
+                      { "provides" => "extension_for_product() = SLED" }] }
       end
 
       it "merges installation workflow for the other module extension packages" do
@@ -73,12 +73,12 @@ describe ::Installation::Clients::InstModulesExtensions do
 
     context "when all roles are specified only for the current product" do
       let(:deps_package_a) do
-        [{ "deps" => [{ "provides" => "installer_module_extension() = module_b" },
-                      { "provides" => "extension_for_product() = SLES" }] }]
+        { "deps" => [{ "provides" => "installer_module_extension() = module_b" },
+                      { "provides" => "extension_for_product() = SLES" }] }
       end
       let(:deps_package_b) do
-        [{ "deps" => [{ "provides" => "installer_module_extension() = module_a" },
-                      { "provides" => "extension_for_product() = SLES" }] }]
+        { "deps" => [{ "provides" => "installer_module_extension() = module_a" },
+                      { "provides" => "extension_for_product() = SLES" }] }
       end
 
       it "merges installation workflow for all module extension packages" do
@@ -90,14 +90,14 @@ describe ::Installation::Clients::InstModulesExtensions do
 
     context "when all roles are specified for multiple products, including the current one" do
       let(:deps_package_a) do
-        [{ "deps" => [{ "provides" => "installer_module_extension() = module_b" },
+        { "deps" => [{ "provides" => "installer_module_extension() = module_b" },
                       { "provides" => "extension_for_product() = SLES" },
-                      { "provides" => "extension_for_product() = SLED" }] }]
+                      { "provides" => "extension_for_product() = SLED" }] }
       end
       let(:deps_package_b) do
-        [{ "deps" => [{ "provides" => "installer_module_extension() = module_a" },
+        { "deps" => [{ "provides" => "installer_module_extension() = module_a" },
                       { "provides" => "extension_for_product() = SLED" },
-                      { "provides" => "extension_for_product() = SLES" }] }]
+                      { "provides" => "extension_for_product() = SLES" }] }
       end
 
       it "merges installation workflow for all module extension packages" do

--- a/test/lib/inst_modules_extensions_test.rb
+++ b/test/lib/inst_modules_extensions_test.rb
@@ -5,8 +5,8 @@ require "installation/clients/inst_modules_extensions"
 
 describe ::Installation::Clients::InstModulesExtensions do
   describe "#run" do
-    let(:deps_package_a) {{ "deps" => [{ "provides" => "installer_module_extension() = module_a" }] }}
-    let(:deps_package_b) {{ "deps" => [{ "provides" => "installer_module_extension() = module_b" }] }}
+    let(:deps_package_a) { { "deps" => [{ "provides" => "installer_module_extension() = module_a" }] } }
+    let(:deps_package_b) { { "deps" => [{ "provides" => "installer_module_extension() = module_b" }] } }
     let(:product) { Y2Packager::Product.new(name: "SLES") }
 
     before do
@@ -44,11 +44,11 @@ describe ::Installation::Clients::InstModulesExtensions do
     context "when all roles are specified for a different product" do
       let(:deps_package_a) do
         { "deps" => [{ "provides" => "installer_module_extension() = module_b" },
-                      { "provides" => "extension_for_product() = SLED" }] }
+                     { "provides" => "extension_for_product() = SLED" }] }
       end
       let(:deps_package_b) do
         { "deps" => [{ "provides" => "installer_module_extension() = module_a" },
-                      { "provides" => "extension_for_product() = SLED" }] }
+                     { "provides" => "extension_for_product() = SLED" }] }
       end
 
       it "does not merge installation workflow for the module extension packages" do
@@ -61,7 +61,7 @@ describe ::Installation::Clients::InstModulesExtensions do
     context "when only one role is specified for a different product" do
       let(:deps_package_a) do
         { "deps" => [{ "provides" => "installer_module_extension() = module_b" },
-                      { "provides" => "extension_for_product() = SLED" }] }
+                     { "provides" => "extension_for_product() = SLED" }] }
       end
 
       it "merges installation workflow for the other module extension packages" do
@@ -74,11 +74,11 @@ describe ::Installation::Clients::InstModulesExtensions do
     context "when all roles are specified only for the current product" do
       let(:deps_package_a) do
         { "deps" => [{ "provides" => "installer_module_extension() = module_b" },
-                      { "provides" => "extension_for_product() = SLES" }] }
+                     { "provides" => "extension_for_product() = SLES" }] }
       end
       let(:deps_package_b) do
         { "deps" => [{ "provides" => "installer_module_extension() = module_a" },
-                      { "provides" => "extension_for_product() = SLES" }] }
+                     { "provides" => "extension_for_product() = SLES" }] }
       end
 
       it "merges installation workflow for all module extension packages" do
@@ -91,13 +91,13 @@ describe ::Installation::Clients::InstModulesExtensions do
     context "when all roles are specified for multiple products, including the current one" do
       let(:deps_package_a) do
         { "deps" => [{ "provides" => "installer_module_extension() = module_b" },
-                      { "provides" => "extension_for_product() = SLES" },
-                      { "provides" => "extension_for_product() = SLED" }] }
+                     { "provides" => "extension_for_product() = SLES" },
+                     { "provides" => "extension_for_product() = SLED" }] }
       end
       let(:deps_package_b) do
         { "deps" => [{ "provides" => "installer_module_extension() = module_a" },
-                      { "provides" => "extension_for_product() = SLED" },
-                      { "provides" => "extension_for_product() = SLES" }] }
+                     { "provides" => "extension_for_product() = SLED" },
+                     { "provides" => "extension_for_product() = SLES" }] }
       end
 
       it "merges installation workflow for all module extension packages" do

--- a/test/update_repository_test.rb
+++ b/test/update_repository_test.rb
@@ -37,13 +37,19 @@ describe Installation::UpdateRepository do
       Y2Packager::Resolvable.new("name" => "pkg1", "path" => "./x86_64/pkg1-3.1.x86_64.rpm", "source" => repo_id)
     end
 
+    let(:other_package) do
+      Y2Packager::Resolvable.new("name" => "pkg0", "path" => "./x86_64/pkg0-3.1.x86_64.rpm", "source" => repo_id)
+    end
+
     let(:from_other_repo) do
       Y2Packager::Resolvable.new("name" => "pkg2", "path" => "./x86_64/pkg2-3.1.x86_64.rpm", "source" => repo_id + 1)
     end
 
     before do
-      allow(Yast::Pkg).to receive(:ResolvableProperties).with("", :package, "")
-        .and_return(packages)
+      allow(Y2Packager::Resolvable).to receive(:find).with(kind: :package, source: repo_id)
+        .and_return([other_package, package])
+      allow(Y2Packager::Resolvable).to receive(:find).with(kind: :package, source: repo_id + 1)
+        .and_return([from_other_repo])
     end
 
     context "when the repository type can't be determined" do
@@ -76,22 +82,16 @@ describe Installation::UpdateRepository do
     end
 
     context "when the repo does not have packages" do
-      let(:packages) { [from_other_repo] }
-
       it "returns an empty array" do
+        expect(Y2Packager::Resolvable).to receive(:find).with(kind: :package, source: repo_id)
+          .and_return([])
         expect(repo.packages).to eq([])
       end
     end
 
     context "when the source contains packages" do
-      let(:other_package) do
-        Y2Packager::Resolvable.new("name" => "pkg0", "path" => "./x86_64/pkg0-3.1.x86_64.rpm", "source" => repo_id)
-      end
-
-      let(:packages) { [package, from_other_repo, other_package] }
-
       it "returns update repository packages sorted by name" do
-        expect(repo.packages).to eq([other_package, package])
+        expect(repo.packages.map(&:name)).to eq([other_package.name, package.name])
       end
     end
   end
@@ -104,7 +104,7 @@ describe Installation::UpdateRepository do
     end
 
     let(:package) do
-      { "name" => "pkg1", "path" => "./x86_64/pkg1-3.1.x86_64.rpm", "source" => repo_id }
+      Y2Packager::Resolvable.new("name" => "pkg1", "path" => "./x86_64/pkg1-3.1.x86_64.rpm", "source" => repo_id)
     end
 
     let(:libzypp_package_path) { "/var/adm/tmp/pkg1-3.1.x86_64.rpm" }
@@ -117,7 +117,7 @@ describe Installation::UpdateRepository do
       allow(repo).to receive(:add_repo).and_return(repo_id)
       allow(repo).to receive(:packages).and_return([package])
       allow(Dir).to receive(:mktmpdir).and_yield(tmpdir.to_s)
-      allow(Packages::PackageDownloader).to receive(:new).with(repo_id, package["name"]).and_return(downloader)
+      allow(Packages::PackageDownloader).to receive(:new).with(repo_id, package.name).and_return(downloader)
       allow(Packages::PackageExtractor).to receive(:new).with(tempfile.path.to_s).and_return(extractor)
       allow(Tempfile).to receive(:new).and_return(tempfile)
     end

--- a/test/update_repository_test.rb
+++ b/test/update_repository_test.rb
@@ -34,11 +34,11 @@ describe Installation::UpdateRepository do
     after { FileUtils.rm_rf(TEMP_DIR) }
 
     let(:package) do
-      Y2Packager::Resolvable.new({ "name" => "pkg1", "path" => "./x86_64/pkg1-3.1.x86_64.rpm", "source" => repo_id })
+      Y2Packager::Resolvable.new("name" => "pkg1", "path" => "./x86_64/pkg1-3.1.x86_64.rpm", "source" => repo_id)
     end
 
     let(:from_other_repo) do
-      Y2Packager::Resolvable.new({ "name" => "pkg2", "path" => "./x86_64/pkg2-3.1.x86_64.rpm", "source" => repo_id + 1 })
+      Y2Packager::Resolvable.new("name" => "pkg2", "path" => "./x86_64/pkg2-3.1.x86_64.rpm", "source" => repo_id + 1)
     end
 
     before do
@@ -85,7 +85,7 @@ describe Installation::UpdateRepository do
 
     context "when the source contains packages" do
       let(:other_package) do
-        Y2Packager::Resolvable.new({ "name" => "pkg0", "path" => "./x86_64/pkg0-3.1.x86_64.rpm", "source" => repo_id })
+        Y2Packager::Resolvable.new("name" => "pkg0", "path" => "./x86_64/pkg0-3.1.x86_64.rpm", "source" => repo_id)
       end
 
       let(:packages) { [package, from_other_repo, other_package] }

--- a/test/update_repository_test.rb
+++ b/test/update_repository_test.rb
@@ -34,11 +34,11 @@ describe Installation::UpdateRepository do
     after { FileUtils.rm_rf(TEMP_DIR) }
 
     let(:package) do
-      { "name" => "pkg1", "path" => "./x86_64/pkg1-3.1.x86_64.rpm", "source" => repo_id }
+      Y2Packager::Resolvable.new({ "name" => "pkg1", "path" => "./x86_64/pkg1-3.1.x86_64.rpm", "source" => repo_id })
     end
 
     let(:from_other_repo) do
-      { "name" => "pkg2", "path" => "./x86_64/pkg2-3.1.x86_64.rpm", "source" => repo_id + 1 }
+      Y2Packager::Resolvable.new({ "name" => "pkg2", "path" => "./x86_64/pkg2-3.1.x86_64.rpm", "source" => repo_id + 1 })
     end
 
     before do
@@ -85,7 +85,7 @@ describe Installation::UpdateRepository do
 
     context "when the source contains packages" do
       let(:other_package) do
-        { "name" => "pkg0", "path" => "./x86_64/pkg0-3.1.x86_64.rpm", "source" => repo_id }
+        Y2Packager::Resolvable.new({ "name" => "pkg0", "path" => "./x86_64/pkg0-3.1.x86_64.rpm", "source" => repo_id })
       end
 
       let(:packages) { [package, from_other_repo, other_package] }


### PR DESCRIPTION
Replacing old Pkg.ResolvableProperties()and Pkg.ResolvabeDependencies() calls by Y2Packager::Resolvable.any? and Y2Packager::Resolvable.find in order to save memory.