### PR TITLE
Write the self-update packages to `/.packages.self_update` (bsc#1175614)

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Sep  1 14:58:31 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
+
+- Self-update improvement: write the list of updated packages to
+  the /.packages.self_update file in the inst-sys (bsc#1175614)
+- 4.3.16
+
+-------------------------------------------------------------------
 Mon Aug 24 09:35:13 UTC 2020 - Steffen Winterfeldt <snwint@suse.com>
 
 - save random pool to /var/lib/systemd/random-seed (bsc#1174964)

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.3.15
+Version:        4.3.16
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only


### PR DESCRIPTION
## The Problem

- See https://bugzilla.suse.com/show_bug.cgi?id=1175614
- The inst-sys contains the list of included packages (and their versions) in the `/.packages.*` files
- However, after YaST applies the self-update packages that is not true anymore
- Additionally it would help with debugging some problems if we could quickly get the list of updated packages in the inst-sys (could be used for debugging bug https://bugzilla.suse.com/show_bug.cgi?id=1175374)

## The Solution

- Write the list of the updated packages to the `/.packages.self_update` file using the same format as the installation-images use for the other `/.packages.*` files.

## Testing

- Added a unit test
- Manually tested in the SP2 installer, after running the self-update step the `/.packages.self_update` file contained these lines:
```
libsolv-tools [0.7.14-3.5.1.x86_64]
libstorage-ng-ruby [4.2.76-3.3.2.x86_64]
libstorage-ng1 [4.2.76-3.3.2.x86_64]
libzypp [17.24.1-3.11.1.x86_64]
release-notes-sles [15.2.20200729-3.3.1.noarch]
skelcd-control-leanos [15.2.12-3.3.1.x86_64]
yast2-installation [4.2.43-3.3.1.noarch]
yast2-packager [4.2.64-3.3.4.x86_64]
yast2-pkg-bindings [4.2.8-3.3.4.x86_64]
yast2-storage-ng [4.2.111-3.4.2.x86_64]
```

