### PR TITLE
Fixed user-visible messages (bsc#1084015)

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Feb 17 17:44:48 UTC 2020 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Fixed user-visible messages (bsc#1084015)
+- 4.2.31
+
+-------------------------------------------------------------------
 Wed Jan 29 13:52:29 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
 
 - Reimplemented the "Previously Used Repositories" dialog

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.2.30
+Version:        4.2.31
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/src/lib/installation/clients/inst_upgrade_urls.rb
+++ b/src/lib/installation/clients/inst_upgrade_urls.rb
@@ -140,10 +140,10 @@ module Yast
         ) +
           # TRANSLATORS: help text 2/3
           _(
-            "<p>To enable, remove or disable an URL, click on the\n<b>Toggle Status</b> button or double-click on the respective table item.</p>"
+            "<p>To enable, remove or disable an URL, click the\n<b>Toggle Status</b> button or double-click the respective table item.</p>"
           ) +
           # TRANSLATORS: help text 3/3
-          _("<p>To change the URL, click on the <b>Change...</b> button.</p>"),
+          _("<p>To change the URL, click the <b>Change...</b> button.</p>"),
         true,
         true
       )


### PR DESCRIPTION
## Bugzilla 

https://bugzilla.suse.com/show_bug.cgi?id=1084015


## Description

This puts en_US "translations" which are really fixes for broken English or broken translations back into the sources.


#### en_US.po File

```po
# English message file for YaST2 (@memory@).
# Copyright (C) 2005 SUSE Linux Products GmbH.
# Copyright (C) 2002 SuSE Linux AG.
#
msgid ""
msgstr ""
"Project-Id-Version: YaST (@memory@)\n"
"Report-Msgid-Bugs-To: \n"
"POT-Creation-Date: 2019-12-19 02:28+0000\n"
"PO-Revision-Date: 2008-05-16 13:44+0200\n"
"Last-Translator: proofreader <i18n@suse.de>\n"
"Language-Team: English <i18n@suse.de>\n"
"Language: en_US\n"
"MIME-Version: 1.0\n"
"Content-Type: text/plain; charset=UTF-8\n"
"Content-Transfer-Encoding: 8bit\n"
"Plural-Forms: nplurals=2; plural=n != 1;"

#. TRANSLATORS: help text 3/3
#: src/lib/installation/clients/inst_upgrade_urls.rb:264
msgid "<p>To change the URL, click on the <b>Change...</b> button.</p>"
msgstr "<p>To change the URL, click the <b>Change...</b> button.</p>"

#. TRANSLATORS: popup header
#: src/lib/installation/clients/inst_upgrade_urls.rb:586
msgid "Network is not Configured"
msgstr "Network is not configured"
```

Also changed the other "click on the XY button" text to retain consistency.

The "Network is not Configured" text no longer exists.