### PR TITLE
Restore some missing icons

### DIFF
--- a/autoyast_desktop/deploy_image.desktop
+++ b/autoyast_desktop/deploy_image.desktop
@@ -18,7 +18,7 @@ X-SuSE-YaST-AutoInstSchema=deploy_image.rnc
 X-SuSE-YaST-AutoInstClonable=false
 X-SuSE-YaST-Keywords=image,deployment
 
-Icon=yast-deploy_image
+Icon=yast-image-deployment
 Exec=
 
 Name=Image deployment

--- a/autoyast_desktop/ssh_import.desktop
+++ b/autoyast_desktop/ssh_import.desktop
@@ -18,7 +18,7 @@ X-SuSE-YaST-AutoInstSchema=ssh_import.rnc
 X-SuSE-YaST-AutoInstClonable=true
 X-SuSE-YaST-Keywords=import,key,ssh,installation
 
-Icon=yast-ssh-server
+Icon=yast-ssh-import
 Exec=
 
 Name=SSH Key Import

--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue May  5 15:54:11 UTC 2020 - David Diaz <dgonzalez@suse.com>
+
+- Restore missing icons for ssh import and image deployment
+  auto clients (bsc#1168123).
+- 4.1.50
+
+-------------------------------------------------------------------
 Mon Apr 20 12:10:19 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
 
 - Force the use of en_US.UTF-8 when running firstboot or the

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.1.49
+Version:        4.1.50
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/icons/hicolor/scalable/apps/yast-image-deployment.svg
+++ b/src/icons/hicolor/scalable/apps/yast-image-deployment.svg
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg version="1.1" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+<metadata>
+<rdf:RDF>
+<cc:Work rdf:about="">
+<dc:format>image/svg+xml</dc:format>
+<dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+<dc:creator>
+<cc:Agent>
+<dc:title>Jakub Steiner</dc:title>
+</cc:Agent>
+</dc:creator>
+<dc:source>http://jimmac.musichall.cz</dc:source>
+<cc:license rdf:resource="http://creativecommons.org/licenses/by-sa/2.0/"/>
+<dc:title/>
+<dc:subject>
+<rdf:Bag>
+<rdf:li>apparmor</rdf:li>
+<rdf:li>novell</rdf:li>
+</rdf:Bag>
+</dc:subject>
+</cc:Work>
+<cc:License rdf:about="http://creativecommons.org/licenses/by-sa/2.0/">
+<cc:permits rdf:resource="http://web.resource.org/cc/Reproduction"/>
+<cc:permits rdf:resource="http://web.resource.org/cc/Distribution"/>
+<cc:requires rdf:resource="http://web.resource.org/cc/Notice"/>
+<cc:requires rdf:resource="http://web.resource.org/cc/Attribution"/>
+<cc:permits rdf:resource="http://web.resource.org/cc/DerivativeWorks"/>
+<cc:requires rdf:resource="http://web.resource.org/cc/ShareAlike"/>
+</cc:License>
+</rdf:RDF>
+</metadata>
+<g transform="matrix(.5 0 0 .5 0 8)">
+<path d="m8-6-6 10 6 2z" fill="#cdab8f"/>
+<path d="m56-6 6 10-6 2z" fill="#cdab8f"/>
+<rect x="8" y="-6" width="48" height="44" ry="0" fill="#cdab8f"/>
+<rect x="8" y="-6" width="48" height="40" ry="0" fill="#dec7b4"/>
+<rect x="22" y="-6" width="34" height="40" fill="#73ba25"/>
+<rect x="22" y="34" width="34" height="4" fill="#54881b"/>
+<path d="m26 24v14h12v-14l-6 4z" fill="#63452c" opacity=".2"/>
+<path d="m8-6-2 16h26v-16z" fill="#dec7b4"/>
+<path d="m22 10h36l-2-16h-34z" fill="#73ba25"/>
+<rect x="6" y="10" width="26" height="2" fill="#cdab8f"/>
+<rect x="22" y="10" width="36" height="2" fill="#54881b"/>
+</g>
+</svg>

--- a/src/icons/hicolor/scalable/apps/yast-ssh-import.svg
+++ b/src/icons/hicolor/scalable/apps/yast-ssh-import.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="32" height="32" version="1.1" viewBox="0 0 32 32.000002" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+<defs>
+<linearGradient id="a" x1="2" x2="30" y1="27" y2="27" gradientTransform="translate(0,-1)" gradientUnits="userSpaceOnUse">
+<stop stop-color="#5e5c64" offset="0"/>
+<stop stop-color="#9a9996" offset=".035714"/>
+<stop stop-color="#5e5c64" offset=".071429"/>
+<stop stop-color="#5e5c64" offset=".92857"/>
+<stop stop-color="#9a9996" offset=".96429"/>
+<stop stop-color="#5e5c64" offset="1"/>
+</linearGradient>
+</defs>
+<metadata>
+<rdf:RDF>
+<cc:Work rdf:about="">
+<dc:format>image/svg+xml</dc:format>
+<dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+<dc:title/>
+</cc:Work>
+</rdf:RDF>
+</metadata>
+<rect x="2" y="6" width="28" height="6" ry="1" fill="#5e5c64"/>
+<rect x="2" y="12" width="28" height="6" ry="1" fill="#5e5c64"/>
+<rect x="2" y="18" width="28" height="6" ry="1.0587" fill="#5e5c64"/>
+<rect x="2" y="23" width="28" height="5" ry="1" fill="url(#a)"/>
+<rect x="2" y="3" width="28" height="5" ry="1" fill="#9a9996"/>
+<rect x="2" y="9" width="28" height="5" ry="1" fill="#9a9996"/>
+<rect x="2" y="15" width="28" height="5" ry="1" fill="#9a9996"/>
+<rect x="2" y="21" width="28" height="5" ry="1" fill="#9a9996"/>
+<rect x="14" y="4" width="15" height="3" ry="0" fill="#3d3846"/>
+<rect x="14" y="5" width="15" height="2" ry="0" fill="#5e5c64"/>
+<rect x="14" y="10" width="15" height="3" ry="0" fill="#3d3846"/>
+<rect x="14" y="11" width="15" height="2" ry="0" fill="#5e5c64"/>
+<rect x="14" y="16" width="15" height="3" ry="0" fill="#3d3846"/>
+<rect x="14" y="17" width="15" height="2" ry="0" fill="#5e5c64"/>
+<rect x="14" y="22" width="15" height="3" ry="0" fill="#3d3846"/>
+<rect x="14" y="23" width="15" height="2" ry="0" fill="#5e5c64"/>
+<rect x="4" y="4" width="1" height="2" ry=".5" fill="#5e5c64"/>
+<rect x="4" y="5" width="1" height="1" ry=".5" fill="#f6d32d"/>
+<rect x="6" y="4" width="1" height="2" ry=".5" fill="#5e5c64"/>
+<rect x="6" y="5" width="1" height="1" ry=".5" fill="#33d17a"/>
+<rect x="4" y="10" width="1" height="2" ry=".5" fill="#5e5c64"/>
+<rect x="4" y="11" width="1" height="1" ry=".5" fill="#33d17a"/>
+<rect x="6" y="10" width="1" height="2" ry=".5" fill="#5e5c64"/>
+<rect x="6" y="11" width="1" height="1" ry=".5" fill="#e01b24"/>
+<rect x="4" y="16" width="1" height="2" ry=".5" fill="#5e5c64"/>
+<rect x="4" y="17" width="1" height="1" ry=".5" fill="#e01b24"/>
+<rect x="6" y="16" width="1" height="2" ry=".5" fill="#5e5c64"/>
+<rect x="6" y="17" width="1" height="1" ry=".5" fill="#f6d32d"/>
+<rect x="4" y="22" width="1" height="2" ry=".5" fill="#5e5c64"/>
+<rect x="4" y="23" width="1" height="1" ry=".5" fill="#f6d32d"/>
+<rect x="6" y="22" width="1" height="2" ry=".5" fill="#5e5c64"/>
+<rect x="6" y="23" width="1" height="1" ry=".5" fill="#33d17a"/>
+<rect x="15" y="11" width="1" height="2" fill="#3d3846"/>
+<rect x="15" y="10" width="1" height="1" fill="#241f31"/>
+<rect x="17" y="11" width="1" height="2" fill="#3d3846"/>
+<rect x="17" y="10" width="1" height="1" fill="#241f31"/>
+<rect x="19" y="11" width="1" height="2" fill="#3d3846"/>
+<rect x="19" y="10" width="1" height="1" fill="#241f31"/>
+<rect x="21" y="11" width="1" height="2" fill="#3d3846"/>
+<rect x="21" y="10" width="1" height="1" fill="#241f31"/>
+<rect x="23" y="11" width="1" height="2" fill="#3d3846"/>
+<rect x="23" y="10" width="1" height="1" fill="#241f31"/>
+<rect x="25" y="11" width="1" height="2" fill="#3d3846"/>
+<rect x="25" y="10" width="1" height="1" fill="#241f31"/>
+<rect x="27" y="11" width="1" height="2" fill="#3d3846"/>
+<rect x="27" y="10" width="1" height="1" fill="#241f31"/>
+<rect x="15" y="5" width="1" height="2" fill="#3d3846"/>
+<rect x="15" y="4" width="1" height="1" fill="#241f31"/>
+<rect x="17" y="5" width="1" height="2" fill="#3d3846"/>
+<rect x="17" y="4" width="1" height="1" fill="#241f31"/>
+<rect x="19" y="5" width="1" height="2" fill="#3d3846"/>
+<rect x="19" y="4" width="1" height="1" fill="#241f31"/>
+<rect x="21" y="5" width="1" height="2" fill="#3d3846"/>
+<rect x="21" y="4" width="1" height="1" fill="#241f31"/>
+<rect x="23" y="5" width="1" height="2" fill="#3d3846"/>
+<rect x="23" y="4" width="1" height="1" fill="#241f31"/>
+<rect x="25" y="5" width="1" height="2" fill="#3d3846"/>
+<rect x="25" y="4" width="1" height="1" fill="#241f31"/>
+<rect x="27" y="5" width="1" height="2" fill="#3d3846"/>
+<rect x="27" y="4" width="1" height="1" fill="#241f31"/>
+<rect x="15" y="17" width="1" height="2" fill="#3d3846"/>
+<rect x="15" y="16" width="1" height="1" fill="#241f31"/>
+<rect x="17" y="17" width="1" height="2" fill="#3d3846"/>
+<rect x="17" y="16" width="1" height="1" fill="#241f31"/>
+<rect x="19" y="17" width="1" height="2" fill="#3d3846"/>
+<rect x="19" y="16" width="1" height="1" fill="#241f31"/>
+<rect x="21" y="17" width="1" height="2" fill="#3d3846"/>
+<rect x="21" y="16" width="1" height="1" fill="#241f31"/>
+<rect x="23" y="17" width="1" height="2" fill="#3d3846"/>
+<rect x="23" y="16" width="1" height="1" fill="#241f31"/>
+<rect x="25" y="17" width="1" height="2" fill="#3d3846"/>
+<rect x="25" y="16" width="1" height="1" fill="#241f31"/>
+<rect x="27" y="17" width="1" height="2" fill="#3d3846"/>
+<rect x="27" y="16" width="1" height="1" fill="#241f31"/>
+<rect x="15" y="23" width="1" height="2" fill="#3d3846"/>
+<rect x="15" y="22" width="1" height="1" fill="#241f31"/>
+<rect x="17" y="23" width="1" height="2" fill="#3d3846"/>
+<rect x="17" y="22" width="1" height="1" fill="#241f31"/>
+<rect x="19" y="23" width="1" height="2" fill="#3d3846"/>
+<rect x="19" y="22" width="1" height="1" fill="#241f31"/>
+<rect x="21" y="23" width="1" height="2" fill="#3d3846"/>
+<rect x="21" y="22" width="1" height="1" fill="#241f31"/>
+<rect x="23" y="23" width="1" height="2" fill="#3d3846"/>
+<rect x="23" y="22" width="1" height="1" fill="#241f31"/>
+<rect x="25" y="23" width="1" height="2" fill="#3d3846"/>
+<rect x="25" y="22" width="1" height="1" fill="#241f31"/>
+<rect x="27" y="23" width="1" height="2" fill="#3d3846"/>
+<rect x="27" y="22" width="1" height="1" fill="#241f31"/>
+<rect x="16" y="16" width="16" height="16" ry="1" fill="#f6f5f4"/>
+<path d="m19.412 25a2.5 2.5 0 0 0 1.9922 -1h-1.9922a1.5 1.5 0 0 1 -1.4121 -1h-1.0312a2.5 2.5 0 0 0 2.4434 2z" fill="#3d3846"/>
+<path d="m22 23a2.5 2.5 0 0 0 -1.9922 1h1.9922a1.5 1.5 0 0 1 1.4121 1h1.0312a2.5 2.5 0 0 0 -2.4434 -2z" fill="#3d3846"/>
+<path d="m26 20v1.41l2.59 2.59-2.59 2.59v1.41l4-4z" fill="#3d3846"/>
+</svg>


### PR DESCRIPTION
## Problem

Despite some missing icons were already restored (see https://github.com/yast/yast-autoinstallation/pull/585), the bug report still open because icons for `Image deployment` and `SSH Key Import` are missing yet.

* https://trello.com/c/8rb9XQHD
* https://bugzilla.suse.com/show_bug.cgi?id=1168123
* https://bugzilla.opensuse.org/show_bug.cgi?id=1168281

## Solution

_Restore_ them using icons that were previously available in https://github.com/yast/yast-theme/commit/afa341066b9851808fbaa25756470cd119d41bfd

The icon for  `Image deployment`  is

> actually a copy of the scalable yast-software icon, since
different versions of `yast-deploy_image`were found, namely
> 
> 
> * 22x22 (a green box with a red `N`)
> 
>   yast/yast-theme@afa3410#diff-6c014aa4c0cb18ea190bfc7b2d2b70a8
> 
> * 32x32 (a link to yast-softare)
> 
>   yast/yast-theme@afa3410#diff-f4f629574b8285abe8d39a48cbd0df65
> 
> * 48x48 (a red box)
> 
>   yast/yast-theme@afa3410#diff-8afcb87d4731f202ea9d8b8cf0cf2567

## Tests

Tested manually

## Screenshots

![Screenshot from 2020-05-05 16-49-22](https://user-images.githubusercontent.com/1691872/81086451-6d950780-8ef0-11ea-9444-3791ec8407bf.png)

![Screenshot from 2020-05-05 16-49-36](https://user-images.githubusercontent.com/1691872/81086461-71c12500-8ef0-11ea-9f2f-cd38e12091c3.png)

