### PR TITLE
Do not remove /etc/install.inf from inst-sys (bsc#1157476)

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Nov 21 14:32:50 UTC 2019 - Knut Anderssen <kanderssen@suse.com>
+
+- Do not remove /etc/install.inf from inst-sys (bsc#1122493,
+  bsc#1157476).
+- 4.2.24
+
+-------------------------------------------------------------------
 Fri Nov 15 08:58:40 UTC 2019 - Oliver Kurz <okurz@suse.com>
 
 - Use linuxrc option "reboot_timeout" to configure the timeout

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.2.23
+Version:        4.2.24
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/src/include/installation/misc.rb
+++ b/src/include/installation/misc.rb
@@ -296,6 +296,8 @@ module Yast
           scst_required == false ? "0" : "1"
         )
       )
+      # Is it really needed? It will enforce a read of /etc/install.inf from
+      # any step after resetting it.
       Linuxrc.ResetInstallInf
 
       nil

--- a/src/lib/installation/clients/copy_files_finish.rb
+++ b/src/lib/installation/clients/copy_files_finish.rb
@@ -293,12 +293,7 @@ module Yast
     def handle_second_stage
       # Copy /etc/install.inf into built system so that the
       # second phase of the installation can find it.
-      if InstFunctions.second_stage_required?
-        Linuxrc.SaveInstallInf(Installation.destdir)
-      else
-        # TODO: write why it is needed
-        ::FileUtils.rm "/etc/install.inf"
-      end
+      Linuxrc.SaveInstallInf(Installation.destdir) if InstFunctions.second_stage_required?
     end
 
     def copy_control_file

--- a/test/copy_files_finish_test.rb
+++ b/test/copy_files_finish_test.rb
@@ -148,14 +148,6 @@ describe Yast::CopyFilesFinishClient do
       subject.write
     end
 
-    it "deletes install.inf if second stage is not required" do
-      allow(Yast::InstFunctions).to receive(:second_stage_required?).and_return(false)
-
-      expect(::FileUtils).to receive(:rm).with("/etc/install.inf")
-
-      subject.write
-    end
-
     it "copies control.xml" do
       allow(::FileUtils).to receive(:cp)
       allow(Yast::ProductControl).to receive(:current_control_file).and_return("/control.xml")


### PR DESCRIPTION
## Problem

When copying files from inst-sys to the target system we are also removing the /etc/install.inf file if the second stage is not required. That problem alone would not affect the installation if the file is read before removing it because we usually cache the state. But it get worst if we reset the Linuxrc state indiscriminately as we currently do.

- https://bugzilla.suse.com/show_bug.cgi?id=1157476

## Solution

By now, we will just drop that removal of the file from inst-sys and will maintain the reset of internals. Mainly because the method is also used during the second stage, and in combination with yast/yast-yast2#984 we should be able to re-read the file.