### PR TITLE
Fix popup

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Feb 18 21:34:23 UTC 2021 - Josef Reidinger <jreidinger@suse.com>
+
+- Adapted unit test to recent changes in Yast::Report (related to
+  bsc#1179893).
+- 4.3.26
+
+-------------------------------------------------------------------
 Wed Feb 10 08:01:33 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Do not crash when it is not possible to create a snapshot after

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.3.25
+Version:        4.3.26
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/test/cio_ignore_test.rb
+++ b/test/cio_ignore_test.rb
@@ -4,7 +4,13 @@ require_relative "./test_helper"
 
 require "installation/cio_ignore"
 
+Yast.import "Bootloader"
+
 describe ::Installation::CIOIgnore do
+  before do
+    allow(Yast::Bootloader).to receive(:kernel_param).with(:common, "rd.zdev")
+  end
+
   describe "cio_ignore enable/disable" do
     it "take AutoYaST cio_ignore setting" do
       allow(Yast::Mode).to receive(:autoinst).and_return(true)
@@ -27,6 +33,7 @@ describe ::Installation::CIOIgnoreProposal do
   subject { ::Installation::CIOIgnoreProposal.new }
 
   before(:each) do
+    allow(Yast::Bootloader).to receive(:kernel_param).with(:common, "rd.zdev")
     ::Installation::CIOIgnore.instance.reset
   end
 

--- a/test/image_installation_test.rb
+++ b/test/image_installation_test.rb
@@ -79,8 +79,9 @@ describe Yast::ImageInstallation do
       expect(subject.FindImageSet([])).to eq true
     end
 
-    it "returns false if xml is not valid" do
+    it "returns false and reports error if xml is not valid" do
       allow(Yast::XML).to receive(:XMLToYCPFile).and_raise(Yast::XMLDeserializationError)
+      expect(Yast::Report).to receive(:Error)
 
       expect(subject.FindImageSet([])).to eq false
     end

--- a/test/inst_update_installer_test.rb
+++ b/test/inst_update_installer_test.rb
@@ -147,7 +147,7 @@ describe Yast::InstUpdateInstaller do
 
       context "when the update cannot be fetched from a user defined repository" do
         it "shows an error and returns :next" do
-          expect(Yast::Popup).to receive(:Error)
+          expect(Yast::Report).to receive(:Error)
           expect(manager).to receive(:add_repository)
             .and_raise(::Installation::UpdatesManager::CouldNotFetchUpdateFromRepo)
           expect(subject.main).to eq(:next)

--- a/test/snapshots_finish_test.rb
+++ b/test/snapshots_finish_test.rb
@@ -110,6 +110,7 @@ describe ::Installation::SnapshotsFinish do
           context "and could not create the snapshot" do
             before do
               allow(Yast2::FsSnapshot).to receive(:create_post).and_raise(Yast2::SnapshotCreationFailed)
+              allow(Yast::Report).to receive(:Error)
             end
 
             it "returns false" do
@@ -136,6 +137,7 @@ describe ::Installation::SnapshotsFinish do
           context "and could not create the snapshot" do
             before do
               allow(Yast2::FsSnapshot).to receive(:create_single).and_raise(Yast2::SnapshotCreationFailed)
+              allow(Yast::Report).to receive(:Error)
             end
 
             it "returns false" do


### PR DESCRIPTION
This pull request in yast-yast2 (https://github.com/yast/yast-yast2/pull/1122) changed the behavior during unit tests of `Yast::Report` and `Yast2::Popup`, making necessary to add some extra mocking to prevent YaST from trying to open windows during the test execution.

As far as we know, that affected the test-suites of: yast-autoinstallation, yast-add-on, yast-bootloader, yast-configuration-management, yast-dns-server, yast-installation, yast-kdump, yast-network, yast-nfs-client, yast-ntp-client, yast-storage-ng, yast-country, yast-firewall, yast-nfs-server, yast-nis-client, yast-pam, yast-security, yast-services-manager, yast-samba-server, yast-packager, yast-registration and yast-sysconfig.

This should fix the problem for this repository.