### PR TITLE
Remove the libzypp cache symlink (bsc#1182928)

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,14 @@
 -------------------------------------------------------------------
+Thu Mar 11 15:13:16 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
+
+- Remove the libzypp cache symlink (related to bsc#1182928)
+- Improved "memsample" script handling
+   - Do not start it again if it is already running
+     (might happen if YaST is started again after crash)
+   - Stop it when YaST finishes
+- 4.3.34
+
+-------------------------------------------------------------------
 Wed Mar 10 17:25:29 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
 
 - Do not trigger any kernel event with udevadm from the

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.3.33
+Version:        4.3.34
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/startup/First-Stage/F08-logging
+++ b/startup/First-Stage/F08-logging
@@ -62,6 +62,10 @@ done
 if [ "$MEMSAMPLE" = 0 ]; then
     log "\tdisabled"
 else
-    memsample --sleep="${MEMSAMPLE-5}" --archive=/var/log/YaST2/memsample.zcat &
-    log "\tPID: $!"
+    if pgrep -f memsample; then
+        log "\talready running"
+    else
+        memsample --sleep="${MEMSAMPLE-5}" --archive=/var/log/YaST2/memsample.zcat &
+        log "\tPID: $!"
+    fi
 fi

--- a/startup/First-Stage/F09-start
+++ b/startup/First-Stage/F09-start
@@ -17,9 +17,16 @@ callHooks preFirstCall
 # Using /dev/null - If there is nothing to do, let it fail silently
 SUSEConnect --cleanup > /dev/null 2>&1
 
-# delete the repositories accidentally saved into inst-sys
+# delete the repositories saved into inst-sys
 # they make troubles when restarting YaST
 rm -fv /etc/zypp/repos.d/*.repo
+
+# during installation we move the libzypp cache to the target system (/mnt)
+# and replace it with a symlink, when YaST is restarted the symlink becomes
+# invalid and needs to be removed
+if [ -L /var/cache/zypp ]; then
+  rm -fv /var/cache/zypp
+fi
 
 #=============================================
 # 9.1) check for driver update mode

--- a/startup/First-Stage/F10-cleanup
+++ b/startup/First-Stage/F10-cleanup
@@ -14,6 +14,9 @@ if [ "$UPDATE_MOUNTED" = true ];then
 	umount /y2update
 fi
 
+# stop memory sampling
+pkill -f memsample
+
 #=============================================
 # 10.4) write exit code for evaluation
 #---------------------------------------------


### PR DESCRIPTION
- Remove the libzypp cache symlink when YaST is restarted
- Related to https://github.com/yast/yast-packager/pull/559
- Improved `memsample` script handling
    - Do not start it again if it is already running (might happen if YaST is started again after crash)
   - Stop it when YaST finishes
- 4.3.34