### PR TITLE
Added selfupdate verification (bsc#1163084)

### DIFF
--- a/doc/SELF_UPDATE.md
+++ b/doc/SELF_UPDATE.md
@@ -216,6 +216,21 @@ under https://updates.suse.com/
 - /SUSE/Updates/SLE-SERVER-INSTALLER/12-SP2/s390x/update
 - /SUSE/Updates/SLE-SERVER-INSTALLER/12-SP2/x86_64/update
 
+## Update Repository Validation
+
+Using an incompatible self-update repository might result in a crash or
+unexpected behavior. Since SLE15-SP2/Leap15.2 the installer compares the
+versions of some specific packages in the self-update repository and in the inst-sys.
+If any unexpected version is found then an error is displayed and the self-update
+step is completely skipped.
+
+Is is possible to skip this validation is special cases and force applying the
+updates despite the version mismatch by setting environment variable
+`Y2_FORCE_SELF_UPDATE=1`.
+
+See the [Installation::SelfupdateVerifier](../src/lib/installation/selfupdate_verifier.rb)
+class for more details.
+
 ## Security
 
 ### Package Integrity

--- a/doc/SELF_UPDATE.md
+++ b/doc/SELF_UPDATE.md
@@ -226,7 +226,8 @@ step is completely skipped.
 
 Is is possible to skip this validation is special cases and force applying the
 updates despite the version mismatch by setting environment variable
-`Y2_FORCE_SELF_UPDATE=1`.
+`Y2_FORCE_SELF_UPDATE=1`. *This should be done only in special cases (testing)
+when you know what you are doing!*
 
 See the [Installation::SelfupdateVerifier](../src/lib/installation/selfupdate_verifier.rb)
 class for more details.

--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Mar 16 08:37:11 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
+ 
+- Verify the package versions before applying the self-update
+  fixes (related to bsc#1163084)
+- 4.2.38
+
+-------------------------------------------------------------------
 Fri Mar 13 09:26:49 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
 
 - Add Abort confirmation for inst_welcome client used in firstboot

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.2.38
+Version:        4.2.39
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.2.37
+Version:        4.2.38
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/src/lib/installation/clients/inst_update_installer.rb
+++ b/src/lib/installation/clients/inst_update_installer.rb
@@ -449,8 +449,8 @@ module Yast
       instsys_packages = ::Installation::InstsysPackages.read("/.packages.root")
       verifier = ::Installation::SelfupdateVerifier.new(updates_manager.repositories, instsys_packages)
 
-      # no downgraded or too new packages => OK
-      return true if verifier.downgraded_packages.empty? && verifier.too_new_packages.empty?
+      # no downgraded packages => OK
+      return true if verifier.downgraded_packages.empty?
 
       if ENV["Y2_FORCE_SELF_UPDATE"] == "1"
         log.warn("Self update forced by user despite of a package version mismatch!")

--- a/src/lib/installation/clients/inst_update_installer.rb
+++ b/src/lib/installation/clients/inst_update_installer.rb
@@ -51,9 +51,11 @@ module Yast
     Yast.import "AutoinstConfig"
     Yast.import "AutoinstGeneral"
 
-    def main
+    def initialize
       textdomain "installation"
+    end
 
+    def main
       return :back if GetInstArgs.going_back
 
       require_registration_libraries

--- a/src/lib/installation/clients/inst_update_installer.rb
+++ b/src/lib/installation/clients/inst_update_installer.rb
@@ -192,18 +192,6 @@ module Yast
       @update_repositories = []
     end
 
-    # Return the custom self-update URL
-    #
-    # A custom URL can be specified via Linuxrc or in an AutoYaST profile.
-    # Only 1 custom self-update URL can be specified.
-    #
-    # @return [URI] self-update URL
-    # @see #self_update_url_from_linuxrc
-    # @see #self_update_url_from_profile
-    def custom_self_update_url
-      @custom_self_update_url ||= self_update_url_from_linuxrc || self_update_url_from_profile
-    end
-
     # Check if installer was updated
     #
     # It checks if a file UPDATED_FLAG_FILENAME exists in Directory.vardir

--- a/src/lib/installation/instsys_packages.rb
+++ b/src/lib/installation/instsys_packages.rb
@@ -1,0 +1,37 @@
+# ------------------------------------------------------------------------------
+# Copyright (c) 2020 SUSE LLC, All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of version 2 of the GNU General Public License as published by the
+# Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# ------------------------------------------------------------------------------
+
+require "yast"
+require "y2packager/package"
+
+module Installation
+  # Find the packages installed in the inst-sys. Because the inst-sys
+  # does not contain the RPM DB we need to load the installed packages
+  # from the /.packages.root file.
+  class InstsysPackages
+    def self.read(file = "/.packages.root")
+      packages = []
+
+      File.foreach(file) do |line|
+        # each line looks like this (the dependency at the end is optional):
+        #   yast2-core [4.1.0-5.18.x86_64] < yast2
+        name, version = /^(\S+) \[(\S+)\]/.match(line)[1, 2]
+        next unless name && version
+
+        # nil repository ID
+        packages << Y2Packager::Package.new(name, nil, version)
+      end
+
+      packages
+    end
+  end
+end

--- a/src/lib/installation/selfupdate_verifier.rb
+++ b/src/lib/installation/selfupdate_verifier.rb
@@ -1,0 +1,140 @@
+# ------------------------------------------------------------------------------
+# Copyright (c) 2020 SUSE LLC, All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of version 2 of the GNU General Public License as published by the
+# Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# ------------------------------------------------------------------------------
+
+require "yast"
+require "installation/instsys_packages"
+require "y2packager/repository"
+
+module Installation
+  # This class does some self-update repository sanity checks to avoid
+  # applying a wrong self update repository (specified by user).
+  class SelfupdateVerifier
+    include Yast::Logger
+
+    # We only check the version of these packages, the reason for a fixed
+    # list is that these packages are maintained by us and their version
+    # is under our control.
+    #
+    # We do not care about the other packages, in theory there might be
+    # valid reasons for downgrading them. With these YaST packages we can
+    # go back to the previous state but but still increase the version number.
+    #
+    # We can also check the "too new" packages because the YaST package versions
+    # are bound to specific SP release (e.g. 4.1.x in SP1, 4.2.x in SP2).
+    # So the major and minor version parts must not be changed during self update.
+    VERIFIED_PACKAGES = [
+      "autoyast2-installation",
+      "yast2",
+      "yast2-installation",
+      "yast2-packager",
+      "yast2-pkg-bindings",
+      "yast2-registration",
+      "yast2-storage-ng",
+      "yast2-update"
+    ].freeze
+
+    # Constructor
+    # @param repositories [Array<UpdateRepository>] the self-update repositories
+    # @param instsys_packages [Array<Y2Packager::Package>] the installed packages
+    #   in the current inst-sys
+    def initialize(repositories, instsys_packages)
+      @instsys_packages = instsys_packages.select do |p|
+        VERIFIED_PACKAGES.include?(p.name)
+      end
+
+      # the selfupdate repo might provide the same package in several versions,
+      # find the latest one
+
+      # group the same packages together
+      packages = {}
+
+      repositories.each do |repo|
+        repo.packages.each do |p|
+          next unless VERIFIED_PACKAGES.include?(p.name)
+
+          if packages[p.name]
+            packages[p.name] << p
+          else
+            packages[p.name] = [p]
+          end
+        end
+      end
+
+      # for each package find the highest version
+      @selfupdate_packages = packages.values.map do |pkgs|
+        pkgs.max { |a, b| Yast::Pkg.CompareVersions(a.version, b.version) }
+      end
+    end
+
+    # check for downgraded packages, e.g. using the SP1 updates in the SP2 installer
+    #
+    # @return [Array<Y2Packager::Resolvable>] List of downgraded packages
+    def downgraded_packages
+      packages = filter_self_updates do |inst_sys_pkg, update_pkg|
+        # -1 = "update_pkg" is older than "inst_sys_pkg" (0 = the same, 1 = newer)
+        Yast::Pkg.CompareVersions(update_pkg.version, inst_sys_pkg.version) == -1
+      end
+
+      log.warn("Found downgraded self-update packages: #{packages} ") unless packages.empty?
+      packages
+    end
+
+    # Check for too new packages, e.g. using the SP3 updates in the SP2 installer.
+    #
+    # As we use fixed versioning schema for the YaST packages which is bound to
+    # a specific product version (e.g. 4.1.x in SP1, 4.2.x in SP2) and we always
+    # bump only the patch version we can also possibly check for "too new" packages.
+    #
+    # @return [Array<Y2Packager::Resolvable>] List of too new packages
+    def too_new_packages
+      packages = filter_self_updates do |inst_sys_pkg, update_pkg|
+        inst_major, inst_minor = parse_version(inst_sys_pkg.version)
+        update_major, update_minor = parse_version(update_pkg.version)
+
+        # check major/minor version update
+        update_major > inst_major || update_minor > inst_minor
+      end
+
+      log.warn("Found too new self-update packages: #{packages} ") unless packages.empty?
+      packages
+    end
+
+  private
+
+    # filter the self update packages using a block
+    def filter_self_updates(&block)
+      selfupdate_packages.select do |s|
+        pkg = instsys_package(s.name)
+        # if not in inst-sys
+        next false unless pkg
+
+        block.call(pkg, s)
+      end
+    end
+
+    # extract the major and minor version number from version string,
+    # it also converts the string versions to integers
+    # @return [Array<Integer>] A pair of major and minor version
+    def parse_version(version)
+      major, minor = /^(\d+)\.(\d+)\./.match(version)[1, 2]
+      [major.to_i, minor.to_i]
+    end
+
+    # find the installed package in the inst-sys
+    # @param name [String] name of the package
+    def instsys_package(name)
+      instsys_packages.find { |p| p.name == name }
+    end
+
+    attr_reader :instsys_packages, :selfupdate_packages
+  end
+end

--- a/src/lib/installation/selfupdate_verifier.rb
+++ b/src/lib/installation/selfupdate_verifier.rb
@@ -88,26 +88,6 @@ module Installation
       packages
     end
 
-    # Check for too new packages, e.g. using the SP3 updates in the SP2 installer.
-    #
-    # As we use fixed versioning schema for the YaST packages which is bound to
-    # a specific product version (e.g. 4.1.x in SP1, 4.2.x in SP2) and we always
-    # bump only the patch version we can also possibly check for "too new" packages.
-    #
-    # @return [Array<Y2Packager::Resolvable>] List of too new packages
-    def too_new_packages
-      packages = filter_self_updates do |inst_sys_pkg, update_pkg|
-        inst_major, inst_minor = parse_version(inst_sys_pkg.version)
-        update_major, update_minor = parse_version(update_pkg.version)
-
-        # check major/minor version update
-        update_major > inst_major || update_minor > inst_minor
-      end
-
-      log.warn("Found too new self-update packages: #{packages} ") unless packages.empty?
-      packages
-    end
-
   private
 
     # filter the self update packages using a block
@@ -119,14 +99,6 @@ module Installation
 
         block.call(pkg, s)
       end
-    end
-
-    # extract the major and minor version number from version string,
-    # it also converts the string versions to integers
-    # @return [Array<Integer>] A pair of major and minor version
-    def parse_version(version)
-      major, minor = /^(\d+)\.(\d+)\./.match(version)[1, 2]
-      [major.to_i, minor.to_i]
     end
 
     # find the installed package in the inst-sys

--- a/src/lib/installation/selfupdate_verifier.rb
+++ b/src/lib/installation/selfupdate_verifier.rb
@@ -26,7 +26,7 @@ module Installation
     #
     # We do not care about the other packages, in theory there might be
     # valid reasons for downgrading them. With these YaST packages we can
-    # go back to the previous state but but still increase the version number.
+    # go back to the previous state but still increase the version number.
     #
     # We can also check the "too new" packages because the YaST package versions
     # are bound to specific SP release (e.g. 4.1.x in SP1, 4.2.x in SP2).

--- a/test/fixtures/inst-sys/packages.root
+++ b/test/fixtures/inst-sys/packages.root
@@ -1,0 +1,527 @@
+Mesa-libEGL1 [19.3.4-44.4.x86_64]
+Mesa-libGL1 [19.3.4-44.4.x86_64]
+Mesa-libglapi0 [19.3.4-44.4.x86_64] < Mesa-libGL1
+SUSEConnect [0.3.25-1.3.x86_64] < yast2-registration < skelcd-control-leanos
+aaa_base [84.87+git20180409.04c9dae-3.33.1.x86_64]
+augeas [1.10.1-1.11.x86_64] < ruby2.5-rubygem-ruby-augeas < ruby2.5-rubygem-cfa < yast2
+augeas-lenses [1.10.1-1.11.x86_64] < yast2-installation
+autoyast2 [4.2.28-1.3.noarch] < skelcd-control-leanos
+autoyast2-installation [4.2.28-1.3.noarch] < yast2-add-on < skelcd-control-leanos
+bash [4.4-9.10.1.x86_64]
+blog [2.18-4.11.x86_64] < sysvinit-tools
+boost-license1_66_0 [1.66.0-3.10.noarch] < libboost_thread1_66_0 < snapper
+btrfsprogs [4.19.1-6.8.x86_64]
+btrfsprogs-udev-rules [4.19.1-6.8.noarch] < btrfsprogs
+bzip2 [1.0.6-5.9.1.x86_64]
+checkmedia [5.3-1.46.x86_64]
+chrony [3.2-9.9.1.x86_64]
+coreutils [8.29-2.12.x86_64]
+cpio [2.12-3.3.1.x86_64]
+cracklib [2.9.6-2.21.x86_64]
+cracklib-dict-full [2.8.12-1.22.x86_64] < libpwquality1 < cryptsetup
+cryptsetup [2.0.5-2.1.x86_64]
+dbus-1 [1.12.2-8.3.1.x86_64] < systemd
+dejavu-fonts [2.37-1.21.noarch]
+device-mapper [1.02.163-3.23.x86_64]
+diffutils [3.6-2.11.x86_64]
+dmidecode [3.2-9.3.2.x86_64] < SUSEConnect < yast2-registration < skelcd-control-leanos
+dmz-icon-theme-cursors [11.3.0-1.22.noarch]
+dosfstools [4.1-1.39.x86_64]
+e2fsprogs [1.43.8-4.17.1.x86_64]
+efibootmgr [14-2.8.x86_64]
+efont-unicode-bitmap-fonts [0.4.2-1.21.noarch]
+elilo [3.16-4.30.x86_64]
+fbiterm [0.5.20040304-3.38.x86_64]
+fcoe-utils [1.0.32-1.41.x86_64] < yast2-fcoe-client < skelcd-control-leanos
+fdupes [1.61-1.452.x86_64] < ruby-common < ruby2.5 < ruby
+file [5.32-7.5.1.x86_64]
+file-magic [5.32-7.5.1.noarch] < libmagic1 < rpm
+fillup [1.42-2.18.x86_64]
+findutils [4.6.0-2.21.x86_64]
+firewall-macros [0.5.5-4.24.9.noarch] < xorg-x11-Xvnc
+fontconfig [2.12.6-2.19.x86_64] < xterm-bin
+fonts-config [20160921-2.16.noarch]
+gawk [4.2.1-1.41.x86_64]
+glib2-tools [2.62.5-1.2.x86_64] < libgio-2_0-0 < polkit
+glibc [2.26-13.36.1.x86_64] < perl-XML-Bare
+glibc-locale-base [2.26-13.36.1.x86_64]
+google-noto-fonts-doc [20170919-2.13.noarch] < noto-naskharabic-fonts
+google-roboto-fonts [20161103.2.135-1.22.noarch]
+gpart [0.3-1.30.x86_64]
+gpg2 [2.2.5-4.14.4.x86_64]
+gpm [1.20.7-5.14.x86_64]
+graphviz [2.40.1-6.3.2.x86_64]
+graphviz-gnome [2.40.1-6.3.2.x86_64]
+graphviz-plugins-core [2.40.1-6.3.2.x86_64]
+grep [3.1-2.20.x86_64]
+grub2 [2.04-3.3.x86_64]
+gzip [1.10-1.46.x86_64]
+hdparm [9.52-1.22.x86_64]
+hex [1.4-2.18.x86_64]
+hicolor-icon-theme [0.17-1.21.noarch] < dmz-icon-theme-cursors
+hostname [3.16-2.22.x86_64] < yast2
+hwinfo [21.66-6.17.x86_64]
+hyper-v [7-12.2.x86_64]
+icewm-lite [1.4.2-7.6.1.x86_64]
+indic-fonts [20160512-1.93.noarch]
+initviocons [0.5-1.27.x86_64]
+insserv-compat [0.1-4.3.1.noarch]
+iproute2 [5.3-2.10.x86_64] < yast2-installation
+iptables [1.8.3-1.20.x86_64]
+iputils [s20161105-6.10.x86_64]
+iscsiuio [0.7.8.2-13.32.1.x86_64] < yast2-iscsi-client < skelcd-control-leanos
+jfsutils [1.1.15-1.27.x86_64]
+joe [4.4-1.32.x86_64]
+kbd [2.0.4-14.20.x86_64]
+kbd-legacy [2.0.4-14.20.noarch] < kbd
+kdump [0.9.0-8.15.x86_64] < yast2-kdump < skelcd-control-leanos
+kexec-tools [2.0.20-1.10.x86_64] < kdump < yast2-kdump < skelcd-control-leanos
+keyutils [1.5.10-3.42.x86_64] < nfs-client
+khmeros-fonts [5.0-1.22.noarch]
+klogd [1.4.1-2.23.x86_64]
+kpartx [0.8.2+18.9ff73e7-1.49.x86_64] < multipath-tools
+krb5 [1.16.3-3.6.1.x86_64]
+less [530-1.6.x86_64]
+libICE6 [1.0.9-1.25.x86_64] < icewm-lite
+libQt5Core5 [5.12.7-1.19.x86_64] < libyui-qt-graph11
+libQt5DBus5 [5.12.7-1.19.x86_64] < libQt5Gui5 < libyui-qt-graph11
+libQt5Gui5 [5.12.7-1.19.x86_64] < libyui-qt-graph11
+libQt5Network5 [5.12.7-1.19.x86_64] < libQt5Gui5 < libyui-qt-graph11
+libQt5Svg5 [5.12.7-1.19.x86_64] < libyui-qt-pkg11
+libQt5Widgets5 [5.12.7-1.19.x86_64] < libyui-qt-graph11
+libQt5X11Extras5 [5.12.7-1.19.x86_64] < libyui-qt11 < libyui-qt-graph11
+libSM6 [1.2.2-1.23.x86_64] < icewm-lite
+libX11-6 [1.6.5-3.3.1.x86_64] < icewm-lite
+libX11-data [1.6.5-3.3.1.noarch] < libX11-6 < icewm-lite
+libX11-xcb1 [1.6.5-3.3.1.x86_64] < Mesa-libGL1
+libXau6 [1.0.8-1.26.x86_64] < xorg-x11-Xvnc
+libXaw7 [1.0.13-3.3.8.x86_64] < xterm-bin
+libXcomposite1 [0.4.4-1.23.x86_64] < xdpyinfo
+libXcursor1 [1.1.15-1.18.x86_64] < xsetroot < xdm
+libXdamage1 [1.1.4-1.23.x86_64] < xorg-x11-Xvnc
+libXdmcp6 [1.1.2-1.23.x86_64] < xorg-x11-Xvnc
+libXext6 [1.3.3-1.30.x86_64] < icewm-lite
+libXfixes3 [5.0.3-1.24.x86_64] < xorg-x11-Xvnc
+libXfont1 [1.5.4-1.17.x86_64] < fbiterm
+libXfont2-2 [2.0.3-1.17.x86_64] < xorg-x11-Xvnc
+libXfontcache1 [1.0.5-1.22.x86_64] < xset
+libXft2 [2.3.2-1.33.x86_64] < icewm-lite
+libXi6 [1.7.9-3.2.1.x86_64] < xf86-input-wacom
+libXinerama1 [1.1.3-1.22.x86_64] < icewm-lite
+libXmu6 [1.1.2-1.30.x86_64] < xterm-bin
+libXmuu1 [1.1.2-1.30.x86_64] < xset
+libXpm4 [3.5.12-1.33.x86_64] < xterm-bin
+libXrandr2 [1.5.1-2.17.x86_64] < icewm-lite
+libXrender1 [0.9.10-1.30.x86_64] < xdpyinfo
+libXt6 [1.1.5-2.24.x86_64] < xterm-bin
+libXtst6 [1.2.3-1.24.x86_64] < xorg-x11-Xvnc
+libXvnc1 [1.9.0-19.3.1.x86_64] < xorg-x11-Xvnc
+libXxf86dga1 [1.1.4-1.24.x86_64] < xdpyinfo
+libXxf86misc1 [1.0.3-1.23.x86_64] < xset
+libXxf86vm1 [1.1.4-1.23.x86_64] < Mesa-libGL1
+libacl1 [2.2.52-4.3.1.x86_64] < sed
+libaio1 [0.3.109-1.25.x86_64] < multipath-tools
+libapparmor1 [2.13.3-1.13.x86_64] < systemd
+libargon2-1 [0.0+git20171227.670229c-2.14.x86_64] < libcryptsetup12 < cryptsetup
+libassuan0 [2.5.1-2.14.x86_64] < gpg2
+libattr1 [2.4.47-2.19.x86_64] < shadow
+libaudit1 [2.8.1-3.30.x86_64] < nscd
+libaugeas0 [1.10.1-1.11.x86_64] < augeas-lenses < yast2-installation
+libblkid1 [2.33.1-4.5.1.x86_64] < cryptsetup
+libboost_system1_66_0 [1.66.0-3.10.x86_64] < snapper
+libboost_thread1_66_0 [1.66.0-3.10.x86_64] < snapper
+libbtrfs0 [4.19.1-6.8.x86_64] < libsnapper5 < snapper
+libbz2-1 [1.0.6-5.9.1.x86_64] < bzip2
+libcairo2 [1.16.0-1.29.x86_64] < pango-tools
+libcap-ng0 [0.7.9-4.37.x86_64] < util-linux
+libcap2 [2.25-2.41.x86_64] < chrony
+libcares2 [1.15.0+20200117-3.5.1.x86_64] < wget
+libcom_err2 [1.43.8-4.17.1.x86_64] < openssh
+libconfig11 [1.7-2.12.x86_64] < open-lldp < fcoe-utils < yast2-fcoe-client < skelcd-control-leanos
+libcrack2 [2.9.6-2.21.x86_64] < pam
+libcryptsetup12 [2.0.5-2.1.x86_64] < cryptsetup
+libcryptsetup12-hmac [2.0.5-2.1.x86_64]
+libcurl4 [7.66.0-2.31.x86_64] < libzypp < libyui-ncurses-pkg11
+libdatrie1 [0.2.9-1.25.x86_64] < libthai0 < libpango-1_0-0 < pango-tools
+libdb-4_8 [4.8.30-7.3.1.x86_64] < pam
+libdbus-1-3 [1.12.2-8.3.1.x86_64] < snapper
+libdevmapper-event1_03 [1.02.163-3.23.x86_64] < device-mapper
+libdevmapper1_03 [1.02.163-3.23.x86_64] < multipath-tools
+libdmx1 [1.1.3-1.23.x86_64] < xdpyinfo
+libdouble-conversion3 [3.1.5-1.3.x86_64] < libQt5Core5 < libyui-qt-graph11
+libdrm2 [2.4.100-1.23.x86_64] < Mesa-libGL1
+libdrm_amdgpu1 [2.4.100-1.23.x86_64] < xf86-video-amdgpu
+libdw1 [0.168-4.5.3.x86_64] < ltrace
+libebl-plugins [0.168-4.5.3.x86_64] < libelf1 < ltrace
+libedit0 [3.1.snap20150325-2.12.x86_64] < chrony
+libefivar1 [35-4.17.x86_64] < efibootmgr
+libelf1 [0.168-4.5.3.x86_64] < ltrace
+libepoxy0 [1.4.3-2.25.x86_64] < xorg-x11-server
+libesmtp [1.0.6-1.27.x86_64] < kdump < yast2-kdump < skelcd-control-leanos
+libevdev2 [1.4.5-1.27.x86_64] < libinput10 < xf86-input-libinput
+libevent-2_1-8 [2.1.8-2.23.x86_64] < nfs-client
+libexpat1 [2.2.5-3.6.1.x86_64] < Mesa-libGL1
+libext2fs2 [1.43.8-4.17.1.x86_64] < btrfsprogs
+libfdisk1 [2.33.1-4.5.1.x86_64] < util-linux
+libffi7 [3.2.1.git259-3.16.x86_64] < libgobject-2_0-0 < icewm-lite
+libfontenc1 [1.1.3-1.22.x86_64] < mkfontscale
+libfreebl3 [3.47.1-3.22.1.x86_64] < chrony
+libfreetype6 [2.9-2.13.x86_64] < mkfontscale
+libfribidi0 [1.0.5-1.14.x86_64] < libpango-1_0-0 < pango-tools
+libgbm1 [19.3.4-44.4.x86_64]
+libgcc_s1 [9.2.1+r275327-1.3.7.x86_64] < icewm-lite
+libgcrypt20 [1.8.2-8.15.1.x86_64] < rpm
+libgdbm4 [1.12-1.418.x86_64] < perl
+libgdk_pixbuf-2_0-0 [2.36.11-3.19.x86_64] < icewm-lite
+libgio-2_0-0 [2.62.5-1.2.x86_64] < polkit
+libglib-2_0-0 [2.62.5-1.2.x86_64] < pango-tools
+libglvnd [1.2.0-1.21.x86_64] < xorg-x11-Xvnc
+libgmodule-2_0-0 [2.62.5-1.2.x86_64] < libgdk_pixbuf-2_0-0 < icewm-lite
+libgmp10 [6.1.2-2.41.x86_64] < coreutils
+libgnutls30 [3.6.7-6.11.1.x86_64] < xorg-x11-Xvnc
+libgobject-2_0-0 [2.62.5-1.2.x86_64] < icewm-lite
+libgpg-error0 [1.29-1.8.x86_64] < gpg2
+libgpgme11 [1.13.1-2.31.x86_64] < wget
+libgpm2 [1.20.7-5.14.x86_64] < gpm
+libgraphite2-3 [1.3.11-2.12.x86_64] < libharfbuzz0 < libQt5Gui5 < libyui-qt-graph11
+libgraphviz6 [2.40.1-6.3.2.x86_64] < libyui-qt-graph11
+libgudev-1_0-0 [232-1.33.x86_64] < libwacom2 < libinput10 < xf86-input-libinput
+libharfbuzz0 [2.6.4-1.28.x86_64] < libQt5Gui5 < libyui-qt-graph11
+libhogweed4 [3.4.1-4.9.1.x86_64] < libgnutls30 < xorg-x11-Xvnc
+libicu-suse65_1 [65.1-1.17.x86_64] < libQt5Core5 < libyui-qt-graph11
+libicu65_1-ledata [65.1-1.17.noarch] < libicu-suse65_1 < libQt5Core5 < libyui-qt-graph11
+libidn11 [1.34-3.2.2.x86_64] < iputils
+libidn2-0 [2.2.0-3.3.1.x86_64] < wget
+libinput10 [1.10.5-1.21.x86_64] < xf86-input-libinput
+libip4tc2 [1.8.3-1.20.x86_64] < iptables
+libip6tc2 [1.8.3-1.20.x86_64] < iptables
+libiterm1 [0.5.20040304-3.38.x86_64] < fbiterm
+libjbig2 [2.1-1.31.x86_64] < libtiff5 < libgdk_pixbuf-2_0-0 < icewm-lite
+libjemalloc2 [5.0.1-1.25.x86_64] < yast2-core < yast2
+libjpeg8 [8.1.2-5.12.1.x86_64] < xorg-x11-Xvnc
+libjson-c3 [0.13-1.19.x86_64] < libcryptsetup12 < cryptsetup
+libkeyutils1 [1.5.10-3.42.x86_64] < nfs-client
+libkmod2 [25-6.7.1.x86_64] < open-iscsi
+libksba8 [1.3.5-2.14.x86_64] < gpg2
+libldap-2_4-2 [2.4.46-9.25.1.x86_64] < gpg2
+libldap-data [2.4.46-9.25.1.noarch] < libldap-2_4-2 < gpg2
+libldapcpp1 [0.3.1-1.33.x86_64] < yast2-ldap < yast2-users < skelcd-control-leanos
+liblldp_clif1 [1.0.1+56.cb81e95-1.27.x86_64] < open-lldp < fcoe-utils < yast2-fcoe-client < skelcd-control-leanos
+libltdl7 [2.4.6-1.406.x86_64] < libgraphviz6 < libyui-qt-graph11
+liblua5_3-5 [5.3.4-3.3.2.x86_64] < rpm
+liblvm2cmd2_03 [2.03.05-3.26.x86_64] < lvm2
+liblz4-1 [1.8.0-3.5.1.x86_64] < systemd
+liblzma5 [5.2.3-4.3.1.x86_64] < rpm
+liblzo2-2 [2.10-2.22.x86_64] < btrfsprogs
+libmagic1 [5.32-7.5.1.x86_64] < rpm
+libmediacheck5 [5.3-1.46.x86_64] < checkmedia
+libmetalink3 [0.1.3-1.24.x86_64] < wget
+libmnl0 [1.0.4-1.25.x86_64] < iptables
+libmodman1 [2.0.1-1.27.x86_64] < libproxy1 < wget
+libmount1 [2.33.1-4.5.1.x86_64] < snapper
+libmozjs-60 [60.9.0-4.18.x86_64] < polkit
+libmtdev1 [1.1.5-1.26.x86_64] < libQt5Gui5 < libyui-qt-graph11
+libncurses6 [6.1-5.6.2.x86_64] < libyui-ncurses-pkg11
+libnetfilter_conntrack3 [1.0.7-1.22.x86_64] < xtables-plugins < iptables
+libnettle6 [3.4.1-4.9.1.x86_64] < xorg-x11-Xvnc
+libnfnetlink0 [1.0.1-2.11.x86_64] < xtables-plugins < iptables
+libnftnl11 [1.1.4-1.23.x86_64] < iptables
+libnghttp2-14 [1.39.2-8.31.x86_64] < libcurl4 < libzypp < libyui-ncurses-pkg11
+libnl-config [3.3.0-1.29.noarch] < libnl3-200 < open-lldp < fcoe-utils < yast2-fcoe-client < skelcd-control-leanos
+libnl3-200 [3.3.0-1.29.x86_64] < open-lldp < fcoe-utils < yast2-fcoe-client < skelcd-control-leanos
+libnpth0 [1.5-2.11.x86_64] < gpg2
+libnsl2 [1.2.0-2.44.x86_64] < pam
+libntfs-3g87 [2016.2.22-3.3.2.x86_64] < ntfsprogs
+libopeniscsiusr0_2_0 [2.0.876-13.32.1.x86_64] < open-iscsi
+libopenssl1_1 [1.1.1d-6.3.x86_64] < openssh
+libp11-kit0 [0.23.2-4.8.3.x86_64] < p11-kit
+libpango-1_0-0 [1.43.0-1.33.x86_64] < pango-tools
+libparted0 [3.2-11.3.1.x86_64] < parted
+libpci3 [3.5.6-1.18.x86_64] < pciutils
+libpciaccess0 [0.14-1.16.x86_64] < xorg-x11-server
+libpcre1 [8.41-4.20.x86_64] < wget
+libpcre2-16-0 [10.31-1.14.x86_64] < libQt5Core5 < libyui-qt-graph11
+libpixman-1-0 [0.34.0-1.27.x86_64] < xorg-x11-Xvnc
+libpng16-16 [1.6.34-3.9.1.x86_64] < libgdk_pixbuf-2_0-0 < icewm-lite
+libpolkit0 [0.116-1.26.x86_64] < polkit
+libpopt0 [1.16-3.22.x86_64] < cryptsetup
+libprocps7 [3.3.15-7.10.2.x86_64] < procps
+libproxy1 [0.4.15-2.15.x86_64] < wget
+libpsl5 [0.20.1-1.20.x86_64] < wget
+libpwquality1 [1.4.0-1.18.x86_64] < cryptsetup
+libpython3_6m1_0 [3.6.10-3.47.2.x86_64] < python3-base < python3-websockify
+libqrencode4 [4.0.0-1.17.x86_64] < systemd
+libreadline7 [7.0-9.10.1.x86_64] < multipath-tools
+libreiserfscore0 [3.6.27-2.24.x86_64] < btrfsprogs
+libruby2_5-2_5 [2.5.5-4.3.1.x86_64] < ruby2.5-rubygem-byebug < skelcd-control-leanos
+libsasl2-3 [2.1.26-5.3.1.x86_64] < libldap-2_4-2 < gpg2
+libseccomp2 [2.4.1-3.3.1.x86_64] < systemd
+libselinux1 [2.8-6.35.x86_64] < psmisc
+libsemanage1 [2.8-4.35.x86_64] < shadow
+libsepol1 [2.8-4.37.x86_64] < libsemanage1 < shadow
+libsgutils2-1_43-2 [1.44~763+19.1ed0757-9.3.1.x86_64] < sg3_utils
+libsigc-2_0-0 [2.10.2-1.2.x86_64] < libzypp < libyui-ncurses-pkg11
+libsmartcols1 [2.33.1-4.5.1.x86_64] < util-linux
+libsnapper5 [0.8.9-1.20.x86_64] < snapper
+libsnappy1 [1.1.3-1.24.x86_64] < makedumpfile < kdump < yast2-kdump < skelcd-control-leanos
+libsolv-tools [0.7.11-1.13.x86_64]
+libsqlite3-0 [3.28.0-3.9.2.x86_64] < gpg2
+libssh4 [0.8.7-10.9.1.x86_64] < libcurl4 < libzypp < libyui-ncurses-pkg11
+libstdc++6 [9.2.1+r275327-1.3.7.x86_64] < icewm-lite
+libstorage-ng-lang [4.2.65-1.2.noarch]
+libstorage-ng-ruby [4.2.65-1.2.x86_64] < yast2-storage-ng
+libstorage-ng1 [4.2.65-1.2.x86_64] < libstorage-ng-ruby < yast2-storage-ng
+libsystemd0 [234-31.10.x86_64] < rpcbind
+libtasn1 [4.13-4.5.1.x86_64] < libtasn1-6 < p11-kit
+libtasn1-6 [4.13-4.5.1.x86_64] < p11-kit
+libthai-data [0.1.27-1.16.x86_64] < libthai0 < libpango-1_0-0 < pango-tools
+libthai0 [0.1.27-1.16.x86_64] < libpango-1_0-0 < pango-tools
+libtiff5 [4.0.9-5.27.5.x86_64] < libgdk_pixbuf-2_0-0 < icewm-lite
+libtirpc-netconfig [1.0.2-3.8.1.x86_64] < libtirpc3 < rpcbind
+libtirpc3 [1.0.2-3.8.1.x86_64] < rpcbind
+libts0 [1.13-1.18.x86_64] < libQt5Gui5 < libyui-qt-graph11
+libudev1 [234-31.10.x86_64]
+libunistring2 [0.9.9-1.15.x86_64] < libgnutls30 < xorg-x11-Xvnc
+liburcu6 [0.10.0-2.20.x86_64] < multipath-tools
+libusb-1_0-0 [1.0.21-1.29.x86_64] < usbutils
+libutempter0 [1.1.6-3.42.x86_64] < xterm-bin
+libuuid1 [2.33.1-4.5.1.x86_64] < cryptsetup
+libverto1 [0.2.6-3.20.x86_64] < krb5
+libwacom-data [1.1-2.33.x86_64] < libwacom2 < libinput10 < xf86-input-libinput
+libwacom2 [1.1-2.33.x86_64] < libinput10 < xf86-input-libinput
+libwayland-client0 [1.18.0-1.2.x86_64] < Mesa-libEGL1
+libwayland-server0 [1.18.0-1.2.x86_64] < Mesa-libEGL1
+libwrap0 [7.6-1.433.x86_64] < rpcbind
+libx86emu3 [3.1-1.7.x86_64] < hwinfo
+libxcb-dri2-0 [1.13-3.3.1.x86_64] < Mesa-libGL1
+libxcb-dri3-0 [1.13-3.3.1.x86_64] < Mesa-libGL1
+libxcb-glx0 [1.13-3.3.1.x86_64] < Mesa-libGL1
+libxcb-icccm4 [0.4.1-1.24.x86_64] < libQt5Gui5 < libyui-qt-graph11
+libxcb-image0 [0.4.0-1.23.x86_64] < libQt5Gui5 < libyui-qt-graph11
+libxcb-keysyms1 [0.4.0-1.23.x86_64] < libQt5Gui5 < libyui-qt-graph11
+libxcb-present0 [1.13-3.3.1.x86_64] < Mesa-libGL1
+libxcb-randr0 [1.13-3.3.1.x86_64] < libQt5Gui5 < libyui-qt-graph11
+libxcb-render-util0 [0.3.9-1.23.x86_64] < libQt5Gui5 < libyui-qt-graph11
+libxcb-render0 [1.13-3.3.1.x86_64] < libQt5Gui5 < libyui-qt-graph11
+libxcb-shape0 [1.13-3.3.1.x86_64] < libQt5Gui5 < libyui-qt-graph11
+libxcb-shm0 [1.13-3.3.1.x86_64] < libQt5Gui5 < libyui-qt-graph11
+libxcb-sync1 [1.13-3.3.1.x86_64] < Mesa-libGL1
+libxcb-util1 [0.4.0-1.23.x86_64] < libxcb-image0 < libQt5Gui5 < libyui-qt-graph11
+libxcb-xfixes0 [1.13-3.3.1.x86_64] < Mesa-libEGL1
+libxcb-xinerama0 [1.13-3.3.1.x86_64] < libQt5Gui5 < libyui-qt-graph11
+libxcb-xinput0 [1.13-3.3.1.x86_64] < libQt5Gui5 < libyui-qt-graph11
+libxcb-xkb1 [1.13-3.3.1.x86_64] < libQt5Gui5 < libyui-qt-graph11
+libxcb1 [1.13-3.3.1.x86_64] < Mesa-libGL1
+libxkbcommon-x11-0 [0.8.2-3.3.1.x86_64] < libQt5Gui5 < libyui-qt-graph11
+libxkbcommon0 [0.8.2-3.3.1.x86_64] < libQt5Gui5 < libyui-qt-graph11
+libxkbfile1 [1.0.9-1.26.x86_64] < setxkbmap
+libxml2-2 [2.9.7-3.12.1.x86_64] < libsolv-tools
+libxshmfence1 [1.2-1.23.x86_64] < Mesa-libGL1
+libxslt-tools [1.1.32-3.3.1.x86_64] < autoyast2 < skelcd-control-leanos
+libxslt1 [1.1.32-3.3.1.x86_64] < libxslt-tools < autoyast2 < skelcd-control-leanos
+libxtables12 [1.8.3-1.20.x86_64] < iptables
+libyajl2 [2.1.0-2.12.x86_64] < xen-libs < kexec-tools < kdump < yast2-kdump < skelcd-control-leanos
+libyaml-0-2 [0.1.7-1.17.x86_64] < ruby2.5-stdlib < ruby2.5 < ruby
+libyui-ncurses-pkg11 [2.50.6-1.11.x86_64]
+libyui-ncurses11 [2.54.5-1.13.x86_64] < libyui-ncurses-pkg11
+libyui-qt-graph11 [2.46.0-1.37.x86_64]
+libyui-qt-pkg11 [2.47.3-1.13.x86_64]
+libyui-qt11 [2.52.2-1.11.x86_64] < libyui-qt-graph11
+libyui11 [3.9.3-1.5.x86_64] < libyui-ncurses-pkg11
+libz1 [1.2.11-3.9.1.x86_64] < openssh
+libzstd1 [1.4.4-1.11.x86_64] < rpm
+libzypp [17.23.0-1.4.x86_64] < libyui-ncurses-pkg11
+lklug-fonts [0.6-1.24.noarch]
+lsscsi [0.28-1.24.x86_64] < libstorage-ng1 < libstorage-ng-ruby < yast2-storage-ng
+ltrace [0.7.91-4.3.x86_64]
+lvm2 [2.03.05-3.26.x86_64]
+makedumpfile [1.6.7-1.6.x86_64] < kdump < yast2-kdump < skelcd-control-leanos
+mkfontdir [1.0.7-1.20.x86_64]
+mkfontscale [1.1.2-1.23.x86_64]
+multipath-tools [0.8.2+18.9ff73e7-1.49.x86_64]
+ncurses-utils [6.1-5.6.2.x86_64]
+net-tools [2.0+git20170221.479bb4a-3.11.x86_64] < SUSEConnect < yast2-registration < skelcd-control-leanos
+nfs-client [2.1.1-10.4.1.x86_64]
+noto-naskharabic-fonts [20170919-2.13.noarch]
+noto-sans-fonts [20170919-2.13.noarch]
+novnc [1.0.0-1.17.noarch]
+nscd [2.26-13.36.1.x86_64]
+ntfsprogs [2016.2.22-3.3.2.x86_64]
+open-iscsi [2.0.876-13.32.1.x86_64]
+open-lldp [1.0.1+56.cb81e95-1.27.x86_64] < fcoe-utils < yast2-fcoe-client < skelcd-control-leanos
+openslp [2.0.0-6.9.1.x86_64]
+openslp-server [2.0.0-6.9.1.x86_64]
+openssh [8.1p1-2.2.x86_64]
+openssh-fips [8.1p1-2.2.x86_64]
+openssl-1_1 [1.1.1d-6.3.x86_64] < xorg-x11-Xvnc
+p11-kit [0.23.2-4.8.3.x86_64]
+p11-kit-tools [0.23.2-4.8.3.x86_64]
+pam [1.3.0-6.9.2.x86_64]
+pam-modules [12.1-3.17.x86_64]
+pango-tools [1.43.0-1.33.x86_64]
+parted [3.2-11.3.1.x86_64]
+pciutils [3.5.6-1.18.x86_64]
+pciutils-ids [20190830-3.3.2.noarch]
+perl [5.26.1-7.9.1.x86_64]
+perl-Digest-SHA1 [2.13-1.27.x86_64] < yast2-users < skelcd-control-leanos
+perl-Parse-RecDescent [1.967015-1.22.x86_64] < perl-X500-DN < yast2-users < skelcd-control-leanos
+perl-X500-DN [0.29-1.22.x86_64] < yast2-users < skelcd-control-leanos
+perl-XML-Bare [0.53-1.28.x86_64]
+perl-XML-NamespaceSupport [1.12-1.24.noarch]
+perl-XML-Parser [2.44-1.443.x86_64] < perl-XML-SAX-Expat < perl-XML-Simple < yast2
+perl-XML-SAX [0.99-1.22.x86_64] < perl-XML-Simple < yast2
+perl-XML-SAX-Base [1.09-1.25.noarch] < perl-XML-SAX < perl-XML-Simple < yast2
+perl-XML-SAX-Expat [0.51-1.22.noarch] < perl-XML-Simple < yast2
+perl-XML-Simple [2.24-1.22.noarch] < yast2
+perl-base [5.26.1-7.9.1.x86_64]
+perl-gettext [1.07-1.442.x86_64]
+pigz [2.3.3-1.28.x86_64] < yast2-update < skelcd-control-leanos
+polkit [0.116-1.26.x86_64]
+procinfo [18-1.30.x86_64]
+procps [3.3.15-7.10.2.x86_64]
+psmisc [23.0-6.7.1.x86_64]
+python-rpm-macros [20200117.8e39013-3.8.1.noarch] < python3-base < python3-websockify
+python-websockify-common [0.8.0-7.14.noarch] < python3-websockify
+python3-base [3.6.10-3.47.2.x86_64] < python3-websockify
+python3-websockify [0.8.0-7.14.noarch]
+raleway-fonts [3.0-1.22.noarch]
+reiserfs [3.6.27-2.24.x86_64]
+rgb [1.0.6-1.22.x86_64]
+rpcbind [0.2.3-5.9.2.x86_64]
+rpm [4.14.1-17.10.x86_64]
+ruby [2.5-1.21.x86_64]
+ruby-common [2.1-3.15.noarch] < ruby2.5 < ruby
+ruby-solv [0.7.11-1.13.x86_64] < yast2-packager < skelcd-control-leanos
+ruby2.5 [2.5.5-4.3.1.x86_64] < ruby
+ruby2.5-rubygem-abstract_method [1.2.1-1.28.x86_64] < yast2
+ruby2.5-rubygem-byebug [9.1.0-1.28.x86_64] < skelcd-control-leanos
+ruby2.5-rubygem-cfa [1.0.2-1.13.x86_64] < yast2
+ruby2.5-rubygem-cfa_grub2 [2.0.0-1.35.x86_64] < yast2-bootloader < yast2-tune < skelcd-control-leanos
+ruby2.5-rubygem-cheetah [0.5.2-1.13.x86_64] < yast2
+ruby2.5-rubygem-fast_gettext [1.6.0-1.18.x86_64] < yast2-ruby-bindings < yast2-storage-ng
+ruby2.5-rubygem-gem2rpm [0.10.1-3.45.x86_64] < ruby-common < ruby2.5 < ruby
+ruby2.5-rubygem-ruby-augeas [0.5.0-1.31.x86_64] < ruby2.5-rubygem-cfa < yast2
+ruby2.5-rubygem-ruby-dbus [0.14.0-1.27.x86_64] < yast2-storage-ng
+ruby2.5-rubygem-simpleidn [0.0.9-1.17.x86_64] < yast2
+ruby2.5-stdlib [2.5.5-4.3.1.x86_64] < ruby2.5 < ruby
+sap-installation-wizard [4.1.16-3.6.1.x86_64]
+screen [4.6.2-3.14.x86_64]
+sed [4.4-2.11.x86_64]
+setxkbmap [1.3.1-1.24.x86_64]
+sg3_utils [1.44~763+19.1ed0757-9.3.1.x86_64]
+shadow [4.6-3.5.6.x86_64]
+skelcd-control-leanos [15.2.10-1.2.x86_64]
+skelcd-fallbackrepo-SLED [1.1-2.97.x86_64]
+skelcd-fallbackrepo-SLES [1.1-2.115.x86_64]
+skelcd-fallbackrepo-SLES_SAP [1.1-2.88.x86_64]
+skelcd-fallbackrepo-SLE_HPC [1.1-2.100.x86_64]
+skelcd-fallbackrepo-SLE_RT [1.1-2.100.x86_64]
+smartmontools [7.0-1.33.x86_64]
+snapper [0.8.9-1.20.x86_64]
+strace [5.3-1.26.x86_64]
+suse-module-tools [15.2.10-1.9.x86_64]
+sysconfig [0.85.3-3.3.1.x86_64] < yast2
+sysconfig-netconfig [0.85.3-3.3.1.x86_64] < wicked < wicked-service < sysconfig < yast2
+syslinux [4.04-8.14.x86_64]
+system-group-hardware [20170617-4.155.noarch] < util-linux
+system-user-nobody [20170617-4.155.noarch] < rpcbind
+system-user-root [20190513-3.3.1.noarch] < pam
+systemd [234-31.10.x86_64]
+systemd-presets-branding-SLE [15.1-18.10.noarch]
+systemd-presets-common-SUSE [15-6.10.noarch] < systemd-presets-branding-SLE
+systemd-sysvinit [234-31.10.x86_64]
+sysuser-shadow [2.0-2.151.noarch] < system-user-nobody < rpcbind
+sysvinit-tools [2.88+-1.26.x86_64]
+tar [1.30-3.3.2.x86_64] < yast2-installation
+terminfo-base [6.1-5.6.2.x86_64] < screen
+thai-fonts [0.6.1-2.39.noarch]
+thin-provisioning-tools [0.7.5-1.24.x86_64] < device-mapper
+timezone [2019c-3.23.1.x86_64]
+udftools [1.3-1.21.x86_64]
+unified-installer-release [15.2-1.28.noarch]
+usbutils [008-1.30.x86_64]
+util-linux [2.33.1-4.5.1.x86_64]
+util-linux-systemd [2.33.1-4.5.1.x86_64] < wicked < wicked-service < sysconfig < yast2
+vim [8.0.1568-5.3.1.x86_64]
+vim-data-common [8.0.1568-5.3.1.noarch] < vim
+wget [1.19.5-3.6.2.x86_64]
+wicked [0.6.62-1.2.x86_64] < wicked-service < sysconfig < yast2
+wicked-service [0.6.62-1.2.x86_64] < sysconfig < yast2
+xauth [1.0.10-1.24.x86_64]
+xbitmaps [1.1.1-1.20.noarch] < libXmu6 < xterm-bin
+xconsole [1.0.7-1.24.x86_64] < xdm
+xdm [1.1.11-13.6.1.x86_64]
+xdpyinfo [1.3.2-1.24.x86_64]
+xen-libs [4.13.0_08-1.2.x86_64] < kexec-tools < kdump < yast2-kdump < skelcd-control-leanos
+xf86-input-libinput [0.28.1-4.32.x86_64]
+xf86-input-wacom [0.34.2-3.3.4.x86_64]
+xf86-video-amdgpu [18.1.0-4.31.x86_64]
+xf86-video-fbdev [0.5.0-4.31.x86_64]
+xf86-video-intel [2.99.917+git8674.25c9a2fcc-5.19.x86_64]
+xf86-video-qxl [0.1.5-3.38.x86_64]
+xf86-video-vesa [2.4.0-3.31.x86_64]
+xfsdump [3.1.6-1.30.x86_64]
+xfsprogs [4.15.0-4.24.3.x86_64]
+xhost [1.0.7-1.29.x86_64]
+xinit [1.4.0-6.17.x86_64] < xorg-x11-Xvnc
+xkbcomp [1.4.1-1.9.x86_64]
+xkeyboard-config [2.23.1-3.6.1.noarch]
+xli [1.17+git20170726.0bb4fb4-1.26.x86_64] < xdm
+xmessage [1.0.4-1.25.x86_64] < xdm
+xmodmap [1.0.9-1.24.x86_64]
+xorg-x11-Xvnc [1.9.0-19.3.1.x86_64]
+xorg-x11-fonts [7.6-3.9.noarch]
+xorg-x11-fonts-core [7.6-3.9.noarch]
+xorg-x11-server [1.20.3-18.27.x86_64]
+xrandr [1.5.0-2.19.x86_64]
+xrefresh [1.0.5-1.23.x86_64]
+xset [1.2.3-2.17.x86_64]
+xsetroot [1.1.1-1.24.x86_64] < xdm
+xtables-plugins [1.8.3-1.20.x86_64] < iptables
+xterm-bin [330-2.22.x86_64]
+xz [5.2.3-4.3.1.x86_64]
+yast2 [4.2.67-1.7.x86_64]
+yast2-add-on [4.2.15-1.30.noarch] < skelcd-control-leanos
+yast2-bootloader [4.2.16-1.3.x86_64] < yast2-tune < skelcd-control-leanos
+yast2-buildtools [4.2.5-1.29.noarch]
+yast2-configuration-management [4.2.3-1.55.noarch] < skelcd-control-leanos
+yast2-core [4.1.0-5.18.x86_64] < yast2
+yast2-country [4.2.18-1.7.x86_64] < yast2-installation
+yast2-country-data [4.2.18-1.7.x86_64] < yast2-installation
+yast2-devtools [4.2.5-1.29.noarch]
+yast2-fcoe-client [4.2.2-1.7.noarch] < skelcd-control-leanos
+yast2-firewall [4.2.3-1.3.noarch] < skelcd-control-leanos
+yast2-hardware-detection [4.1.1-1.47.x86_64] < yast2
+yast2-installation [4.2.35-1.8.noarch]
+yast2-iscsi-client [4.2.4-1.31.noarch] < skelcd-control-leanos
+yast2-kdump [4.2.9-1.14.x86_64] < skelcd-control-leanos
+yast2-ldap [4.1.0-1.28.x86_64] < yast2-users < skelcd-control-leanos
+yast2-logs [4.2.67-1.7.x86_64] < yast2
+yast2-multipath [4.2.1-1.31.noarch] < skelcd-control-leanos
+yast2-network [4.2.57-1.3.noarch] < skelcd-control-leanos
+yast2-nfs-client [4.2.7-1.23.noarch] < skelcd-control-leanos
+yast2-nfs-common [4.2.4-1.25.noarch] < yast2-nfs-client < skelcd-control-leanos
+yast2-ntp-client [4.2.8-1.8.noarch] < skelcd-control-leanos
+yast2-packager [4.2.52-1.3.x86_64] < skelcd-control-leanos
+yast2-pam [4.2.4-1.34.noarch] < yast2-users < skelcd-control-leanos
+yast2-perl-bindings [4.1.0-1.18.x86_64] < yast2
+yast2-pkg-bindings [4.2.7-1.4.x86_64] < yast2-installation
+yast2-proxy [4.2.2-1.100.noarch] < skelcd-control-leanos
+yast2-rdp [4.2.1-1.109.noarch] < skelcd-control-leanos
+yast2-registration [4.2.35-1.6.noarch] < skelcd-control-leanos
+yast2-ruby-bindings [4.2.8-1.14.x86_64] < yast2-storage-ng
+yast2-schema [4.2.8-1.32.x86_64] < autoyast2 < skelcd-control-leanos
+yast2-security [4.2.11-1.7.noarch] < yast2-users < skelcd-control-leanos
+yast2-services-manager [4.2.5-1.93.noarch] < skelcd-control-leanos
+yast2-slp [4.1.1-1.100.x86_64] < skelcd-control-leanos
+yast2-storage-ng [4.2.90-1.7.x86_64]
+yast2-theme [4.2.8-1.22.noarch] < skelcd-control-leanos
+yast2-trans-stats [2.19.0-1.28.noarch] < skelcd-control-leanos
+yast2-transfer [4.1.0-1.28.x86_64] < yast2-packager < skelcd-control-leanos
+yast2-tune [4.2.2-1.52.x86_64] < skelcd-control-leanos
+yast2-update [4.2.17-1.5.x86_64] < skelcd-control-leanos
+yast2-users [4.2.9-1.19.x86_64] < skelcd-control-leanos
+yast2-vm [4.2.3-1.123.x86_64] < skelcd-control-leanos
+yast2-x11 [4.1.0-5.18.x86_64] < skelcd-control-leanos
+yast2-xml [4.1.1-1.17.x86_64] < yast2
+yast2-ycp-ui-bindings [4.2.9-1.13.x86_64] < yast2-storage-ng

--- a/test/inst_update_installer_test.rb
+++ b/test/inst_update_installer_test.rb
@@ -52,6 +52,7 @@ describe Yast::InstUpdateInstaller do
     allow(subject).to receive(:finish_packager)
     allow(subject).to receive(:fetch_profile).and_return(ay_profile)
     allow(subject).to receive(:process_profile)
+    allow(subject).to receive(:valid_repositories?).and_return(true)
     allow(finder).to receive(:add_installation_repo)
 
     # stub the Profile module to avoid dependency on autoyast2-installation

--- a/test/inst_update_installer_test.rb
+++ b/test/inst_update_installer_test.rb
@@ -26,7 +26,7 @@ describe Yast::InstUpdateInstaller do
   let(:all_signed?) { true }
   let(:network_running) { true }
   let(:has_repos) { true }
-  let(:repo) { double("repo", repo_id: 42) }
+  let(:repo) { double("repo", repo_id: 42, packages: []) }
   let(:repos) { [repo] }
   let(:restarting) { false }
   let(:profile) { {} }
@@ -334,10 +334,13 @@ describe Yast::InstUpdateInstaller do
         # expect(subject).to receive(:valid_repositories?).and_return(false)
         expect(manager).to_not receive(:apply_all)
         allow(Yast::Report).to receive(:Error)
+        # remove the global mock
+        allow(subject).to receive(:valid_repositories?).and_call_original
 
+        downgraded_pkg = double
         allow(Installation::InstsysPackages).to receive(:read).and_return([])
         allow_any_instance_of(Installation::SelfupdateVerifier).to receive(:downgraded_packages)
-          .and_return([])
+          .and_return([downgraded_pkg])
 
         subject.update_installer
       end

--- a/test/inst_update_installer_test.rb
+++ b/test/inst_update_installer_test.rb
@@ -327,5 +327,20 @@ describe Yast::InstUpdateInstaller do
         expect(subject.update_installer).to eq(false)
       end
     end
+
+    context "when the repository contains old packages" do
+      it "does not update the installer" do
+        allow(manager).to receive(:add_repository).and_return(true)
+        # expect(subject).to receive(:valid_repositories?).and_return(false)
+        expect(manager).to_not receive(:apply_all)
+        allow(Yast::Report).to receive(:Error)
+
+        allow(Installation::InstsysPackages).to receive(:read).and_return([])
+        allow_any_instance_of(Installation::SelfupdateVerifier).to receive(:downgraded_packages)
+          .and_return([])
+
+        subject.update_installer
+      end
+    end
   end
 end

--- a/test/instsys_packages_test.rb
+++ b/test/instsys_packages_test.rb
@@ -1,0 +1,37 @@
+#!/usr/bin/env rspec
+# ------------------------------------------------------------------------------
+# Copyright (c) 2020 SUSE LLC, All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of version 2 of the GNU General Public License as published by the
+# Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# ------------------------------------------------------------------------------
+
+require_relative "test_helper"
+
+require "installation/instsys_packages"
+
+describe Installation::InstsysPackages do
+
+  let(:test_file) { File.join(FIXTURES_DIR, "inst-sys", "packages.root") }
+
+  describe ".read" do
+    it "reads the packages from a file" do
+      pkgs = Installation::InstsysPackages.read(test_file)
+
+      expect(pkgs).to_not be_empty
+      expect(pkgs.first).to be_a(Y2Packager::Package)
+    end
+
+    it "reads the package versions" do
+      pkgs = Installation::InstsysPackages.read(test_file)
+      yast2 = pkgs.find { |p| p.name == "yast2" }
+
+      expect(yast2.version).to eq("4.2.67-1.7.x86_64")
+    end
+  end
+end

--- a/test/selfupdate_verifier_test.rb
+++ b/test/selfupdate_verifier_test.rb
@@ -36,8 +36,6 @@ describe Installation::SelfupdateVerifier do
   let(:downgraded_nony2_pkg) { create_package_resolvable("rpm", "3.1.2-1.2") }
   # this one is upgraded a bit
   let(:upgraded_pkg) { create_package_resolvable("yast2-installation", "4.2.37-1.1") }
-  # this one is upgraded too much
-  let(:too_new) { create_package_resolvable("yast2-packager", "4.3.11-1.3") }
 
   let(:instsys_packages) { Installation::InstsysPackages.read(test_file) }
 
@@ -45,19 +43,13 @@ describe Installation::SelfupdateVerifier do
 
   before do
     expect(repo).to receive(:packages).and_return(
-      [downgraded_pkg, upgraded_pkg, too_new, downgraded_nony2_pkg]
+      [downgraded_pkg, upgraded_pkg, downgraded_nony2_pkg]
     )
   end
 
   describe "#downgraded_packages" do
     it "returns the downgraded packages" do
       expect(subject.downgraded_packages).to eq([downgraded_pkg])
-    end
-  end
-
-  describe "#too_new_packages" do
-    it "returns the too new packages" do
-      expect(subject.too_new_packages).to eq([too_new])
     end
   end
 

--- a/test/selfupdate_verifier_test.rb
+++ b/test/selfupdate_verifier_test.rb
@@ -1,0 +1,64 @@
+#!/usr/bin/env rspec
+# ------------------------------------------------------------------------------
+# Copyright (c) 2020 SUSE LLC, All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of version 2 of the GNU General Public License as published by the
+# Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# ------------------------------------------------------------------------------
+
+require_relative "test_helper"
+
+require "uri"
+require "installation/selfupdate_verifier"
+require "installation/update_repository"
+require "installation/instsys_packages"
+require "y2packager/resolvable"
+
+def create_package_resolvable(name, version)
+  Y2Packager::Resolvable.new("kind" => :package, "name" => name, "source" => nil,
+    "version" => version, "arch" => "x86_64", "deps" => [])
+end
+
+describe Installation::SelfupdateVerifier do
+  let(:test_file) { File.join(FIXTURES_DIR, "inst-sys", "packages.root") }
+  let(:repo) do
+    Installation::UpdateRepository.new(URI("http://example.com"))
+  end
+
+  # this one is downgraded
+  let(:downgraded_pkg) { create_package_resolvable("yast2", "4.1.7-1.2") }
+  # downgraded non-YaST package
+  let(:downgraded_nony2_pkg) { create_package_resolvable("rpm", "3.1.2-1.2") }
+  # this one is upgraded a bit
+  let(:upgraded_pkg) { create_package_resolvable("yast2-installation", "4.2.37-1.1") }
+  # this one is upgraded too much
+  let(:too_new) { create_package_resolvable("yast2-packager", "4.3.11-1.3") }
+
+  let(:instsys_packages) { Installation::InstsysPackages.read(test_file) }
+
+  subject { Installation::SelfupdateVerifier.new([repo], instsys_packages) }
+
+  before do
+    expect(repo).to receive(:packages).and_return(
+      [downgraded_pkg, upgraded_pkg, too_new, downgraded_nony2_pkg]
+    )
+  end
+
+  describe "#downgraded_packages" do
+    it "returns the downgraded packages" do
+      expect(subject.downgraded_packages).to eq([downgraded_pkg])
+    end
+  end
+
+  describe "#too_new_packages" do
+    it "returns the too new packages" do
+      expect(subject.too_new_packages).to eq([too_new])
+    end
+  end
+
+end


### PR DESCRIPTION
## The Problem

- The inst-sys does not contain the RPM DB with the installed packages so the self-update code just blindly downloads and installs everything it finds without any dependency checks.
- YaST gets the self update repository URL either from the SCC or uses the default from the `control.xml`. This way ensures the self-update repository contains the right packages for the installer.
- However, users can use their custom self-update repository (e.g. SMT/RMT) and there is a possibility that by mistake the users could use a wrong repository, e.g. SP1 repository in SP2
- We got even an [L3 bug](https://bugzilla.suse.com/show_bug.cgi?id=1163084) with this mistake

## The Solution

- The inst-sys contains the list of the installed packages in the `/.packages.root` file
- To avoid false positives (as there might be a real package downgrade) we check only some YaST packages because their versions are under our control
- Before applying the self-update we check that the update versions are not older than the packages in the inst-sys
- It is possible to disable this sanity check by setting the environment variable `Y2_FORCE_SELF_UPDATE=1`, then the error is not displayed and the self-updates are applied. But this should be done only in special cases (testing) when you know what you are doing.

## Notes

Originally I also implemented a check for "too new" packages (e.g. using SP3 updates in the SP2 installer), but as this could potentially report some false positives I have removed that. Lets discuss that first...

## Testing 

- Tested manually (see the screenshot below)
- Added unit tests

## Screenshots

Using SP1 updates in the SP2 installer will result in this error message:

![self_update_error](https://user-images.githubusercontent.com/907998/76605823-6c0f1a80-6511-11ea-9f9e-7d3564d1d073.png)
