### PR TITLE
bsc#1180142: do not use 'installation-helper' to create snapshots

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Dec 21 10:44:22 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Do not crash when it is not possible to create a snapshot after
+  installing or upgrading the system (bsc#1180142).
+- 4.1.51
+
+-------------------------------------------------------------------
 Tue May  5 15:54:11 UTC 2020 - David Diaz <dgonzalez@suse.com>
 
 - Restore missing icons for ssh import and image deployment

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.1.50
+Version:        4.1.51
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -42,9 +42,9 @@ BuildRequires:  yast2-xml
 BuildRequires:  rubygem(rspec)
 BuildRequires:  rubygem(yast-rake)
 
-# Yast::Execute.stdout
-BuildRequires:  yast2 >= 4.1.42
-Requires:       yast2 >= 4.1.42
+# Yast2::FsSnapshotStore::IOError
+BuildRequires:  yast2 >= 4.1.80
+Requires:       yast2 >= 4.1.80
 
 # Y2Packager::KnownRepositories
 BuildRequires:	yast2-packager >= 4.1.27

--- a/src/lib/installation/snapshots_finish.rb
+++ b/src/lib/installation/snapshots_finish.rb
@@ -53,7 +53,7 @@ module Installation
       Yast2::FsSnapshot.create_post("after update", pre_number, cleanup: :number, important: true)
       Yast2::FsSnapshotStore.clean("update")
       true
-    rescue Yast2::SnapshotCreationFailed, Yast2::FsSnapshotsStore::IOError => error
+    rescue Yast2::SnapshotCreationFailed, Yast2::FsSnapshotStore::IOError => error
       log.error("Error creating a post-update snapshot: #{error}")
       Yast::Report.Error(_("Could not create a post-update snapshot."))
       false

--- a/src/lib/installation/snapshots_finish.rb
+++ b/src/lib/installation/snapshots_finish.rb
@@ -12,6 +12,7 @@ module Installation
 
       Yast.import "Mode"
       Yast.import "InstFunctions"
+      Yast.import "Report"
       Yast.include self, "installation/misc.rb"
     end
 
@@ -52,12 +53,18 @@ module Installation
       Yast2::FsSnapshot.create_post("after update", pre_number, cleanup: :number, important: true)
       Yast2::FsSnapshotStore.clean("update")
       true
+    rescue Yast2::SnapshotCreationFailed, Yast2::FsSnapshotsStore::IOError
+      Yast::Report.Error(_("Could not create a post-update snapshot."))
+      false
     end
 
     def create_single_snapshot
       # as of bsc #1092757 snapshot descriptions are not translated
       Yast2::FsSnapshot.create_single("after installation", cleanup: :number, important: true)
       true
+    rescue Yast2::SnapshotCreationFailed
+      Yast::Report.Error(_("Could not create a post-installation snapshot."))
+      false
     end
 
     def snapper_config

--- a/src/lib/installation/snapshots_finish.rb
+++ b/src/lib/installation/snapshots_finish.rb
@@ -53,7 +53,8 @@ module Installation
       Yast2::FsSnapshot.create_post("after update", pre_number, cleanup: :number, important: true)
       Yast2::FsSnapshotStore.clean("update")
       true
-    rescue Yast2::SnapshotCreationFailed, Yast2::FsSnapshotsStore::IOError
+    rescue Yast2::SnapshotCreationFailed, Yast2::FsSnapshotsStore::IOError => error
+      log.error("Error creating a post-update snapshot: #{error}")
       Yast::Report.Error(_("Could not create a post-update snapshot."))
       false
     end
@@ -62,7 +63,8 @@ module Installation
       # as of bsc #1092757 snapshot descriptions are not translated
       Yast2::FsSnapshot.create_single("after installation", cleanup: :number, important: true)
       true
-    rescue Yast2::SnapshotCreationFailed
+    rescue Yast2::SnapshotCreationFailed => error
+      log.error("Error creating a post-installation snapshot: #{error}")
       Yast::Report.Error(_("Could not create a post-installation snapshot."))
       false
     end

--- a/test/snapshots_finish_test.rb
+++ b/test/snapshots_finish_test.rb
@@ -98,13 +98,28 @@ describe ::Installation::SnapshotsFinish do
         context "when updating" do
           before do
             allow(Yast::Mode).to receive(:update).and_return(true)
+            allow(Yast2::FsSnapshotStore).to receive(:load).with("update").and_return(1)
+            allow(Yast2::FsSnapshotStore).to receive(:clean).with("update")
           end
 
           it "creates a snapshot of type 'post' with 'after update' as description and paired with 'pre' snapshot" do
-            expect(Yast2::FsSnapshotStore).to receive(:load).with("update").and_return(1)
-            expect(Yast2::FsSnapshotStore).to receive(:clean).with("update")
             expect(Yast2::FsSnapshot).to receive(:create_post).with("after update", 1, cleanup: :number, important: true).and_return(true)
             expect(subject.write).to eq(true)
+          end
+
+          context "and could not create the snapshot" do
+            before do
+              allow(Yast2::FsSnapshot).to receive(:create_post).and_raise(Yast2::SnapshotCreationFailed)
+            end
+
+            it "returns false" do
+              expect(subject.write).to eq(false)
+            end
+
+            it "reports the problem to the user" do
+              expect(Yast::Report).to receive(:Error).with(/snapshot/)
+              subject.write
+            end
           end
         end
 
@@ -116,6 +131,21 @@ describe ::Installation::SnapshotsFinish do
           it "creates a snapshot of type 'single' with 'after installation' as description" do
             expect(Yast2::FsSnapshot).to receive(:create_single).with("after installation", cleanup: :number, important: true).and_return(true)
             expect(subject.write).to eq(true)
+          end
+
+          context "and could not create the snapshot" do
+            before do
+              allow(Yast2::FsSnapshot).to receive(:create_single).and_raise(Yast2::SnapshotCreationFailed)
+            end
+
+            it "returns false" do
+              expect(subject.write).to eq(false)
+            end
+
+            it "reports the problem to the user" do
+              expect(Yast::Report).to receive(:Error).with(/snapshot/)
+              subject.write
+            end
           end
         end
       end


### PR DESCRIPTION
Adapt to `FsSnapshot` API changes introduced in yast/yast-yast2#1125.

![post-update-snapshot-error](https://user-images.githubusercontent.com/15836/107330462-7d5a0180-6aa9-11eb-85f6-ebab1feda2f2.png)