### PR TITLE
yupdate - make also /usr/share/icons writable

### DIFF
--- a/bin/yupdate
+++ b/bin/yupdate
@@ -35,7 +35,7 @@ module YUpdate
   class Version
     MAJOR = 0
     MINOR = 1
-    PATCH = 1
+    PATCH = 2
 
     STRING = "#{MAJOR}.#{MINOR}.#{PATCH}".freeze
   end
@@ -187,7 +187,8 @@ HELP
       "/usr/lib/YaST2",
       "/usr/lib64/YaST2",
       "/usr/share/autoinstall",
-      "/usr/share/applications/YaST2"
+      "/usr/share/applications/YaST2",
+      "/usr/share/icons"
     ].freeze
 
     attr_reader :dir, :orig_dir

--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Oct 27 15:36:13 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
+
+- yupdate - also make /usr/share/icons writable by default
+  (needed for updating yast2-theme)
+
+-------------------------------------------------------------------
 Fri Oct 16 06:28:53 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Run configuration_management_finish client after *.repo files


### PR DESCRIPTION
- It is needed for updating yast2-theme
- No package version bump, let's release it with other "real" fix