### PR TITLE
Remove useless udevadm calls from kernel_finish client

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Mar 10 17:25:29 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
+
+- Do not trigger any kernel event with udevadm from the
+  kernel_finish client (bsc#1180535)
+- 4.3.33
+
+-------------------------------------------------------------------
 Wed Mar 10 10:06:00 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Reduce self-update mechanism memory consumption (bsc#1182928):

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.3.32
+Version:        4.3.33
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/src/lib/installation/clients/kernel_finish.rb
+++ b/src/lib/installation/clients/kernel_finish.rb
@@ -30,6 +30,10 @@
 #
 # $Id$
 #
+
+require "yast"
+require "yast2/execute"
+
 module Yast
   class KernelFinishClient < Client
     def main
@@ -83,10 +87,8 @@ module Yast
         # This will recreate all missing links.
         # bnc#774301 - without --action=change at least when installing
         # over lcs device on s390 emulated eth device get lost
-        SCR.Execute(
-          path(".target.bash"),
-          "/usr/bin/udevadm trigger --action=change; /usr/bin/udevadm settle --timeout=60"
-        )
+        Yast::Execute.on_target("/usr/bin/udevadm", "trigger", "--action=change")
+        Yast::Execute.on_target("/usr/bin/udevadm", "settle", "--timeout=60")
       else
         Builtins.y2error("unknown function: %1", @func)
         @ret = nil

--- a/src/lib/installation/clients/kernel_finish.rb
+++ b/src/lib/installation/clients/kernel_finish.rb
@@ -31,9 +31,6 @@
 # $Id$
 #
 
-require "yast"
-require "yast2/execute"
-
 module Yast
   class KernelFinishClient < Client
     def main
@@ -81,14 +78,6 @@ module Yast
 
         # Write list of modules to load after system gets up
         Kernel.SaveModulesToLoad
-
-        # BNC #427705, formerly added as BNC #163073
-        # after the chroot into the installed system has been performed.
-        # This will recreate all missing links.
-        # bnc#774301 - without --action=change at least when installing
-        # over lcs device on s390 emulated eth device get lost
-        Yast::Execute.on_target("/usr/bin/udevadm", "trigger", "--action=change")
-        Yast::Execute.on_target("/usr/bin/udevadm", "settle", "--timeout=60")
       else
         Builtins.y2error("unknown function: %1", @func)
         @ret = nil


### PR DESCRIPTION
## Problem

The kernel_finish client does some udevadm calls from the target system (chroot) which do not have any effect at all.

- https://bugzilla.suse.com/show_bug.cgi?id=1180535

## Solution

Remove unnecessary calls from kernel_finish as since /dev and /run are shared and since (https://github.com/systemd/systemd/pull/11346) them are completely useless.

