### PR TITLE
don't use /bin/systemctl compat symlink (bsc#1160890)

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jan 23 12:53:29 UTC 2020 - Steffen Winterfeldt <snwint@suse.com>
+
+- don't use /bin/systemctl compat symlink (bsc#1160890)
+- 4.2.29
+
+-------------------------------------------------------------------
 Wed Jan 22 13:44:48 CET 2020 - schubi@suse.de
 - Using tag $os_release_version in the control.xml file
   (entry <self_update_url>) which will be replaced by the

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.2.28
+Version:        4.2.29
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/startup/Second-Stage/S07-medium
+++ b/startup/Second-Stage/S07-medium
@@ -24,8 +24,8 @@ fi
 #---------------------------------------------
 if [ ! -z "$(ls /etc/sysconfig/network/ifcfg-* |grep  -v 'ifcfg-lo')" ]; then
 	log "\tnetwork configuration found -> activate network"
-	/bin/systemctl start network && Y2_NETWORK_ACTIVE=1
-	[ -f /var/lib/YaST2/network_install_rpcbind ] && /bin/systemctl start rpcbind
+	/usr/bin/systemctl start network && Y2_NETWORK_ACTIVE=1
+	[ -f /var/lib/YaST2/network_install_rpcbind ] && /usr/bin/systemctl start rpcbind
 fi
 
 #=============================================
@@ -38,7 +38,7 @@ fi
 
 if got_install_param '^UseSSH:.*1' ; then
 	log "\tGot kernel parameter UseSSH -> export UseSSH variable"
-	/bin/systemctl start sshd && Y2_SSH_ACTIVE=1
+	/usr/bin/systemctl start sshd && Y2_SSH_ACTIVE=1
 	export USE_SSH=1
 fi
 log "\tSummary for commandline checks:"

--- a/startup/Second-Stage/S09-cleanup
+++ b/startup/Second-Stage/S09-cleanup
@@ -20,7 +20,7 @@ fi
 # 13.3) stop network and sshd
 if [ "$Y2_NETWORK_ACTIVE" -ne 0 ] ; then
 	log "\tShutdown SSH daemon and network interfaces..."
-	test -z "$Y2_SSH_ACTIVE" && /bin/systemctl stop sshd
+	test -z "$Y2_SSH_ACTIVE" && /usr/bin/systemctl stop sshd
 
 #
 #	network mustn't be stopped when using systemd - systemd ignores
@@ -28,14 +28,14 @@ if [ "$Y2_NETWORK_ACTIVE" -ne 0 ] ; then
 #	restart is used to force reconfiguration of network - first stage
 #	config is used up to now.
 #
-	/bin/systemctl restart network
+	/usr/bin/systemctl restart network
 fi
 
 # 13.5) restart other services if necessary (bnc#395402)
 if [ -f /var/lib/YaST2/restart_services ] ; then
     cat /var/lib/YaST2/restart_services | while read service; do
 	log "\tRestart $service service..."
-	/bin/systemctl restart $service
+	/usr/bin/systemctl restart $service
     done
     rm -f /var/lib/YaST2/restart_services
 fi


### PR DESCRIPTION
## Problem

https://bugzilla.suse.com/show_bug.cgi?id=1160890
https://trello.com/c/3Y9HSV8m

`/bin/systemctl` symlink is gone.

## Solution

Don't use it.