### PR TITLE
Show Release Notes for Add-On Products

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Feb 27 15:03:36 UTC 2020 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Make sure to show release notes for add-on products (bsc#1158287)
+- 4.2.36
+
+-------------------------------------------------------------------
 Fri Feb 21 09:45:10 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
 
 - Added "yupdate" script to simplify patching the installer

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.2.35
+Version:        4.2.36
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/src/lib/installation/clients/inst_download_release_notes.rb
+++ b/src/lib/installation/clients/inst_download_release_notes.rb
@@ -27,6 +27,7 @@
 # $Id$
 
 require "y2packager/product"
+require "y2packager/product_reader"
 
 Yast.import "InstData"
 Yast.import "Pkg"
@@ -100,10 +101,13 @@ module Yast
     def products
       # installed may mean old (before upgrade) in initial stage
       # product may not yet be selected although repo is already added
-      return Y2Packager::Product.with_status(:selected, :installed) unless Stage.initial
-      selected = Y2Packager::Product.with_status(:selected)
+      #
+      # Don't rely on Product.with_status() here, use force_repos (bsc#1158287)
+      all_products = Y2Packager::ProductReader.new.all_products(force_repos: true)
+      return all_products.select { |p| p.status?(:selected, :installed) } unless Stage.initial
+      selected = all_products.select { |p| p.selected? }
       return selected unless selected.empty?
-      Y2Packager::Product.with_status(:available)
+      all_products.select { |p| p.status?(:available) }
     end
 
     # Refresh release notes UI

--- a/src/lib/installation/clients/inst_download_release_notes.rb
+++ b/src/lib/installation/clients/inst_download_release_notes.rb
@@ -107,7 +107,7 @@ module Yast
       # of online media, and that means only base products, no add-ons.
       all_products = Y2Packager::ProductReader.new.all_products(force_repos: true)
       return all_products.select { |p| p.status?(:selected, :installed) } unless Stage.initial
-      selected = all_products.select { |p| p.selected? }
+      selected = all_products.select { |p| p.status?(:selected) }
       return selected unless selected.empty?
       all_products.select { |p| p.status?(:available) }
     end

--- a/src/lib/installation/clients/inst_download_release_notes.rb
+++ b/src/lib/installation/clients/inst_download_release_notes.rb
@@ -102,7 +102,9 @@ module Yast
       # installed may mean old (before upgrade) in initial stage
       # product may not yet be selected although repo is already added
       #
-      # Don't rely on Product.with_status() here, use force_repos (bsc#1158287)
+      # Don't rely on Product.with_status() here, use force_repos (bsc#1158287):
+      # Otherwise we will only get products from the control file in the case
+      # of online media, and that means only base products, no add-ons.
       all_products = Y2Packager::ProductReader.new.all_products(force_repos: true)
       return all_products.select { |p| p.status?(:selected, :installed) } unless Stage.initial
       selected = all_products.select { |p| p.selected? }


### PR DESCRIPTION
## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1158287

## Trello

https://trello.com/c/vmm7flFk/

## Problem

The release notes for add-on products were not shown any more.

## Fix

Don't use `Product.with_status()` because that uses `all_products()` without the `force_repos` parameter.

In the case of online media, this means that it only uses products from the control file which means you will only get base products.

Now using `all_products()` directly, but _with_ the `force_repos` parameter, so we get all products from all repos; and now we also get SLE-HA, so we can check it for release notes.

## Screenshot

![sle-ha-release-notes](https://user-images.githubusercontent.com/11538225/75457804-37318e00-597d-11ea-8e12-201022ec8afb.png)

