### PR TITLE
use LANG=UTF-8 in case RC_LANG is 'POSIX' or 'C'

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Apr 20 12:10:19 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
+
+- Force the use of en_US.UTF-8 when running firstboot or the
+  AutoYaST Second Stage with 'POSIX' or 'C as RC_LANG (bsc#1169017)
+- 4.0.76
+
+-------------------------------------------------------------------
 Fri May 10 15:07:17 CEST 2019 - schubi@suse.de
 
 - Downloading files: Remounting CD with bind option correctly if

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.0.75
+Version:        4.0.76
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/startup/common/language.sh
+++ b/startup/common/language.sh
@@ -73,8 +73,13 @@ function set_language_cont () {
                 export RC_LANG=en_US
         fi
 
-        # get rid of encoding and/or modifier
-        export LANG=${RC_LANG%%[.@]*}.UTF-8
+        if [ "$RC_LANG" == "POSIX" ] || [ "$RC_LANG" == "C" ] ; then
+                log "\tRC_LANG is ${RC_LANG}, using LANG en_US.UTF-8 as default..."
+                export LANG=en_US.UTF-8
+        else
+                # get rid of encoding and/or modifier
+                export LANG=${RC_LANG%%[.@]*}.UTF-8
+        fi
 }
 
 #----[ start_unicode ]-----#


### PR DESCRIPTION
It cherry picks #851 

I tried to sync SLE-12-SP5 but there are too many changes and some of them related to CaaSP, so, it seems we usually just cherry pick the changes.