### PR TITLE
Fix "Cmdline: parameter not set" for virt-install (bsc#1172139)

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jun 25 13:24:45 UTC 2020 - Martin Vidner <mvidner@suse.com>
+
+- Fix "Cmdline: parameter not set" for virt-install (bsc#1172139)
+- 4.3.7
+
+-------------------------------------------------------------------
 Thu Jun 25 11:07:53 CEST 2020 - aschnell@suse.com
 
 - copy NVMe hostnqn and hostid from installation system to target

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.3.6
+Version:        4.3.7
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/startup/First-Stage/F08-logging
+++ b/startup/First-Stage/F08-logging
@@ -56,7 +56,7 @@ log "\tMaximum log count: $Y2MAXLOGNUM"
 # 8.3) Start sampling memory usage data
 #---------------------------------------------
 log "\tStart sampling memory usage data:"
-for WORD in ${Cmdline?}; do
+for WORD in ${Cmdline-}; do
     case $WORD in MEMSAMPLE=*) MEMSAMPLE=${WORD#MEMSAMPLE=};; esac
 done
 if [ "$MEMSAMPLE" = 0 ]; then


### PR DESCRIPTION
This is a fixup for #864.
For a normal installation, install.inf will declare `Cmdline` but @teclator found that virt-install will omit it. The installation will fail.