### PR TITLE
save random pool to /var/lib/systemd/random-seed (bsc#1174964)

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Aug 24 09:23:09 UTC 2020 - Steffen Winterfeldt <snwint@suse.com>
+
+- save random pool to /var/lib/systemd/random-seed (bsc#1174964)
+- 4.2.45
+
+-------------------------------------------------------------------
 Fri Aug 14 10:55:53 UTC 2020 - Steffen Winterfeldt <snwint@suse.com>
 
 - handle device autoconfig setting in summary screen (bsc#1168036)

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.2.44
+Version:        4.2.45
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/src/lib/installation/clients/pre_umount_finish.rb
+++ b/src/lib/installation/clients/pre_umount_finish.rb
@@ -107,7 +107,7 @@ module Installation
 
       log.info "Saving the current randomness state..."
 
-      store_to = "#{Installation.destdir}/var/lib/misc/random-seed"
+      store_to = "#{Installation.destdir}/var/lib/systemd/random-seed"
 
       # Copy the current state of random number generator to the installed system
       if local_command(


### PR DESCRIPTION
## Task

- https://trello.com/c/uvvRtBXL
- https://bugzilla.suse.com/show_bug.cgi?id=1174964

Save random pool for systemd to the correct location `/var/lib/systemd/random-seed`.

## Rationale

Why not call `/usr/lib/systemd/systemd-random-seed save`?

- `systemd-random-seed` is not documented and it's in systemd's private `/usr/lib/systemd` dir - so its interface might change
- `/var/lib/systemd/random-seed` is quite stable (unchanged since we introduced systemd in SLE12)
- our use case here is copying the random seed from one system to another while  `systemd-random-seed` saves and loads it on the same system