### PR TITLE
AY: write linuxrc proxy and hostname to inst-sys

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Oct 27 22:30:43 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
+
+- Write hostname and proxy configuration to the inst-sys when
+  configured through linuxrc not only during an installation but
+  also when running an autoinstallation (bsc#1177768)
+- 4.2.47
+
+-------------------------------------------------------------------
 Fri Oct  9 15:04:33 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Run configuration_management_finish client after *.repo files

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.2.46
+Version:        4.2.47
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/src/lib/installation/clients/inst_install_inf.rb
+++ b/src/lib/installation/clients/inst_install_inf.rb
@@ -16,7 +16,9 @@ module Yast
     def main
       textdomain "installation"
 
-      InstallInfConvertor.instance.write_netconfig unless Mode.auto
+      InstallInfConvertor.instance.write_netconfig
+
+      return :next if Mode.auto
 
       Yast::Wizard.CreateDialog if separate_wizard_needed?
 

--- a/test/inst_install_inf_test.rb
+++ b/test/inst_install_inf_test.rb
@@ -4,13 +4,14 @@ require_relative "test_helper"
 require "installation/clients/inst_install_inf"
 
 describe Yast::InstInstallInfClient do
+  let(:auto) { false }
 
   before do
     allow(Yast::InstallInfConvertor.instance).to receive(:write_netconfig)
     allow(Yast::SCR).to receive(:Read)
     allow(Yast::SCR).to receive(:Write)
     allow(Yast::Linuxrc).to receive(:InstallInf)
-    allow(Yast::Mode).to receive(:auto)
+    allow(Yast::Mode).to receive(:auto).and_return(auto)
   end
 
   describe "#main" do
@@ -24,18 +25,20 @@ describe Yast::InstInstallInfClient do
       let(:invalid_url) { "http://wrong_url{}.com" }
       let(:valid_url) { "https://scc.custom.com" }
 
-      it "allows the user to fix it it's invalid" do
-        expect(Yast::Linuxrc).to receive(:InstallInf).with("regurl").and_return(invalid_url)
-        expect(subject).to receive(:fix_regurl!).with(invalid_url)
+      context "and not running an autoinstallation" do
+        it "allows the user to fix it it's invalid" do
+          expect(Yast::Linuxrc).to receive(:InstallInf).with("regurl").and_return(invalid_url)
+          expect(subject).to receive(:fix_regurl!).with(invalid_url)
 
-        subject.main
-      end
+          subject.main
+        end
 
-      it "does nothing with the URL in case of valid" do
-        expect(Yast::Linuxrc).to receive(:InstallInf).with("regurl").and_return(valid_url)
-        expect(subject).to_not receive(:fix_regurl!)
+        it "does nothing with the URL in case of valid" do
+          expect(Yast::Linuxrc).to receive(:InstallInf).with("regurl").and_return(valid_url)
+          expect(subject).to_not receive(:fix_regurl!)
 
-        subject.main
+          subject.main
+        end
       end
     end
 


### PR DESCRIPTION
## Problem

During an autoinstallation, if the networking section only contains the [keep_install_network](https://documentation.suse.com/sles/15-SP2/single-html/SLES-autoyast/#CreateProfile-Network) option it should copy the network configuration from linuxrc to the target system. This is not the case of the hostname option which is lost.

- https://bugzilla.suse.com/show_bug.cgi?id=1177768

## Solution

Write the linuxrc hostname and proxy configuration also during an autoinstallation.

It needs https://github.com/yast/skelcd-control-leanos/pull/67 in order to be run.