### PR TITLE
no getty on hvc0 & ttyAMA0 before Yast2-Firstboot (bsc#1157233)

### DIFF
--- a/package/YaST2-Firstboot.service
+++ b/package/YaST2-Firstboot.service
@@ -3,6 +3,7 @@ Description=YaST2 Firstboot
 After=apparmor.service local-fs.target plymouth-start.service YaST2-Second-Stage.service
 Conflicts=plymouth-start.service
 Before=getty@tty1.service serial-getty@ttyS0.service serial-getty@ttyS1.service serial-getty@ttyS2.service
+Before=serial-getty@hvc0.service serial-getty@ttyAMA0.service
 Before=display-manager.service
 ConditionPathExists=/var/lib/YaST2/reconfig_system
 OnFailure=shutdown.target

--- a/package/YaST2-Second-Stage.service
+++ b/package/YaST2-Second-Stage.service
@@ -3,6 +3,7 @@ Description=YaST2 Second Stage
 After=apparmor.service local-fs.target plymouth-start.service
 Conflicts=plymouth-start.service
 Before=getty@tty1.service serial-getty@ttyS0.service serial-getty@ttyS1.service serial-getty@ttyS2.service
+Before=serial-getty@hvc0.service serial-getty@ttyAMA0.service
 Before=display-manager.service
 ConditionPathExists=/var/lib/YaST2/runme_at_boot
 

--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jan 30 12:07:42 UTC 2020 - Steffen Winterfeldt <snwint@suse.com>
+
+- don't start getty on hvc0 & ttyAMA0 before Yast2-Firstboot (bsc#1157233)
+- 4.1.48
+
+-------------------------------------------------------------------
 Wed Sep 18 09:21:57 UTC 2019 - Steffen Winterfeldt <snwint@suse.com>
 
 - do NOT remove /mnt/run, it's a mounted directory (bsc#1149011)

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.1.47
+Version:        4.1.48
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
## Problem

`yast firstboot` gets killed by signal HUP because there's a getty process running concurrently on the same console.

- https://bugzilla.suse.com/show_bug.cgi?id=1157233
- https://trello.com/c/yzMr62XT

## Solution

Prevent systemd from starting a getty service on hvc0 and ttyAMA0 which are typical serial consoles on ppc64 resp. aarch64.

## See also

https://bugzilla.suse.com/show_bug.cgi?id=935965#c15