### PR TITLE
Stop plymouth splash to avoid serial terminal splutter.

### DIFF
--- a/startup/YaST2.First-Stage
+++ b/startup/YaST2.First-Stage
@@ -18,6 +18,11 @@
 #
 #set -x
 #=============================================
+# 0) Stop boot animation.
+#---------------------------------------------
+plymouth quit 2>&1 >/dev/null
+
+#=============================================
 # 1) Source common script functions
 #---------------------------------------------
 . /usr/lib/YaST2/startup/common/functions.sh


### PR DESCRIPTION
Hi Yast-team:
I have a little modification to
Stop Plymouth animation splash before the installation program run, it will avoid mass up the serial screen's character garbled (bnc#1164123).
Thanks for the review.