### PR TITLE
don't start getty on hvc0 & ttyAMA0 before Yast2-Firstboot (bsc#1157233)

### DIFF
--- a/package/YaST2-Firstboot.service
+++ b/package/YaST2-Firstboot.service
@@ -3,6 +3,7 @@ Description=YaST2 Firstboot
 After=apparmor.service local-fs.target plymouth-start.service YaST2-Second-Stage.service
 Conflicts=plymouth-start.service
 Before=getty@tty1.service serial-getty@ttyS0.service serial-getty@ttyS1.service serial-getty@ttyS2.service
+Before=serial-getty@hvc0.service serial-getty@ttyAMA0.service
 Before=display-manager.service
 ConditionPathExists=/var/lib/YaST2/reconfig_system
 OnFailure=shutdown.target

--- a/package/YaST2-Second-Stage.service
+++ b/package/YaST2-Second-Stage.service
@@ -3,6 +3,7 @@ Description=YaST2 Second Stage
 After=apparmor.service local-fs.target plymouth-start.service
 Conflicts=plymouth-start.service
 Before=getty@tty1.service serial-getty@ttyS0.service serial-getty@ttyS1.service serial-getty@ttyS2.service
+Before=serial-getty@hvc0.service serial-getty@ttyAMA0.service
 Before=display-manager.service
 ConditionPathExists=/var/lib/YaST2/runme_at_boot
 

--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Feb 19 09:40:45 UTC 2020 - Steffen Winterfeldt <snwint@suse.com>
+
+- don't start getty on hvc0 & ttyAMA0 before Yast2-Firstboot (bsc#1157233)
+- 4.2.32
+
+-------------------------------------------------------------------
 Mon Feb 17 17:44:48 UTC 2020 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Fixed user-visible messages (bsc#1084015)

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.2.31
+Version:        4.2.32
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only


### PR DESCRIPTION
## Note

This is a port of https://github.com/yast/yast-installation/pull/834 to master.

## Problem

`yast firstboot` gets killed by signal HUP because there's a getty process running concurrently on the same console.

- https://bugzilla.suse.com/show_bug.cgi?id=1157233
- https://trello.com/c/yzMr62XT

## Solution

Prevent systemd from starting a getty service on hvc0 and ttyAMA0 which are typical serial consoles on ppc64 resp. aarch64.

## See also

https://bugzilla.suse.com/show_bug.cgi?id=935965#c15