### PR TITLE
The Installer Console (SLE-16263, SLE-16358)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
 
     - name: Git Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: Install Dependencies
       run: rake build_dependencies:install
@@ -41,7 +41,7 @@ jobs:
     steps:
 
     - name: Git Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: Rubocop
       run: rake check:rubocop
@@ -53,7 +53,7 @@ jobs:
     steps:
 
     - name: Git Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: Install Dependencies
       run: rake build_dependencies:install
@@ -68,7 +68,7 @@ jobs:
     steps:
 
     - name: Git Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: Yardoc
       run: rake check:doc
@@ -82,7 +82,7 @@ jobs:
     steps:
 
     - name: Git Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: Perl Syntax
       run: yast-ci-ruby -o perl_syntax

--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,18 @@
 -------------------------------------------------------------------
+Thu Mar  4 13:49:52 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
+
+- Added special installer configuration dialog
+  (jsc#PM-1895, jsc#SLE-16263)
+
+  - Can be started from the initial language selection dialog
+    using an "hambuger" button  (openSUSE Tumbleweed only)
+  - Or in any dialog using a keyboard shortcut:
+    - Ctrl+Alt+Shift+C in graphical (Qt) UI
+    - Ctrl+D Shift+C in text mode (ncurses)
+
+- 4.3.31
+
+-------------------------------------------------------------------
 Tue Mar  2 11:09:17 UTC 2021 - Josef Reidinger <jreidinger@suse.com>
 
 - Do not write selinux and polkit default rules during upgrade

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.3.30
+Version:        4.3.31
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/src/lib/installation/console.rb
+++ b/src/lib/installation/console.rb
@@ -1,0 +1,87 @@
+# ------------------------------------------------------------------------------
+# Copyright (c) 2021 SUSE LLC, All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of version 2 of the GNU General Public License as published by the
+# Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+#
+# ------------------------------------------------------------------------------
+
+require "yast"
+require "installation/console/commands"
+require "installation/console/gui"
+require "installation/console/tui"
+
+Yast.import "UI"
+
+# Override the IRB to log all executed commands into the y2log so we know
+# what exactly happened there (in case user did something wrong or strange...)
+module IrbLogger
+  # wrap the original "evaluate" method, do some logging around
+  def evaluate(*args)
+    statements = args[1]
+    # do not log the internal IRB command for setting the last value variable
+    if statements.is_a?(::String) && statements.start_with?("_ = ")
+      super
+    else
+      Yast::Y2Logger.instance.info "Executing console command: #{statements.inspect}"
+      ret = super
+      Yast::Y2Logger.instance.info "Console command result: #{ret.inspect}"
+      ret
+    end
+  end
+end
+
+# inject the code
+require "irb/workspace"
+module IRB # :nodoc:
+  class WorkSpace
+    prepend IrbLogger
+  end
+end
+
+module Installation
+  module Console
+    class << self
+      # open a console and run an interactive IRB session in it
+      # testing in installed system:
+      # ruby -I src/lib -r installation/console.rb -e ::Installation::Console.run
+      def run
+        console = Yast::UI.TextMode ? Console::Tui.new : Console::Gui.new
+        console.run do
+          commands = Console::Commands.new(console)
+          # print the basic help text
+          commands.welcome
+
+          # start an IRB session in the context of the "commands" object
+          irb(commands)
+        end
+      end
+
+    private
+
+      # configure IRB and start an interactive session
+      # @param context [Object] context in which the IRB session runs
+      def irb(context)
+        # lazy loading
+        require "irb"
+        # enable TAB completion
+        require "irb/completion"
+
+        # see the Binding::irb method in irb.rb in the Ruby stdlib
+        IRB.setup(eval("__FILE__"), argv: [])
+        # use a simple prompt with some customizations
+        IRB.conf[:PROMPT][:YAST] = IRB.conf[:PROMPT][:SIMPLE].dup
+        IRB.conf[:PROMPT][:YAST][:RETURN] = ""
+        IRB.conf[:PROMPT][:YAST][:PROMPT_I] = "YaST >> "
+        IRB.conf[:PROMPT_MODE] = :YAST
+        workspace = IRB::WorkSpace.new(context)
+        IRB::Irb.new(workspace).run(IRB.conf)
+      end
+    end
+  end
+end

--- a/src/lib/installation/console/commands.rb
+++ b/src/lib/installation/console/commands.rb
@@ -43,8 +43,12 @@ module Installation
         puts
         # this is the most important message so make it translatable,
         # the console is for experts so it is OK have the rest untranslated
-        # TRANSLATORS: help text displayed in the installer command line console
-        puts _("Type 'quit' or press Ctrl+D to close the console and go back to the installer")
+        # TRANSLATORS: help text displayed in the installer command line console,
+        # do not change these texts they are replaced:
+        # %{cmd} is replaced by a command name
+        # %{keys} is replaced by a keyboard shortcut
+        puts _("Type '%{cmd}' or press %{keys} to close the console and go back " \
+          "to the installer") % {cmd: "quit", keys: "Ctrl+D"}
         puts
         puts "Type 'commands' to see the available special commands"
         puts

--- a/src/lib/installation/console/commands.rb
+++ b/src/lib/installation/console/commands.rb
@@ -1,0 +1,96 @@
+# ------------------------------------------------------------------------------
+# Copyright (c) 2021 SUSE LLC, All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of version 2 of the GNU General Public License as published by the
+# Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+#
+# ------------------------------------------------------------------------------
+
+require "pp"
+require "shellwords"
+
+require "yast"
+require "installation/console/plugins"
+
+module Installation
+  module Console
+    class Commands
+      include Yast::I18n
+
+      # This class implements the commands in the installer console,
+      # the actual commands are implemented as plugins loaded from
+      # lib/installation/console/plugins/*.rb files
+      #
+      # All public methods in this class are the commands available in the console,
+      # that means we cannot include Yast::Logger here because it would define
+      # "log" command. For logging we have to use the full form here, e.g.
+      # Yast::Y2Logger.instance.info
+      def initialize(console)
+        textdomain "installation"
+
+        @console = console
+        Plugins.load_plugins
+      end
+
+      # print the "welcome" message with a basic help text
+      def welcome
+        puts "---- This is the YaST Installation Console ----"
+        puts
+        # this is the most important message so make it translatable,
+        # the console is for experts so it is OK have the rest untranslated
+        # TRANSLATORS: help text displayed in the installer command line console
+        puts _("Type 'quit' or press Ctrl+D to close the console and go back to the installer")
+        puts
+        puts "Type 'commands' to see the available special commands"
+        puts
+        puts "This is a Ruby shell, you can also type any Ruby command here"
+        puts "and inspect or change the YaST installer"
+        puts
+        puts "Hints: <Tab> completion is enabled, the command history is kept,"
+        puts "you can use the usual \"readline\" features..."
+        puts
+      end
+
+      # print the available commands
+      def commands
+        puts "Available commands:"
+        puts
+        print_command("quit", "Close the console and return back to the installer")
+
+        private_methods.grep(/_description$/).sort.each do |method|
+          print_command(method.to_s.sub(/_description$/, ""), send(method))
+        end
+
+        puts
+      end
+
+      # all unknown commands are handled via this "method_missing" callback
+      def method_missing(method_name, *_args)
+        Yast::Y2Logger.instance.info "Entered unknown command: #{method_name.inspect}"
+        puts "Error: Unknown command \"#{method_name}\""
+        puts
+        commands
+      end
+
+      # helper for running an YaST module
+      def run_yast_module(*args)
+        @console.run_yast_module(*args)
+      end
+
+    private
+
+      # print help text for a command
+      def print_command(cmd, descr)
+        # indent multiline descriptions
+        description = descr.gsub("\n", "\n    ")
+        puts "  #{cmd} - #{description}"
+        puts
+      end
+    end
+  end
+end

--- a/src/lib/installation/console/commands.rb
+++ b/src/lib/installation/console/commands.rb
@@ -48,7 +48,7 @@ module Installation
         # %{cmd} is replaced by a command name
         # %{keys} is replaced by a keyboard shortcut
         puts _("Type '%{cmd}' or press %{keys} to close the console and go back " \
-          "to the installer") % {cmd: "quit", keys: "Ctrl+D"}
+          "to the installer") % { cmd: "quit", keys: "Ctrl+D" }
         puts
         puts "Type 'commands' to see the available special commands"
         puts

--- a/src/lib/installation/console/gui.rb
+++ b/src/lib/installation/console/gui.rb
@@ -1,0 +1,136 @@
+# ------------------------------------------------------------------------------
+# Copyright (c) 2021 SUSE LLC, All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of version 2 of the GNU General Public License as published by the
+# Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+#
+# ------------------------------------------------------------------------------
+
+require "yast"
+
+module Installation
+  module Console
+    # the installer console implementation for the graphical (Qt) UI
+    class Gui
+      Yast.import "Wizard"
+
+      # open a console and run a block in it
+      def run(&block)
+        start
+        redirect(&block)
+      ensure
+        stop
+      end
+
+      # helper for running an YaST module in console
+      def run_yast_module(*args)
+        # we cannot run any YaST module if there is a popup displayed, the module
+        # would be displayed *below* the popup making it inaccessible :-(
+        # make sure a wizard dialog is at the top
+        return unless wizard_dialog?
+
+        begin
+          # get the window ID of the currently active window (the xterm window)
+          window = `#{SWITCHER}`.chomp
+        rescue Errno::ENOENT
+          # if the switcher is missing display a short help
+          puts "Starting an YaST configuration module..."
+          puts
+          puts "After it is finished (by pressing [Next]/[Back]/[Abort])"
+          puts "press Alt+Tab to get back to this console."
+
+          # wait a bit so the user can read the message above
+          sleep(5)
+        end
+
+        Yast::WFM.call(*args)
+
+        # automatically switch the window focus from YaST back to the xterm window
+        system("#{SWITCHER} #{Shellwords.escape(window)}") if window
+      end
+
+    private
+
+      # path to the window switching helper tool (from yast2-x11)
+      SWITCHER = "/usr/lib/YaST2/bin/active_window".freeze
+
+      # is the toplevel dialog a wizard dialog? We cannot run an YaST module
+      # if a popup is currently displayed...
+      def wizard_dialog?
+        return true if Yast::Wizard.IsWizardDialog
+
+        puts "Error: YaST modules cannot be started if there is a popup dialog"
+        puts "displayed. First close this console then close the popup in the installer"
+        puts "and then start the console again."
+
+        false
+      end
+
+      # start the console, open a new xterm window
+      def start
+        # create a pipe for communication with the shell running in the xterm
+        @read, @write = IO.pipe
+        # get the /proc path for the reading end of the pipe
+        read_path = fd_path(Process.pid, @read.fileno)
+
+        # start a new xterm window, run a shell command which:
+        # 1. opens a watching FD for signaling exit
+        # 2. "echo" command prints the PID, the watching FD and the terminal
+        #    device to the Ruby pipe above
+        # 3. "read" command keeps the xterm window open until any input is sent
+        #    to the watching FD
+        command = "xterm -title \"YaST Installation Console\" -e bash -c \"exec {CLOSEFD}<> <(:);
+                    echo \\$\\$ \\$CLOSEFD \\$(tty) > #{read_path};
+                    read -u \\$CLOSEFD\" &"
+
+        system(command)
+
+        # read the values printed by the "echo" command above
+        @pid, @close_fd, @tty = @read.readline.split
+      end
+
+      # stop the console, close the xterm window
+      def stop
+        # send an empty string to the waiting "read" process
+        File.write(fd_path(@pid, @close_fd), "\n") if @pid && @close_fd
+        # close the pipes
+        @read.close if @read
+        @write.close if @write
+      end
+
+      # run a block with redirected IO (redirect to the started xterm console)
+      def redirect(&block)
+        # remember the initial IO channels
+        stdout_orig = $stdout.dup
+        stderr_orig = $stderr.dup
+        stdin_orig = $stdin.dup
+
+        # redirect all IO to the xterm window (its tty device)
+        $stdout.reopen(@tty)
+        $stderr.reopen(@tty)
+        $stdin.reopen(@tty)
+
+        begin
+          block.call if block_given?
+        ensure
+          # restore the original IO channels
+          $stdout.reopen(stdout_orig)
+          $stderr.reopen(stderr_orig)
+          $stdin.reopen(stdin_orig)
+        end
+      end
+
+      # get /proc path for a file descriptor
+      # @param pid [String, Integer] PID of the process
+      # @param fd [String, Integer] file descriptor number
+      def fd_path(pid, fd)
+        "/proc/#{pid}/fd/#{fd}"
+      end
+    end
+  end
+end

--- a/src/lib/installation/console/gui.rb
+++ b/src/lib/installation/console/gui.rb
@@ -116,7 +116,7 @@ module Installation
         $stdin.reopen(@tty)
 
         begin
-          block.call if block_given?
+          block.call
         ensure
           # restore the original IO channels
           $stdout.reopen(stdout_orig)

--- a/src/lib/installation/console/menu.rb
+++ b/src/lib/installation/console/menu.rb
@@ -50,8 +50,6 @@ module Installation
           ret = super
           break if [:next, :back, :abort, :close].include?(ret)
         end
-
-        nil
       end
 
       # the content of the dialog

--- a/src/lib/installation/console/menu.rb
+++ b/src/lib/installation/console/menu.rb
@@ -1,0 +1,113 @@
+# ------------------------------------------------------------------------------
+# Copyright (c) 2021 SUSE LLC, All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of version 2 of the GNU General Public License as published by the
+# Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+#
+# ------------------------------------------------------------------------------
+
+require "yast"
+
+require "cwm"
+require "cwm/dialog"
+
+require "installation/console"
+require "installation/console/menu_plugin"
+require "installation/console/plugins"
+
+Yast.import "Label"
+Yast.import "Report"
+Yast.import "UI"
+Yast.import "Wizard"
+
+module Installation
+  module Console
+    # the main dialog for configuring the installer
+    #
+    # testing in a running system:
+    # Y2DIR=./src ruby -I src/lib -r installation/console/menu.rb -e \
+    #  'Yast.ui_component="qt";Yast.import("Wizard");Yast::Wizard.CreateDialog; \
+    #  ::Installation::Console::Menu.run'
+    class Menu < CWM::Dialog
+      def initialize
+        textdomain "installation"
+      end
+
+      def title
+        # TRANSLATORS: dialog title
+        _("Configuration")
+      end
+
+      def run
+        return nil unless can_start?
+
+        loop do
+          ret = super
+          break if [:next, :back, :abort, :close].include?(ret)
+        end
+
+        nil
+      end
+
+      # the content of the dialog
+      def contents
+        # load the plugins
+        Plugins.load_plugins
+
+        # collect the plugin widgets
+        widgets = MenuPlugin.widgets
+        # insert a small spacing between the widgets depending on the list size,
+        # no spacing in ncurses if there are too many widgets
+        # (the size is rounded down to 0)
+        spacing = widgets.size > 10 ? 0.4 : 1
+        # this is a "join" for an Array...
+        widgets = widgets.flat_map { |w| [w, VSpacing(spacing)] }.tap(&:pop)
+
+        VBox(*widgets)
+      end
+
+      # show [OK] button
+      def next_button
+        Yast::Label.OKButton
+      end
+
+      # hide abort button
+      def abort_button
+        ""
+      end
+
+      # hide back button
+      def back_button
+        ""
+      end
+
+      # create a new Wizard dialog to hide the installation steps on the left side
+      def should_open_dialog?
+        true
+      end
+
+      def help
+        _("<p>This is a special configuration menu which allows configuring " \
+          "the system during installation or tweak some installation options.</p>")
+      end
+
+      # Is the toplevel dialog a wizard dialog? We cannot display the dialog
+      # in Qt UI if a popup is currently displayed...
+      def can_start?
+        return true if Yast::UI.TextMode || Yast::Wizard.IsWizardDialog
+
+        # TRANSLATORS: error message
+        Yast::Report.Error(_("The installer configuration dialog cannot be displayed"\
+          " when a popup window is visible.\nClose the popup first and then" \
+          " repeat the action."))
+
+        false
+      end
+    end
+  end
+end

--- a/src/lib/installation/console/menu_plugin.rb
+++ b/src/lib/installation/console/menu_plugin.rb
@@ -1,0 +1,53 @@
+# ------------------------------------------------------------------------------
+# Copyright (c) 2021 SUSE LLC, All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of version 2 of the GNU General Public License as published by the
+# Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+#
+# ------------------------------------------------------------------------------
+
+require "yast"
+
+module Installation
+  module Console
+    # base class for the configuration menu plugins
+    class MenuPlugin
+      extend Yast::Logger
+
+      # when a new subclass is defined this code gets executed
+      def self.inherited(subclass)
+        # collect instances of all subclasses
+        log.info("Found new plugin class: #{subclass}")
+        plugins << subclass.new
+      end
+
+      # the collected plugin objects
+      def self.plugins
+        @plugins ||= []
+      end
+
+      # get widgets for all plugins
+      def self.widgets
+        plugins.sort_by! { |p| [p.order, p.class.to_s] }
+        plugins.map(&:widget).reject(&:nil?)
+      end
+
+      # return a widget do display
+      # @return [CWM::Widget] the widget
+      def widget
+        nil
+      end
+
+      # define the display order (in ascending order),
+      # if the order value is same than it sorts by the class name
+      def order
+        100
+      end
+    end
+  end
+end

--- a/src/lib/installation/console/menu_plugin.rb
+++ b/src/lib/installation/console/menu_plugin.rb
@@ -45,6 +45,7 @@ module Installation
 
       # define the display order (in ascending order),
       # if the order value is same than it sorts by the class name
+      # @return [Integer] the order
       def order
         100
       end

--- a/src/lib/installation/console/plugins.rb
+++ b/src/lib/installation/console/plugins.rb
@@ -1,0 +1,48 @@
+# ------------------------------------------------------------------------------
+# Copyright (c) 2021 SUSE LLC, All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of version 2 of the GNU General Public License as published by the
+# Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+#
+# ------------------------------------------------------------------------------
+
+require "yast"
+
+module Installation
+  module Console
+    # helper module for loading the console plugins
+    module Plugins
+      extend Yast::Logger
+
+      # load all console plugins from lib/installation/console/plugins
+      # subdirectory
+      def self.load_plugins
+        # use Yast.y2paths to honor the Y2DIR setting
+        plugin_paths = Yast.y2paths.map { |p| File.join(p, "lib/installation/console/plugins") }
+        plugin_paths.select { |p| File.directory?(p) }
+
+        plugins = plugin_paths.each_with_object([]) do |p, obj|
+          # find all *.rb files
+          obj.concat(Dir[File.join(p, "*.rb")])
+        end
+
+        log.debug "All found plugins: #{plugins.inspect}"
+
+        # remove the duplicates, this ensures the Y2DIR precedence
+        plugins.uniq! do |f|
+          File.basename(f)
+        end
+
+        plugins.each do |p|
+          log.info "Loading plugin #{p}"
+          require p
+        end
+      end
+    end
+  end
+end

--- a/src/lib/installation/console/plugins/console_button.rb
+++ b/src/lib/installation/console/plugins/console_button.rb
@@ -1,0 +1,58 @@
+# ------------------------------------------------------------------------------
+# Copyright (c) 2021 SUSE LLC, All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of version 2 of the GNU General Public License as published by the
+# Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+#
+# ------------------------------------------------------------------------------
+
+require "yast"
+
+require "cwm"
+require "installation/console/menu_plugin"
+
+module Installation
+  module Console
+    module Plugins
+      # define a button for starting the command line console
+      class ConsoleButton < CWM::PushButton
+        def initialize
+          textdomain "installation"
+        end
+
+        def label
+          _("Expert Console...")
+        end
+
+        def handle
+          require "installation/console"
+          ::Installation::Console.run
+          nil
+        end
+
+        def help
+          _("<p>The <b>Expert Console</b> button starts a command line interface " \
+            "to the installer. It is intended for special purposes, wrong usage " \
+            "might result in crash or unexpected behavior.</p>")
+        end
+      end
+
+      # define the plugin
+      class ConsoleButtonPlugin < MenuPlugin
+        def widget
+          ConsoleButton.new
+        end
+
+        # this should be the very last button
+        def order
+          1000
+        end
+      end
+    end
+  end
+end

--- a/src/lib/installation/console/plugins/shell_command.rb
+++ b/src/lib/installation/console/plugins/shell_command.rb
@@ -1,0 +1,30 @@
+# ------------------------------------------------------------------------------
+# Copyright (c) 2021 SUSE LLC, All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of version 2 of the GNU General Public License as published by the
+# Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+#
+# ------------------------------------------------------------------------------
+
+module Installation
+  module Console
+    # define the "shell" command in the expert console
+    class Commands
+      def shell
+        system("/bin/bash")
+      end
+
+    private
+
+      def shell_description
+        "Starts a shell session (/bin/bash), use the \"exit\" command\n" \
+        "or press Ctrl+D to return back to the YaST console"
+      end
+    end
+  end
+end

--- a/src/lib/installation/console/tui.rb
+++ b/src/lib/installation/console/tui.rb
@@ -1,0 +1,65 @@
+# ------------------------------------------------------------------------------
+# Copyright (c) 2021 SUSE LLC, All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of version 2 of the GNU General Public License as published by the
+# Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+#
+# ------------------------------------------------------------------------------
+
+require "yast"
+require "shellwords"
+
+Yast.import "UI"
+
+module Installation
+  module Console
+    # the installer console implementation for the text mode (ncurses) UI
+    class Tui
+      # run the passed block in a console
+      def run(&block)
+        start
+        block.call if block_given?
+      ensure
+        stop
+      end
+
+      # helper method for running an interactive YaST module
+      def run_yast_module(*args)
+        # restore the UI back
+        Yast::UI.OpenUI
+        # run the YaST module
+        Yast::WFM.call(*args)
+        # display back the console prompt
+        Yast::UI.CloseUI
+      end
+
+    private
+
+      def start
+        # dump the terminal setting at the start so we can restore them
+        # back when finishing the console
+        @stty = `stty --save`.chomp
+        # close the UI, now the terminal can be used by other application/code
+        Yast::UI.CloseUI
+        # for some reason not all flags are fully restored...
+        system("stty onlcr echo")
+      end
+
+      def stop
+        # restore the saved terminal settings back
+        system("stty #{Shellwords.escape(@stty)}")
+        # reopen the UI back
+        Yast::UI.OpenUI
+
+        # in installed system the console is for some reason not fully restored
+        # to the original state, ensure that some terminal flags are set at the exit
+        at_exit { system("stty onlcr echo") }
+      end
+    end
+  end
+end

--- a/src/lib/installation/dialogs/complex_welcome.rb
+++ b/src/lib/installation/dialogs/complex_welcome.rb
@@ -21,6 +21,7 @@ require "y2packager/widgets/product_license"
 
 Yast.import "UI"
 Yast.import "Wizard"
+Yast.import "OSRelease"
 Yast.import "ProductControl"
 
 module Installation
@@ -48,6 +49,7 @@ module Installation
 
         @products = products
         @disable_buttons = disable_buttons.map { |b| "#{b}_button" }
+        @language_selection = Y2Country::Widgets::LanguageSelection.new(emit_event: true)
       end
 
       # Returns the dialog title
@@ -68,6 +70,7 @@ module Installation
       def contents
         VBox(
           filling,
+          console_button,
           locale_settings,
           license_or_product_content,
           filling
@@ -93,12 +96,25 @@ module Installation
 
     private
 
+      def display_console_button?
+        # for now display the configuration button only in openSUSE Tumbleweed
+        # TODO: later enable it also for SLE15-SP4 and Leap 15.4
+        Yast::OSRelease.id.match?(/tumbleweed/i)
+      end
+
+      def console_button
+        return Empty() unless display_console_button?
+
+        require "installation/widgets/console_button"
+        Right(Widgets::ConsoleButton.new(@language_selection))
+      end
+
       def locale_settings
         Left(
           VBox(
             Left(
               HBox(
-                HWeight(1, Left(Y2Country::Widgets::LanguageSelection.new(emit_event: true))),
+                HWeight(1, Left(@language_selection)),
                 HSpacing(3),
                 HWeight(1, Left(Y2Country::Widgets::KeyboardSelectionCombo.new))
               )

--- a/src/lib/installation/widgets/console_button.rb
+++ b/src/lib/installation/widgets/console_button.rb
@@ -1,0 +1,51 @@
+# ------------------------------------------------------------------------------
+# Copyright (c) 2021 SUSE LLC, All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of version 2 of the GNU General Public License as published by the
+# Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# ------------------------------------------------------------------------------
+
+require "English"
+require "yast"
+require "cwm/widget"
+
+Yast.import "UI"
+
+module Installation
+  module Widgets
+    # A CWM button for starting the installer configuration dialog
+    class ConsoleButton < CWM::PushButton
+      # constructor
+      # @param focused_widget [CWM::Widget,nil] widget which should have
+      # the initial focus
+      def initialize(focused_widget = nil)
+        textdomain "installation"
+        @focus = focused_widget
+      end
+
+      def init
+        # set the focus (only in text mode, in GUI the focus does not change
+        # after displaying the button)
+        @focus.focus if @focus && Yast::UI.TextMode
+      end
+
+      def label
+        # use an hamburger icon to make the button as small as possible
+        "☰"
+      end
+
+      def handle
+        require "installation/console/menu"
+        ::Installation::Console::Menu.new.run
+        # ignore the console menu result, force refreshing the dialog
+        # to activate possible changes
+        :redraw
+      end
+    end
+  end
+end

--- a/test/lib/dialogs/complex_welcome_test.rb
+++ b/test/lib/dialogs/complex_welcome_test.rb
@@ -4,6 +4,10 @@ require_relative "../../test_helper"
 require "installation/dialogs/complex_welcome"
 
 describe Installation::Dialogs::ComplexWelcome do
+  before do
+    allow(Yast::Language).to receive(:language)
+  end
+
   RSpec.shared_examples "show_license" do
     it "shows the product license" do
       expect(Y2Packager::Widgets::ProductLicense).to receive(:new)


### PR DESCRIPTION
## The Goal

The goal is to enable configuring some devices (network, proxy) or setting some installer options in special cases. Usually it should not be needed but in some rare cases it would nice to offer some hidden configuration options.

## Links

- [Internal Trello card](https://trello.com/c/TOdZIh98/2209-5-continue-with-an-easy-to-way-to-configure-and-in-installer)
- Jira: [SLE-16263](https://jira.suse.com/browse/SLE-16263), [SLE-16358](https://jira.suse.com/browse/SLE-16358)

## Notes

Because it's too late to change the dialogs in the SLE15-SP3 (and Leap 15.3) the push button is displayed only in a Tumbleweed installation. In SLE15-SP3 we will use a keyboard shortcut (needs https://github.com/yast/yast-ruby-bindings/pull/270), that will also work in Tumbleweed.

## Screenshots

#### Graphical Installation

![installation_console_gui](https://user-images.githubusercontent.com/907998/109934950-59b36100-7ccd-11eb-8d5f-770d1ca4afe8.gif)

#### Text Mode Installation

![installation_console_tui](https://user-images.githubusercontent.com/907998/109942990-00e7c680-7cd5-11eb-93dc-c1714d1de04a.gif)


#### Plain VGA Text Console

In a plain VGA console (without KMS) the unicode characters cannot be displayed. Fortunately it displays a full block in that case which is quite similar to the [hamburger icon](https://en.wikipedia.org/wiki/Hamburger_button) used. So lets use this fallback.

![console_plain_text_console](https://user-images.githubusercontent.com/907998/109939220-21ae1d00-7cd1-11eb-95c4-d851b5791f27.png)

#### SSH Installation

When installing via SSH the icon is displayed properly (if the terminal properly supports it).

##### xterm
![installation_console_ssh_xterm](https://user-images.githubusercontent.com/907998/109945175-45746180-7cd7-11eb-8804-204bc26cef38.png)

##### KDE konsole
![installation_console_ssh_konsole](https://user-images.githubusercontent.com/907998/109945324-650b8a00-7cd7-11eb-9534-c23a3639c2d7.png)

##### GNOME terminal

![installation_console_ssh_gnome_term](https://user-images.githubusercontent.com/907998/109945587-ae5bd980-7cd7-11eb-8e96-bd6cc28552e4.png)

## Usage

The extra configuration menu allow starting several YaST configuration modules.

## The Expert Commandline Console

The console supports only few commands, additional commands can be defined in each YaST module

- `quit` - closes the console and resumes the installation
- `commands` - prints the available commands  (`help` is a built-in IRB command)

As it runs in an IRB session you can enter any valid Ruby command. The session is running in the YaST installer context so you can inspect the installer settings (e.g. `Yast::WFM.GetLanguage`), change variables, run methods... just like in a debugger.

### Hints

- The Tab completion is enabled, for writing the `repositories` command you can just press `repos<Tab>`, the commands are  autocompleted.
- In the prompt you use the usual "readline" features like history (Up/Down arrows) or history completion (PgUp).

## Testing

### In Installation

- Boot the installer (latest build of SLE15-SP3, Leap 15.3 or Tumbleweed) with `startshell=1 netsetup=dhcp` (or configure static IP if you need that....)
- When the shell is started run the `yupdate patch yast-installation config_console` command - this will patch the installer with the code from GitHub
- Then run the `yast` command to start the installer as usually
- In Tumbleweed it adds a new button in the language selection screen
- You can also start the console at any point during installation in (graphical installation only, in text mode this does not work :worried: ):
  - Press the `Ctrl+Alt+Shift+D` combination start a debugger session
  - Enter commands `require "installation/console/menu"` to load the code and `::Installation::Console::Menu.run` to actually start the console

### In Running System

You can start the configuration dialog or the console manually. 

```
# command line console
Y2DIR=./src ruby -I src/lib -r installation/console.rb -e ::Installation::Console.run
# configuration dialog
Y2DIR=./src ruby -I src/lib -r installation/console/menu.rb -e 'Yast.ui_component="qt";Yast.import("Wizard");Yast::Wizard.CreateDialog;::Installation::Console::Menu.run'
```

As the installer is not running and there is no UI the most console commands do not make sense. But this can be used for testing the IRB setup, opening xterminal, etc...

## Commandline Console Implementation Details

I took advantage of already existing IRB support in Ruby which allows to easily run a command prompt and execute Ruby commands, inspect variables, etc.

The IRB shell runs in a context of an `Installation::Console::Commands` object, the commands (like `repositories`, `configure_network` are just methods defined in that object.

The commands are loaded from plugins, each YaST module can easily define its own console commands.

In GUI YaST opens a new xterm window and redirects the YaST stdout/stdin from the first linux console to that new xterm window. (Otherwise you would need to switch via `Ctrl+Alt+F1` to the IRB session and then via `Ctrl+F7` back to the YaST installer.) Additionally a small helper is needed to change the focus between the console (xterm) and the YaST window.

In text mode it uses `UI.CloseUI` and `UI.OpenUI` to shut down and restore the ncurses UI. There are some small tweaks to make sure the terminal is properly re-initialized.

## TODO

- [x] Text mode (ncurses) support (needs this additional small fix:  https://github.com/libyui/libyui-ncurses/pull/111)
- [x] Implement a shortcut for directly starting the console (`Ctrl+Alt+Shift+C`, using `C` as console...) - https://github.com/libyui/libyui/pull/179, https://github.com/libyui/libyui-ncurses/pull/113,  https://github.com/libyui/libyui-qt/pull/145, https://github.com/yast/yast-ycp-ui-bindings/pull/66, https://github.com/yast/yast-ruby-bindings/pull/268
- [x] After finishing an YaST module in GUI focus back automatically to the console window (see https://github.com/yast/yast-x11/pull/23)
- [x] Make the commands easily extensible, allow each YaST module to add own commands (implement a plugin mechanism)

To be done later:

- [ ] Documentation - for end-user (how to use it) and developers (how to write plugins)
- [ ] Unit tests