### PR TITLE
Self-update control file

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Feb 20 11:24:41 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Allow to modify the control file at installation time using a
+  skelcd-* package (bsc#1164468).
+- 4.2.33
+
+-------------------------------------------------------------------
 Wed Feb 19 09:40:45 UTC 2020 - Steffen Winterfeldt <snwint@suse.com>
 
 - don't start getty on hvc0 & ttyAMA0 before Yast2-Firstboot (bsc#1157233)

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.2.32
+Version:        4.2.33
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/src/lib/installation/updates_manager.rb
+++ b/src/lib/installation/updates_manager.rb
@@ -127,7 +127,7 @@ module Installation
 
   private
 
-    NEW_CONTROL_FILE_PATH = "/usr/lib/skelcd/CD1/control.xml"
+    NEW_CONTROL_FILE_PATH = "/usr/lib/skelcd/CD1/control.xml".freeze
     APPLY_CMD = "/sbin/adddir %<source>s /".freeze
 
     # Replaces the control file with the the updated one (if it exists)

--- a/test/updates_manager_test.rb
+++ b/test/updates_manager_test.rb
@@ -131,26 +131,18 @@ describe Installation::UpdatesManager do
 
     context "when a new control file is available" do
       let(:new_control_file?) { true }
-      let(:exit_code) { 0 }
 
-      before do
-        allow(Yast::SCR).to receive(:Execute).and_return("exit" => exit_code)
-      end
-
-      it "updates the control file if needed" do
-        expect(Yast::SCR).to receive(:Execute)
-          .with(Yast::Path.new(".target.bash_output"), "/sbin/adddir /usr/lib/skelcd/CD1 /")
+      it "updates the control file" do
+        expect(Yast::Execute).to receive(:locally!)
+          .with("/sbin/adddir", "/usr/lib/skelcd/CD1", "/")
         manager.apply_all
       end
+    end
 
-      context "and updating the control file fails" do
-        let(:exit_code) { 1 }
-
-        it "raises an exception" do
-          expect { manager.apply_all }
-            .to raise_error(Installation::UpdatesManager::CouldNotUpdateControlFile)
-        end
-      end
+    it "does not replace the control file" do
+      expect(Yast::Execute).to_not receive(:locally!)
+        .with("/sbin/adddir", /skelcd/, "/")
+      manager.apply_all
     end
   end
 


### PR DESCRIPTION
Using the self-update is not possible to replace the `control.xml` file unless you craft a special package that contains that file in the root filesystem. This PRs extends the the self-update mechanism to update the `/control.xml` file with `/usr/lib/skelcd/CD1/control.xml`, which is where `skelcd-control-CAASP`, `skelcd-control-Kubic`, `skelcd-control-leanos`, `skelcd-control-MicroOS` and `skelcd-control-openSUSE` put the control file.