### PR TITLE
Expert console: use "dash" shell (bsc#1183648)

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Mar 17 16:53:42 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
+
+- Expert console: use "dash" if available instead of "bash" shell
+  to avoid job control error messages (bsc#1183648)
+- 4.3.35
+
+-------------------------------------------------------------------
 Thu Mar 11 15:13:16 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
 
 - Remove the libzypp cache symlink (related to bsc#1182928)

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.3.34
+Version:        4.3.35
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/src/lib/installation/console/plugins/shell_command.rb
+++ b/src/lib/installation/console/plugins/shell_command.rb
@@ -16,13 +16,23 @@ module Installation
     # define the "shell" command in the expert console
     class Commands
       def shell
-        system("/bin/bash")
+        # dash is a simple shell and needs less memory, also it does not complain
+        # about missing job control terminal
+        if File.exist?("/bin/dash")
+          system("/bin/dash")
+        # use full featured bash
+        elsif File.exist?("/bin/bash")
+          system("/bin/bash")
+        # fallback
+        else
+          system("/bin/sh")
+        end
       end
 
     private
 
       def shell_description
-        "Starts a shell session (/bin/bash), use the \"exit\" command\n" \
+        "Starts a shell session, use the \"exit\" command\n" \
         "or press Ctrl+D to return back to the YaST console"
       end
     end


### PR DESCRIPTION
- See https://bugzilla.suse.com/show_bug.cgi?id=1183648
- Use the `dash` shell in the expert console to avoid job control error messages which `bash` prints at start:
  ```
  bash: cannot set terminal process group (1980): Inappropriate ioctl for device
  bash: no job control in this shell
  ```
- The `dash` shell is present in the inst-sys, but to make the code more robust it checks if it is present and fallbacks to `bash` or even `sh`.
- The problem is that in GUI to have a terminal window we have to run `bash` in background in an `xterm` window. And if from that terminal you want to start `bash` again than it will complain with the error messages above because the terminal process group is already taken by that `bash` running in background.
- Unfortunately `bash` does not have any command line option for *disabling* the job control. You can force *enable* it with `-i` or 
  `--interactive`, but there is no way how to *disable* it.
- There is a `set +m` command which can disable job control but it does not work when used in the `-c` option and even does not work from `bashrc` file. I guess the terminal is initialized early in the process so that `set +m` get executed too late, after printing that error message.
- The workaround is to use the `dash` shell, it does not print any error message at start.
- If somebody really needs a shell with job control (very unlikely) then the workaround is to press the `Ctrl+Alt+Shift+X` keyboard shortcut which opens an X terminal window with full shell or switch to another Linux console (`Ctrl+Alt+F2`).
- 4.3.35