### PR TITLE
copy NVMe hostnqn and hostid

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Jun 25 11:07:53 CEST 2020 - aschnell@suse.com
+
+- copy NVMe hostnqn and hostid from installation system to target
+  system during installation (bsc#1172853)
+- 4.2.43
+
+-------------------------------------------------------------------
 Tue May  5 15:54:11 UTC 2020 - David Diaz <dgonzalez@suse.com>
 
 - Restore missing icons for ssh import and image deployment

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.2.42
+Version:        4.2.43
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/src/lib/installation/clients/copy_files_finish.rb
+++ b/src/lib/installation/clients/copy_files_finish.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-# Copyright (c) [2006-2019] SUSE LLC
+# Copyright (c) [2006-2020] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -73,6 +73,7 @@ module Yast
       copy_hardware_status
       copy_vnc
       copy_multipath
+      copy_nvme
       # Copy cio_ignore whitelist (bsc#1095033)
       copy_active_devices
 
@@ -269,6 +270,29 @@ module Yast
         next unless File.exist?(config_file)
 
         log.info "Copying multipath config file: '#{config_file}'"
+        target_path = File.join(Installation.destdir, config_file)
+        target_dir = File.dirname(target_path)
+        ::FileUtils.mkdir_p(target_dir) unless File.exist?(target_dir)
+        ::FileUtils.cp(config_file, target_path)
+      end
+    end
+
+    NVME_CONFIG_FILES = [
+      "/etc/nvme/hostnqn",
+      "/etc/nvme/hostid"
+    ].freeze
+
+    private_constant :NVME_CONFIG_FILES
+
+    def copy_nvme
+      # Only in install, as update should keep its config
+      return unless Mode.installation
+
+      # Copy NVMe config files (bsc #1172853)
+      NVME_CONFIG_FILES.each do |config_file|
+        next unless File.exist?(config_file)
+
+        log.info "Copying NVMe config file: '#{config_file}'"
         target_path = File.join(Installation.destdir, config_file)
         target_dir = File.dirname(target_path)
         ::FileUtils.mkdir_p(target_dir) unless File.exist?(target_dir)

--- a/test/copy_files_finish_test.rb
+++ b/test/copy_files_finish_test.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env rspec
 # encoding: utf-8
 
-# Copyright (c) [2018-2019] SUSE LLC
+# Copyright (c) [2018-2020] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -123,6 +123,18 @@ describe Yast::CopyFilesFinishClient do
       expect(::FileUtils).to receive(:cp).with("/etc/multipath.conf", "/mnt/etc/multipath.conf")
       expect(::FileUtils).to receive(:cp).with("/etc/multipath/bindings", "/mnt/etc/multipath/bindings")
       expect(::FileUtils).to receive(:cp).with("/etc/multipath/wwids", "/mnt/etc/multipath/wwids")
+
+      subject.write
+    end
+
+    it "copies NVMe config files in installation only" do
+      allow(Yast::Mode).to receive(:installation).and_return(true)
+      allow(::File).to receive(:exist?).with(/^\/etc\/nvme/).and_return(true)
+      allow(::File).to receive(:exist?).with(/^\/mnt\/etc\/nvme/).and_return(false)
+
+      expect(::FileUtils).to receive(:mkdir_p).with("/mnt/etc/nvme")
+      expect(::FileUtils).to receive(:cp).with("/etc/nvme/hostnqn", "/mnt/etc/nvme/hostnqn")
+      expect(::FileUtils).to receive(:cp).with("/etc/nvme/hostid", "/mnt/etc/nvme/hostid")
 
       subject.write
     end


### PR DESCRIPTION
Copy the NVMe hostnqn and hostid config files from the installation system to the target system during installation. Otherwise the nvme-cli package has generated different config files which can lead to trouble.

This patch does not generate the files during installation. That still has to be implemented.

For https://bugzilla.suse.com/show_bug.cgi?id=1172853 and https://trello.com/c/xHxU2p3J/1910-2-sles15-sp2-p2-1172853-no-nvme-hostnqn-or-hostid-in-the-install-system.