### PR TITLE
save random pool to /var/lib/systemd/random-seed (bsc#1174964)

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Aug 24 09:35:13 UTC 2020 - Steffen Winterfeldt <snwint@suse.com>
+
+- save random pool to /var/lib/systemd/random-seed (bsc#1174964)
+- 4.3.15
+
+-------------------------------------------------------------------
 Tue Aug 11 10:33:04 CEST 2020 - schubi@suse.de
 
 - AutoYaST: Added supplements: autoyast(deploy_image,ssh_import)

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.3.14
+Version:        4.3.15
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only
@@ -49,6 +49,7 @@ BuildRequires:  yast2-network >= 4.2.55
 BuildRequires:  yast2-users >= 3.2.8
 # storage-ng based version
 BuildRequires:  yast2-country >= 3.3.1
+BuildRequires:  yast2-bootloader
 
 PreReq:         %fillup_prereq
 Requires:       yast2-users >= 3.2.8

--- a/src/lib/installation/clients/pre_umount_finish.rb
+++ b/src/lib/installation/clients/pre_umount_finish.rb
@@ -107,7 +107,7 @@ module Installation
 
       log.info "Saving the current randomness state..."
 
-      store_to = "#{Installation.destdir}/var/lib/misc/random-seed"
+      store_to = "#{Installation.destdir}/var/lib/systemd/random-seed"
 
       # Copy the current state of random number generator to the installed system
       if local_command(


### PR DESCRIPTION
## Task

Port https://github.com/yast/yast-installation/pull/883 to `master` branch.

## Original Task

- https://trello.com/c/uvvRtBXL
- https://bugzilla.suse.com/show_bug.cgi?id=1174964

Save random pool for systemd to the correct location `/var/lib/systemd/random-seed`.

## Rationale

Why not call `/usr/lib/systemd/systemd-random-seed save`?

- `systemd-random-seed` is not documented and it's in systemd's private `/usr/lib/systemd` dir - so its interface might change
- `/var/lib/systemd/random-seed` is quite stable (unchanged since we introduced systemd in SLE12)
- our use case here is copying the random seed from one system to another while  `systemd-random-seed` saves and loads it on the same system