### PR TITLE
Replace some labels in the Previously Used Repositories dialog

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Jun 12 16:09:32 UTC 2020 - David Diaz <dgonzalez@suse.com>
+
+- Improve the UX of the Previously Used Repositories dialog by
+  using more accurate labels.
+
+-------------------------------------------------------------------
+
 Fri Jun 12 15:03:11 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
 
 - Remove ssh_import section from AY when cloning (bsc#1172749)

--- a/src/lib/installation/clients/inst_upgrade_urls.rb
+++ b/src/lib/installation/clients/inst_upgrade_urls.rb
@@ -31,6 +31,7 @@ Yast.import "Popup"
 Yast.import "Stage"
 Yast.import "UI"
 Yast.import "Wizard"
+Yast.import "String"
 
 module Yast
   # This client allows reusing the old repositories during system upgrade.
@@ -126,10 +127,10 @@ module Yast
           Left(
             HBox(
               # TRANSLATORS: Push button
-              PushButton(Id(:edit), _("&Change URL...")),
+              PushButton(Id(:edit), edit_button_label),
               HSpacing(1),
               # TRANSLATORS: Push button
-              PushButton(Id(:toggle), _("&Toggle Action")),
+              PushButton(Id(:toggle), toggle_button_label),
               HStretch()
             )
           )
@@ -161,6 +162,22 @@ module Yast
         # TRANSLATORS: The action to perform with a repository
         _("Keep")
       end
+    end
+
+    # Returns the label for the toggle button
+    #
+    # @return [String]
+    def toggle_button_label
+      # TRANSLATORS: the "Toggle Action" button label
+      _("&Toggle Action")
+    end
+
+    # Returns the label for the change url button
+    #
+    # @return [String]
+    def edit_button_label
+      # TRANSLATORS: the "Change URL" button label
+      _("&Change URL...")
     end
 
     def refresh_dialog
@@ -300,18 +317,16 @@ module Yast
         # TRANSLATORS: help text 1/3
         _("<p>Here you see all software repositories found on the system you are upgrading. " \
           "Enable the ones you want to include in the upgrade process.</p>"),
-        # TRANSLATORS: help text 2/3, %{change_action} is replaced by the button label
+        # TRANSLATORS: help text 2/3, %{toggle_action} is replaced by the button label
         format(
-          _("<p>To enable, remove or disable an URL, click the <b>%{change_action}</b> button " \
+          _("<p>To enable, remove or disable an URL, click the <b>%{toggle_action}</b> button " \
             "or double-click the respective table item.</p>"),
-          # TRANSLATORS: the "Toggle Action" button label
-          change_action: _("Toggle Action")
+          toggle_action: Yast::String.RemoveShortcut(toggle_button_label)
         ),
         # TRANSLATORS: help text 3/3, %{change_url} is replaced by the button label
         format(
           _("<p>To change the URL, click the <b>%{change_url}</b> button.</p>"),
-          # TRANSLATORS: the "Change URL" button label
-          change_url: _("Change URL...")
+          change_url: Yast::String.RemoveShortcut(edit_button_label)
         )
       ].join
     end

--- a/src/lib/installation/clients/inst_upgrade_urls.rb
+++ b/src/lib/installation/clients/inst_upgrade_urls.rb
@@ -126,7 +126,7 @@ module Yast
           Left(
             HBox(
               # TRANSLATORS: Push button
-              PushButton(Id(:edit), _("&Change...")),
+              PushButton(Id(:edit), _("&Change URL...")),
               HSpacing(1),
               # TRANSLATORS: Push button
               PushButton(Id(:toggle), _("&Toggle Action")),
@@ -143,7 +143,7 @@ module Yast
             "<p>To enable, remove or disable an URL, click the\n<b>Toggle Action</b> button or double-click the respective table item.</p>"
           ) +
           # TRANSLATORS: help text 3/3
-          _("<p>To change the URL, click the <b>Change...</b> button.</p>"),
+          _("<p>To change the URL, click the <b>Change URL...</b> button.</p>"),
         true,
         true
       )

--- a/src/lib/installation/clients/inst_upgrade_urls.rb
+++ b/src/lib/installation/clients/inst_upgrade_urls.rb
@@ -134,16 +134,7 @@ module Yast
             )
           )
         ),
-        # TRANSLATORS: help text 1/3
-        _(
-          "<p>Here you see all software repositories found\non the system you are upgrading. Enable the ones you want to include in the upgrade process.</p>"
-        ) +
-          # TRANSLATORS: help text 2/3
-          _(
-            "<p>To enable, remove or disable an URL, click the\n<b>Toggle Action</b> button or double-click the respective table item.</p>"
-          ) +
-          # TRANSLATORS: help text 3/3
-          _("<p>To change the URL, click the <b>Change URL...</b> button.</p>"),
+        help_text,
         true,
         true
       )
@@ -299,6 +290,30 @@ module Yast
     # @return [Boolean] `true` if running in the test mode, `false` otherwise
     def test?
       ENV["YAST_TEST"] == "1"
+    end
+
+    # Returns the help text for the dialog
+    #
+    # @return [String]
+    def help_text
+      [
+        # TRANSLATORS: help text 1/3
+        _("<p>Here you see all software repositories found on the system you are upgrading. " \
+          "Enable the ones you want to include in the upgrade process.</p>"),
+        # TRANSLATORS: help text 2/3, %{change_action} is replaced by the button label
+        format(
+          _("<p>To enable, remove or disable an URL, click the <b>%{change_action}</b> button " \
+            "or double-click the respective table item.</p>"),
+          # TRANSLATORS: the "Toggle Action" button label
+          change_action: _("Toggle Action")
+        ),
+        # TRANSLATORS: help text 3/3, %{change_url} is replaced by the button label
+        format(
+          _("<p>To change the URL, click the <b>%{change_url}</b> button.</p>"),
+          # TRANSLATORS: the "Change URL" button label
+          change_url: _("Change URL...")
+        )
+      ].join
     end
   end
 end

--- a/src/lib/installation/clients/inst_upgrade_urls.rb
+++ b/src/lib/installation/clients/inst_upgrade_urls.rb
@@ -115,7 +115,7 @@ module Yast
             Opt(:notify, :keepSorting),
             Header(
               # TRANSLATORS: Table header item
-              _("Current Status"),
+              _("Action"),
               # TRANSLATORS: Table header item
               _("Repository"),
               # TRANSLATORS: Table header item
@@ -129,7 +129,7 @@ module Yast
               PushButton(Id(:edit), _("&Change...")),
               HSpacing(1),
               # TRANSLATORS: Push button
-              PushButton(Id(:toggle), _("&Toggle Status")),
+              PushButton(Id(:toggle), _("&Toggle Action")),
               HStretch()
             )
           )
@@ -140,7 +140,7 @@ module Yast
         ) +
           # TRANSLATORS: help text 2/3
           _(
-            "<p>To enable, remove or disable an URL, click the\n<b>Toggle Status</b> button or double-click the respective table item.</p>"
+            "<p>To enable, remove or disable an URL, click the\n<b>Toggle Action</b> button or double-click the respective table item.</p>"
           ) +
           # TRANSLATORS: help text 3/3
           _("<p>To change the URL, click the <b>Change...</b> button.</p>"),
@@ -151,20 +151,24 @@ module Yast
       nil
     end
 
-    def translated_repo_status(status)
+    # Translated repository action, based on its status
+    #
+    # @param status [Symbol] the repository status
+    # @return [String] the action to perform with a repository
+    def repo_action(status)
       case status
       when :removed
-        # TRANSLATORS: The repository status
-        _("Removed")
-      when :disabled
-        # TRANSLATORS: The repository status
-        _("Disabled")
-      when :enabled
-        # TRANSLATORS: The repository status
-        _("Enabled")
+        # TRANSLATORS: The action to perform with a repository
+        _("Remove")
+      when :disable
+        # TRANSLATORS: The action to perform with a repository
+        _("Disable")
+      when :enable
+        # TRANSLATORS: The action to perform with a repository
+        _("Enable")
       else
-        # TRANSLATORS: The repository status is unknown
-        _("Unknown")
+        # TRANSLATORS: The repository status is unknown, none action will be taken
+        _("None")
       end
     end
 
@@ -174,7 +178,7 @@ module Yast
       items = repo_manager.repositories.map do |r|
         Item(
           Id(r.repo_alias),
-          translated_repo_status(repo_manager.repo_status(r)),
+          repo_action(repo_manager.repo_status(r)),
           r.name,
           repo_manager.repo_url(r)
         )

--- a/src/lib/installation/clients/inst_upgrade_urls.rb
+++ b/src/lib/installation/clients/inst_upgrade_urls.rb
@@ -167,8 +167,8 @@ module Yast
         # TRANSLATORS: The action to perform with a repository
         _("Enable")
       else
-        # TRANSLATORS: The repository status is unknown, none action will be taken
-        _("None")
+        # TRANSLATORS: The action to perform with a repository
+        _("Keep")
       end
     end
 

--- a/test/ssh_import_auto_test.rb
+++ b/test/ssh_import_auto_test.rb
@@ -32,8 +32,8 @@ describe ::Installation::SSHImportAutoClient do
           importer.add_config(fixtures_dir("root1"), "dev")
           expect(subject.run).to eq(
             "copy_config" => false,
-            "device" => "dev",
-            "import" => true
+            "device"      => "dev",
+            "import"      => true
           )
         end
       end


### PR DESCRIPTION
## Problem

While reviewing changes done in https://github.com/yast/yast-registration/pull/466, we decided to improve the UX (although I'd say _cognitive improvement_) by labeling slightly different the _Current Status_ column.

## Solution

To use _Action_ instead _Current Status_ and re-labeling accordingly.

| Before | After | 
|-|-|
| Current Status | Action |
| Toggle Status | Toggle Action |
| Change... | Change URL... |
| Removed  | Remove |
| Enabled | Enable |
| Disabled | Disable |
| Unknown | Keep |


## Notes

No version bump required

## Tests

Only tested manually

## Screenshots

<details>
<summary>Click to show/hide screenshots when running in graphical mode</summary>

---

| Dialog | Help |
|-|-|
| ![Screenshot_opensusetumbleweed_2020-06-12_15:43:48](https://user-images.githubusercontent.com/1691872/84515174-0541fe80-acc4-11ea-96fb-6e0e816c179e.png) | ![Screenshot_opensusetumbleweed_2020-06-12_15:43:57](https://user-images.githubusercontent.com/1691872/84515256-20147300-acc4-11ea-9449-8daebb6c04fb.png) |


</details>

<details>
<summary>Click to show/hide screenshots when running in text mode</summary>

---

| Dialog | Help |
|-|-|
| ![Screenshot_opensusetumbleweed_2020-06-12_14:29:06](https://user-images.githubusercontent.com/1691872/84507712-2a7d3f80-acb9-11ea-8bef-793be44f90d7.png) | ![Screenshot_opensusetumbleweed_2020-06-12_14:29:23](https://user-images.githubusercontent.com/1691872/84507733-310bb700-acb9-11ea-912f-ba1f5567da76.png) |


</details>

## Related links

* https://trello.com/c/BdAVUwtK/1614-1-change-previously-used-repositories-labels

