### PR TITLE
Improve the role selection dialog

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Sun Nov 10 18:56:53 UTC 2019 - David Diaz <dgonzalez@suse.com>
+
+- Improve the role selection dialog using a new scrollable widget
+  to select a role (related to bsc#1084674, bsc#bsc#1086187).
+- 4.2.21
+-------------------------------------------------------------------
+
 Thu Nov  7 09:32:00 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
 
 - Implement upgrade for the Full medium (jsc#SLE-7101)

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -94,6 +94,8 @@ Requires:       iproute2
 %endif
 
 
+# SingleItemSelector not enforcing an initial selection
+Conflicts:      libyui < 3.8.2
 # Pkg::SourceProvideSignedFile Pkg::SourceProvideDigestedFile
 # pkg-bindings are not directly required
 Conflicts:      yast2-pkg-bindings < 2.17.25

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.2.20
+Version:        4.2.21
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/src/lib/installation/select_system_role.rb
+++ b/src/lib/installation/select_system_role.rb
@@ -37,6 +37,12 @@ module Installation
       "services"
     ].freeze
 
+    MAX_LINE_LENGTH = 110
+    private_constant :MAX_LINE_LENGTH
+
+    TEXT_MODE_MAX_LINE_LENGTH = 70
+    private_constant :TEXT_MODE_MAX_LINE_LENGTH
+
     def initialize
       super
 
@@ -122,11 +128,20 @@ module Installation
         Item(
           Id(role.id),
           role.label,
-          # Keep the description's line lenght short enough to avoid horizontal scroll in 80x24
-          role.description.strip.scan(/.{1,70}\W/).join("\n"),
+          adjust_text(role.description),
           role.id == preselected_role_id
         )
       end
+    end
+
+    # Split the given text into several lines if it exceeds the max length set
+    #
+    # @param text [String]
+    # @return [String]
+    def adjust_text(text)
+      max_line_length = Yast::UI.TextMode ? TEXT_MODE_MAX_LINE_LENGTH : MAX_LINE_LENGTH
+
+      text.strip.scan(/(.{1,#{max_line_length}})(?:\s|$)/).join("\n")
     end
 
     # Return the current selected role id

--- a/src/lib/installation/select_system_role.rb
+++ b/src/lib/installation/select_system_role.rb
@@ -31,12 +31,6 @@ Yast.import "ProductFeatures"
 
 module Installation
   class SelectSystemRole < ::UI::InstallationDialog
-    NON_OVERLAY_ATTRIBUTES = [
-      "additional_dialogs",
-      "id",
-      "services"
-    ].freeze
-
     MAX_LINE_LENGTH = 110
     private_constant :MAX_LINE_LENGTH
 

--- a/src/lib/installation/select_system_role.rb
+++ b/src/lib/installation/select_system_role.rb
@@ -19,6 +19,7 @@
 
 require "yast"
 require "ui/installation_dialog"
+require "ui/text_helpers"
 require "installation/services"
 require "installation/system_role"
 
@@ -31,6 +32,8 @@ Yast.import "ProductFeatures"
 
 module Installation
   class SelectSystemRole < ::UI::InstallationDialog
+    include UI::TextHelpers
+
     MAX_LINE_LENGTH = 110
     private_constant :MAX_LINE_LENGTH
 
@@ -118,24 +121,16 @@ module Installation
     # @param preselected_role_id [String, nil] the id of the role that should be selected
     # @return [Array<Item>] collection of role items
     def roles_items(preselected_role_id)
+      max_line_length = Yast::UI.TextMode ? TEXT_MODE_MAX_LINE_LENGTH : MAX_LINE_LENGTH
+
       roles.map do |role|
         Item(
           Id(role.id),
           role.label,
-          adjust_text(role.description),
+          wrap_text(role.description, max_line_length),
           role.id == preselected_role_id
         )
       end
-    end
-
-    # Split the given text into several lines if it exceeds the max length set
-    #
-    # @param text [String]
-    # @return [String]
-    def adjust_text(text)
-      max_line_length = Yast::UI.TextMode ? TEXT_MODE_MAX_LINE_LENGTH : MAX_LINE_LENGTH
-
-      text.strip.scan(/(.{1,#{max_line_length}})(?:\s|$)/).join("\n")
     end
 
     # Return the current selected role id


### PR DESCRIPTION
## Context

Some time ago, the list of available roles grown enough to start not fitting in the role selection dialog. To fix it, the list was embedded in a scrollable `RichText` widget since [libyui](https://github.com/libyui/libyui) didn't offer a better option (see https://github.com/yast/yast-installation/pull/671, [bsc#1084674](https://bugzilla.suse.com/show_bug.cgi?id=1084674), [bsc#1086187](https://bugzilla.suse.com/show_bug.cgi?id=1086187)).

## Current status

As part of a [YaST UI improvements](https://gist.github.com/shundhammer/1bc79af7d1a31892bd977678bc2af2c1) a new `SingleItemSelector` (see https://github.com/libyui/libyui/pull/148) has been added, which is a much better solution to display the roles list.

## Changes

To update the role selection dialog using the new widget and removing the old code.

## Tests

* Unit tests updated/adapted
* Also tested manually via driver update.

## Screenshots

<details>
<summary>Toggle</summary>

<hr />

<p align="center">Before</p>

| ncurses | Qt |
|---------|----|
| ![Current role selection dialog ncurse](https://user-images.githubusercontent.com/1691872/68574444-c7e16e00-0461-11ea-9754-80912e8d3e81.png) | ![Current role selection dialog](https://user-images.githubusercontent.com/1691872/68570885-8c42a600-0459-11ea-8fea-8bba3522ad20.png) |

| ncurses 80x25 | ncurses 80x25 scrolling |
|---------|----|
| ![ncurses 80x25](https://user-images.githubusercontent.com/1691872/68579106-4d1d5080-046b-11ea-9bfc-df05b169d566.png) | ![ncurses 80x25 scrolling](https://user-images.githubusercontent.com/1691872/68579145-5c040300-046b-11ea-8c2d-2a8bba0c1657.png) |


<hr />

<p align="center">After</p>


| ncurses | Qt |
|---------|----|
| ![Selection role dialog using the new widget ncurses](https://user-images.githubusercontent.com/1691872/68574494-ea738700-0461-11ea-973c-80d92f9ffcd9.png)| ![Selection role dialog using the new widget](https://user-images.githubusercontent.com/1691872/68766158-3ff09500-0616-11ea-8d0c-15543d60f39b.png) |

| ncurses 80x25 | ncurses 80x25 scrolling |
|---------|----|
| ![ncurses 80x25](https://user-images.githubusercontent.com/1691872/68766184-51d23800-0616-11ea-977e-01d8726b578d.png) | ![ncurses 80x25 scrolling](https://user-images.githubusercontent.com/1691872/68766211-5f87bd80-0616-11ea-9d20-7dea8fdeb9e0.png)|

| Qt 1920x1080 | Qt 2560x1600 |
|---------|----|
| ![Qt 1920x1080](https://user-images.githubusercontent.com/1691872/68841906-5e5d9b80-06bd-11ea-9e3e-660d50ac2739.png) | ![Qt 2560x1600](https://user-images.githubusercontent.com/1691872/68841938-6a495d80-06bd-11ea-803e-daeea09584a3.png) |


