### PR TITLE
Use wizard layout

### DIFF
--- a/doc/control-file.md
+++ b/doc/control-file.md
@@ -4,10 +4,9 @@ Product Installation Control
 Functionality
 -------------
 
-The product control enables customization of the installation makes it
-possible to enable and disable features during installation in the final
-installed product. It controls the workflow and what is really shown to
-the user during installation.
+The product control file is used to customize the installation process.
+It allows to enable and disable features and it defines the workflow,
+that is, what is really shown to the user during the installation.
 
 Besides workflow configuration, other system variables are configurable
 and can be predefined by the system administrator. To name a few: the
@@ -475,6 +474,56 @@ installation and debugging:
     write more debug logs and some more debugging features in the
     workflow. The default is *false*. This feature should be off in the
     production phase.
+
+### Look & Feel
+
+The *globals* section also offers some settings to configure the layout of the
+installer. There are three possible layouts:
+
+* With a left sidebar including the list of installation steps.
+* Without a sidebar and placing the title of the dialogs on the left side.
+* Without a sidebar and placing the title of the dialogs on top.
+
+These settings can be used for configuring the layout:
+
+-   (string) *installation_ui* - only accepts *sidebar* value. When used, the
+    layout is configured to include a left sidebar with the installation steps.
+    This setting is deprecated in favor of *installation_layout*.
+
+-   *installation_layout*: this section includes a set of individual settings
+    to configure the layout.
+
+In the *installation_layout* section, these settings are available:
+
+-   (string) *mode* - configures the layout mode and accepts these values:
+    *steps*, *title-on-left* and *title-on-top*.
+-   (boolean) *banner* - indicates whether a top banner should be included.
+    The banner is typically used for placing a logo.
+
+Note that *installation_layout* takes precedence over *installation_ui*. When
+nothing is configured, the default layout is rendered with title on the left and
+with the top banner (SLE flavor).
+
+Some examples of layout configuration:
+
+```xml
+<globals>
+    <!-- installation_ui is ignored because installation_layout is used -->
+    <installation_ui>sidebar</installation_ui>
+    <installation_layout>
+        <mode>title-on-top</mode>
+        <banner config:type="boolean">true</banner>
+    </installation_layout>
+</globals>
+```
+
+```xml
+<globals>
+    <!-- installation_ui is used because nothing is defined by installation_layout -->
+    <installation_ui>sidebar</installation_ui>
+    <installation_layout></installation_layout>
+</globals>
+```
 
 ### Software
 

--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Jul 24 06:48:57 UTC 2020 - José Iván López González <jlopez@suse.com>
+
+- Configure the wizard layout according to the product features.
+- Related to jsc#PM-1998.
+- 4.3.10
+
+-------------------------------------------------------------------
 Thu Jul 16 11:01:42 CEST 2020 - schubi@suse.de
 
 - Moving <files> section handling from second installation stage

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.3.9
+Version:        4.3.10
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -73,8 +73,8 @@ Requires:       yast2-proxy
 # Systemd default target and services. This version supports
 # writing settings in the first installation stage.
 Requires:       yast2-services-manager >= 3.2.1
-# Yast::OSRelease.ReleaseVersionHumanReadable
-Requires:       yast2 >= 4.2.56
+# UI::Wizards::Layout
+Requires:       yast2 >= 4.3.16
 # Y2Network::NtpServer
 Requires:       yast2-network >= 4.2.55
 # for AbortException and handle direct abort


### PR DESCRIPTION
## Problem

YaST installer and YaST Firstboot look very different because they are using different layout configuration.

YaST installer allows a limited configuration of its layout by using the *installation_ui* setting in the control file. Now there are more possible layout configurations thanks to the new *installation_layout* settings, see https://github.com/yast/yast-installation-control/pull/99.

* Part of https://trello.com/c/cWUeijfl/1962-2-round-unify-firstboot-look-and-feel-with-installer
* Related to https://jira.suse.com/browse/PM-1998

## Solution

There is a new helper class (`UI::Wizards::Layout`) provided by *yast2* that allows to configure the layout according to the control file settings. That class is now used to configure the layout.

* See https://github.com/yast/yast-yast2/pull/1080
* See https://github.com/yast/yast-installation-control/pull/99

## Testing

* Manually tested.