### PR TITLE
fix missing require

### DIFF
--- a/src/lib/installation/widgets/polkit_default_priv.rb
+++ b/src/lib/installation/widgets/polkit_default_priv.rb
@@ -17,6 +17,8 @@
 # current contact information at www.suse.com.
 # ------------------------------------------------------------------------------
 
+require "cwm/common_widgets"
+
 module Installation
   module Widgets
     class PolkitDefaultPriv < CWM::ComboBox


### PR DESCRIPTION
It adds missing `require` detected by public Jenkins jobs while running the test suite. 

See #906 / https://ci.opensuse.org/job/yast-yast-installation-master/142/consolen and #920 / https://ci.opensuse.org/job/yast-yast-installation-master/143/