### PR TITLE
use LANG=UTF-8 in case of RC_LANG=POSIX

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Apr 17 16:10:19 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
+
+- Force the use of en_US.UTF-8 when running firstboot or the
+  AutoYaST Second Stage with 'POSIX' or 'C as RC_LANG (bsc#1169017)
+- 3.3.0.4
+
+-------------------------------------------------------------------
 Fri Mar 15 13:22:58 UTC 2019 - snwint@suse.com
 
 - revert SSH textmode patches (bsc#1129375, bsc#1047470)

--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -3,7 +3,7 @@ Fri Apr 17 16:10:19 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
 
 - Force the use of en_US.UTF-8 when running firstboot or the
   AutoYaST Second Stage with 'POSIX' or 'C as RC_LANG (bsc#1169017)
-- 3.3.0.4
+- 3.3.1
 
 -------------------------------------------------------------------
 Fri Mar 15 13:22:58 UTC 2019 - snwint@suse.com

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation
-Version:        3.3.0.4
+Version:        3.3.1
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation
-Version:        3.3.0.3
+Version:        3.3.0.4
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/startup/common/language.sh
+++ b/startup/common/language.sh
@@ -73,8 +73,13 @@ function set_language_cont () {
                 export RC_LANG=en_US
         fi
 
-        # get rid of encoding and/or modifier
-        export LANG=${RC_LANG%%[.@]*}.UTF-8
+        if [ "$RC_LANG" == "POSIX" ] ; then
+                log "\tRC_LANG is POSIX, using LANG en_US.UTF-8 as default..."
+                export LANG=en_US.UTF-8
+        else
+                # get rid of encoding and/or modifier
+                export LANG=${RC_LANG%%[.@]*}.UTF-8
+        fi
 }
 
 #----[ start_unicode ]-----#

--- a/startup/common/language.sh
+++ b/startup/common/language.sh
@@ -73,8 +73,8 @@ function set_language_cont () {
                 export RC_LANG=en_US
         fi
 
-        if [ "$RC_LANG" == "POSIX" ] ; then
-                log "\tRC_LANG is POSIX, using LANG en_US.UTF-8 as default..."
+        if [ "$RC_LANG" == "POSIX" ] || [ "$RC_LANG" == "C" ] ; then
+                log "\tRC_LANG is ${RC_LANG}, using LANG en_US.UTF-8 as default..."
                 export LANG=en_US.UTF-8
         else
                 # get rid of encoding and/or modifier


### PR DESCRIPTION
## Problem

- During firstboot, when RC_LANG is 'POSIX' we try to export LANG as POSIX.UTF-8 which is not valid.

- https://trello.com/c/eMiBCnv0/1813-sle12-sp4-l3-1169017-yast2-firstboot-cannot-configure-network-if-disabled-confused-by-posixutf-8

## Solution

- Fallback to en_US.UTF-8 when RC_LANG is 'POSIX' or 'C'