### PR TITLE
handle device autoconfig setting in summary screen (bsc#1168036)

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Jul 27 08:14:24 UTC 2020 - Steffen Winterfeldt <snwint@suse.com>
+
+- handle device autoconfig setting in summary screen (bsc#1168036)
+- 4.3.11
+
+-------------------------------------------------------------------
 Fri Jul 24 06:48:57 UTC 2020 - José Iván López González <jlopez@suse.com>
 
 - Configure the wizard layout according to the product features.

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.3.10
+Version:        4.3.11
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only


### PR DESCRIPTION
## Task

- https://bugzilla.suse.com/show_bug.cgi?id=1168036
- https://trello.com/c/if9ZgetC

yast should offer the option to turn off device autoconfig on s390. Similar to the cio settings.

## Related

This needs https://github.com/yast/yast-bootloader/pull/612 to make it possible to adjust the `rd.zdev` kernel option.

## Screenshots
![x1](https://user-images.githubusercontent.com/927244/87803146-670cff80-c852-11ea-896e-0e46c32d59c6.jpg)