### PR TITLE
[SLE-7188] Default to SUSE ntp servers

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Feb 19 12:52:27 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Rely on the new Y2Network::NtpServer class (jsc#SLE-7188).
+- 4.2.33
+
+-------------------------------------------------------------------
 Wed Feb 19 09:40:45 UTC 2020 - Steffen Winterfeldt <snwint@suse.com>
 
 - don't start getty on hvc0 & ttyAMA0 before Yast2-Firstboot (bsc#1157233)

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.2.32
+Version:        4.2.33
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only
@@ -41,8 +41,8 @@ BuildRequires:  yast2 >= 4.2.56
 BuildRequires:  yast2-packager >= 4.2.27
 # using /usr/bin/udevadm
 BuildRequires:  yast2-storage-ng >= 4.2.71
-## y2remote based version
-BuildRequires:  yast2-network >= 4.0.13
+# Y2Network::NtpServer
+BuildRequires:  yast2-network >= 4.2.55
 # new root password cwm widget
 BuildRequires:  yast2-users >= 3.2.8
 # storage-ng based version
@@ -77,7 +77,8 @@ Requires:       yast2-proxy
 Requires:       yast2-services-manager >= 3.2.1
 # Yast::OSRelease.ReleaseVersionHumanReadable
 Requires:       yast2 >= 4.2.56
-Requires:       yast2-network >= 4.0.13
+# Y2Network::NtpServer
+Requires:       yast2-network >= 4.2.55
 # for AbortException and handle direct abort
 Requires:       yast2-ruby-bindings >= 4.0.6
 # for the first/second stage of installation

--- a/src/lib/installation/dialogs/ntp_setup.rb
+++ b/src/lib/installation/dialogs/ntp_setup.rb
@@ -22,6 +22,7 @@
 require "yast"
 require "cwm/dialog"
 require "installation/widgets/ntp_server"
+require "y2network/ntp_server"
 
 module Installation
   module Dialogs
@@ -68,7 +69,7 @@ module Installation
         # TODO: use Yast::NtpClient.ntp_conf if configured
         # to better handle going back
         servers = dhcp_ntp_servers
-        servers = [ntp_fallback] if servers.empty? && default_ntp_setup_enabled?
+        servers = [ntp_fallback.hostname] if servers.empty? && default_ntp_setup_enabled?
 
         servers
       end
@@ -98,23 +99,11 @@ module Installation
 
       # The fallback servers for NTP configuration
       #
-      # It propose a random pool server in range 0..3
+      # It propose a random server from the default pool
       #
-      # @return [String] the fallback servers
+      # @return [Y2Network::NtpServer] the fallback server
       def ntp_fallback
-        "#{rand(4)}.#{ntp_host}.pool.ntp.org"
-      end
-
-      def ntp_host
-        # copied from timezone/dialogs.rb:
-        base_products = Yast::Product.FindBaseProducts
-
-        if base_products.any? { |p| p["name"] =~ /openSUSE/i }
-          "opensuse"
-        else
-          # TODO: use a SUSE server when available in the future
-          "novell"
-        end
+        Y2Network::NtpServer.default_servers.sample
       end
     end
   end

--- a/test/dialogs/ntp_setup_test.rb
+++ b/test/dialogs/ntp_setup_test.rb
@@ -36,16 +36,22 @@ describe ::Installation::Dialogs::NtpSetup do
     end
 
     context "no NTP server set in DHCP and default NTP is enabled in control.xml" do
+      let(:default_servers) do
+        [
+          Y2Network::NtpServer.new("0.opensuse.pool.ntp.org"),
+          Y2Network::NtpServer.new("1.opensuse.pool.ntp.org")
+        ]
+      end
+
       before do
         allow(Yast::ProductFeatures).to receive(:GetBooleanFeature)
           .with("globals", "default_ntp_setup").and_return(true)
-        allow(Yast::Product).to receive(:FindBaseProducts)
-          .and_return(["name" => "openSUSE-Tumbleweed-Kubic"])
+        allow(Y2Network::NtpServer).to receive(:default_servers).and_return(default_servers)
       end
 
-      it "proposes to use a random openSUSE pool server" do
+      it "proposes to use a random server from the default pool" do
         expect(::Installation::Widgets::NtpServer).to receive(:new).and_wrap_original do |original, arg|
-          expect(arg.first).to match(/\A[0-3]\.opensuse\.pool\.ntp\.org\z/)
+          expect(default_servers.map(&:hostname)).to include(arg.first)
           original.call(arg)
         end
         subject.run


### PR DESCRIPTION
Use the new `Y2Network::NtpServer` when proposing the default values for NTP servers.

Related PR: https://github.com/yast/yast-network/pull/1039