### PR TITLE
fix full media product selection (bsc#1179094, bsc#1176424)

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Nov 26 14:06:30 UTC 2020 - Steffen Winterfeldt <snwint@suse.com>
+
+- fix full media product selection (bsc#1179094, bsc#1176424)
+- 4.3.21
+
+-------------------------------------------------------------------
 Tue Oct 27 22:30:43 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
 
 - Write hostname and proxy configuration to the inst-sys when

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.3.20
+Version:        4.3.21
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/src/lib/installation/dialogs/complex_welcome.rb
+++ b/src/lib/installation/dialogs/complex_welcome.rb
@@ -133,11 +133,11 @@ module Installation
 
       # Determine whether the license must be shown
       #
-      # The license will be shown when only one product is available.
+      # The license will be shown when only one product with license information is available.
       #
       # @return [Boolean] true if the license must be shown; false otherwise
       def show_license?
-        products.size == 1
+        products.size == 1 && products.first.respond_to?(:license)
       end
 
       # Determine whether some product is available or not

--- a/test/dialogs/complex_welcome_test.rb
+++ b/test/dialogs/complex_welcome_test.rb
@@ -4,6 +4,22 @@ require_relative "../test_helper"
 require "installation/dialogs/complex_welcome"
 
 describe Installation::Dialogs::ComplexWelcome do
+  RSpec.shared_examples "show_license" do
+    it "shows the product license" do
+      expect(Y2Packager::Widgets::ProductLicense).to receive(:new)
+        .with(products.first, skip_validation: true).and_return(license_widget)
+      expect(widget.contents.to_s).to include("license_widget")
+    end
+  end
+
+  RSpec.shared_examples "show_selector" do
+    it "shows the product selector" do
+      expect(Installation::Widgets::ProductSelector).to receive(:new)
+        .with(products, skip_validation: true)
+      expect(widget.contents.to_s).to include("selector_widget")
+    end
+  end
+
   subject(:widget) { described_class.new(products) }
 
   let(:products) { [] }
@@ -27,7 +43,14 @@ describe Installation::Dialogs::ComplexWelcome do
   end
 
   describe "#content" do
-    let(:sles_product) { instance_double("Y2Packager::Product", label: "SLES") }
+    let(:license) { instance_double("Y2Packager::ProductLicense") }
+    # there are 3 different 'product' classes: Y2Packager::Product, Y2Packager::ProductControlProduct, Y2Packager::ProductLocation
+    let(:sles_product) { instance_double("Y2Packager::Product", label: "SLES", license: license) }
+    let(:sles_online_product) { instance_double("Y2Packager::ProductControlProduct", label: "SLES", license: license) }
+    let(:sles_offline_product) { instance_double("Y2Packager::ProductLocation", label: "SLES") }
+    let(:sled_product) { instance_double("Y2Packager::Product", label: "SLED", license: license) }
+    let(:sled_online_product) { instance_double("Y2Packager::ProductControlProduct", label: "SLED", license: license) }
+    let(:sled_offline_product) { instance_double("Y2Packager::ProductLocation", label: "SLED") }
     let(:language_widget) { Yast::Term.new(:language_widget) }
     let(:keyboard_widget) { Yast::Term.new(:keyboard_widget) }
     let(:license_widget) { Yast::Term.new(:license_widget) }
@@ -50,23 +73,32 @@ describe Installation::Dialogs::ComplexWelcome do
     end
 
     context "when only 1 product is available" do
-      let(:products) { [sles_product] }
-
-      it "shows the product license" do
-        expect(Y2Packager::Widgets::ProductLicense).to receive(:new)
-          .with(products.first, skip_validation: true).and_return(license_widget)
-        expect(widget.contents.to_s).to include("license_widget")
+      context "when it is the normal medium" do
+        let(:products) { [sles_product] }
+        include_examples "show_license"
+      end
+      context "when it is the online medium" do
+        let(:products) { [sles_online_product] }
+        include_examples "show_license"
+      end
+      context "when it is the offline medium" do
+        let(:products) { [sles_offline_product] }
+        include_examples "show_selector"
       end
     end
 
     context "when more than 1 product is available" do
-      let(:sled_product) { instance_double("Y2Packager::Product", label: "SLED") }
-      let(:products) { [sles_product, sled_product] }
-
-      it "shows the product selector" do
-        expect(Installation::Widgets::ProductSelector).to receive(:new)
-          .with(products, skip_validation: true)
-        expect(widget.contents.to_s).to include("selector_widget")
+      context "when it is the normal medium" do
+        let(:products) { [sles_product, sled_product] }
+        include_examples "show_selector"
+      end
+      context "when it is the online medium" do
+        let(:products) { [sles_online_product, sled_online_product] }
+        include_examples "show_selector"
+      end
+      context "when it is the offline medium" do
+        let(:products) { [sles_offline_product, sled_offline_product] }
+        include_examples "show_selector"
       end
     end
   end


### PR DESCRIPTION
## Problem

- https://trello.com/c/3NmLtDUr
- https://bugzilla.suse.com/show_bug.cgi?id=1179094
- https://bugzilla.suse.com/show_bug.cgi?id=1176424

When the full media contain only a single product, yast crashes trying to display the license.

## Analysis

The problem starts here:

- https://github.com/yast/yast-installation/blob/master/src/lib/installation/clients/inst_complex_welcome.rb#L172-L198

`available_base_products` returns the list of products but for the offline media ('full media') the returned type is a list of `Y2Packager::ProductLocation` classes which are not compatible with `Y2Packager::Product` which might also be returned and are in fact implicitly assumed in (part of) the code.

The issue arises when there's only a single product as then yast tries to skip the product selection and to show a license confirmation instead on the first screen.

## Solution

For offline media, enforce the product selection, even if there's only a single product. The license will be available later when the product dir is accessed.

## Tests

Tested with SLE15-SP3, SLE15-SP2, Leap 15.2, and Tumbleweed.

## Comment

Not sure why `Y2Packager::ProductLocation` doesn't also have the `ProductLicenseMixin` (and would provide the license).