### PR TITLE
Do not cleanup the libzypp cache (bsc#1179415)

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Mon Dec  7 09:27:38 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
+
+- Do not cleanup the libzypp cache when the system has low memory,
+  incomplete cache confuses libzypp later (bsc#1179415)
+- 4.0.77
+
+-------------------------------------------------------------------
+
 Mon Apr 20 12:10:19 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
 
 - Force the use of en_US.UTF-8 when running firstboot or the

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.0.76
+Version:        4.0.77
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
#### This is just a backport of #900 to GA.

- Requested in https://bugzilla.suse.com/show_bug.cgi?id=1179415#c27
- Do not cleanup the libzypp cache when the system has low memory, incomplete cache confuses libzypp later
- See https://bugzilla.suse.com/show_bug.cgi?id=1179415#c9
- See PR #900