### PR TITLE
Fix UpgradeRepoManager tests

### DIFF
--- a/test/lib/upgrade_repo_manager_test.rb
+++ b/test/lib/upgrade_repo_manager_test.rb
@@ -6,19 +6,19 @@ require "installation/upgrade_repo_manager"
 describe Installation::UpgradeRepoManager do
   let(:repo1) do
     Y2Packager::Repository.new(repo_id: 1, repo_alias: "test1",
-    url: "https://example.com/1", raw_url: "https://example.com/1",
+    url: URI("https://example.com/1"), raw_url: URI("https://example.com/1"),
     name: "repo1", enabled: true, autorefresh: true)
   end
 
   let(:repo2) do
     Y2Packager::Repository.new(repo_id: 2, repo_alias: "test2",
-    url: "https://example.com/2", raw_url: "https://example.com/2",
+    url: URI("https://example.com/2"), raw_url: URI("https://example.com/2"),
     name: "repo2", enabled: true, autorefresh: true)
   end
 
   let(:extra_repo) do
     Y2Packager::Repository.new(repo_id: 42, repo_alias: "extra",
-    url: "https://example.com/extra", raw_url: "https://example.com/extra",
+    url: URI("https://example.com/extra"), raw_url: URI("https://example.com/extra"),
     name: "extra", enabled: true, autorefresh: true)
   end
 
@@ -42,7 +42,7 @@ describe Installation::UpgradeRepoManager do
 
   describe "#repo_url" do
     it "returns the original raw URL if it has not been changed" do
-      expect(subject.repo_url(repo1)).to eq(repo1.raw_url)
+      expect(subject.repo_url(repo1)).to eq(repo1.raw_url.to_s)
     end
 
   end


### PR DESCRIPTION
Fix UpgradeRepoManager tests. It looks like a side effect of https://github.com/yast/yast-yast2/pull/1071.

Open question: do we need to adapt the `UpgradeRepoManager` API?