### PR TITLE
Save and restore properly the proposal vertical scroll

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Nov 14 09:56:21 UTC 2019 - David Diaz <dgonzalez@suse.com>
+
+- Save and restore the proposal vertical scroll (related to a
+  problem reseting the scroll position reported in bsc#1143558)
+- 4.2.22
+
+-------------------------------------------------------------------
 Sun Nov 10 18:56:53 UTC 2019 - David Diaz <dgonzalez@suse.com>
 
 - Improve the role selection dialog using a new scrollable widget

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.2.21
+Version:        4.2.22
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/src/lib/installation/proposal_runner.rb
+++ b/src/lib/installation/proposal_runner.rb
@@ -199,16 +199,19 @@ module Installation
     def input_loop
       loop do
         richtext_normal_cursor(Id(:proposal))
+
         # bnc #431567
         # Some proposal module can change it while called
         assign_next_button
 
+        restore_vertical_scroll
         input = Yast::UI.UserInput
 
+        log.info "Proposal - UserInput: '#{input}'"
         return :next if input == :accept
         return :abort if input == :cancel
 
-        log.info "Proposal - UserInput: '#{input}'"
+        save_vertical_scroll
         richtext_busy_cursor(Id(:proposal))
 
         case input
@@ -259,6 +262,14 @@ module Installation
       end # while input loop
 
       nil
+    end
+
+    def save_vertical_scroll
+      @proposal_vscroll = Yast::UI.QueryWidget(Id(:proposal), :VScrollValue)
+    end
+
+    def restore_vertical_scroll
+      Yast::UI.ChangeWidget(Id(:proposal), :VScrollValue, @proposal_vscroll)
     end
 
     def switch_to_tab(input)


### PR DESCRIPTION
## The problem

The proposal installation summary back to the top after performing any change, not preserving the scroll.

* Related to the behavior described at https://bugzilla.suse.com/show_bug.cgi?id=1143558
* https://trello.com/c/ZocPUtvz/1330-3-use-save-restore-scrolling-in-installation-proposal

## Why?

The proposal summary, which is being held by a `RichText` widget, is re-drawn after making a change. So, it's actually new content.

## The solution

To use [the new `:VScrollValue` property](https://github.com/libyui/libyui/pull/149) added to the  [libyui](https://github.com/libyui/libyui) RichText widget as part of the [YaST UI improvements](https://gist.github.com/shundhammer/1bc79af7d1a31892bd977678bc2af2c1). Taking into account that the content could be longer or shorter after each change, the solution is not completely perfect but it's perfect enough for most of the time.

## Test

Tested manually via driver update in both, Qt and ncurse.

## Screencasts


<details>
<summary>Before (toggle)</summary>

<hr/>

![vscroll_not_restored](https://user-images.githubusercontent.com/1691872/68775460-6dddd580-0626-11ea-9768-e96d9c4d9a26.gif)

</details>

<details>
<summary>After (toggle)</summary>

<hr/>

![vscroll_restored](https://user-images.githubusercontent.com/1691872/68775549-95cd3900-0626-11ea-8a5e-39cbf6d7ac3d.gif)


</details>
