### PR TITLE
Optional in-process memory profiling: MEMORY_PROFILER=1 and MASSIF=1

### DIFF
--- a/bin/memsample-csv-plot
+++ b/bin/memsample-csv-plot
@@ -10,7 +10,7 @@ set datafile separator comma
 set timefmt "%Y-%m-%dT%H:%M:%S+00:00"
 set xdata time
 set xtics rotate
-set format x "%H:%M"
+set format x "%H:%M:%S"
 set terminal png size 800, 600
 set xlabel "wall clock (UTC)"
 set ylabel "used [MiB]"
@@ -22,10 +22,10 @@ set key rmargin
 # 4 mem_total_k, 4 mem_used_k, 6 mem_free_k,
 # 7 swap_total_k, 8 swap_used_k, 9 swap_free_k,
 # 10 rss, 11 rss_all, 12 datetime
-plot "${CSV}" using 12:(\$10/1024) title "y2start RSS" with lines,\
-           "" using 12:(\$11/1024) title "y2start+children RSS" with lines,\
-           "" using 12:(\$2/1024)  title "disk" with lines,\
-           "" using 12:(\$5/1024)  title "mem" with lines,\
-           "" using 12:((\$2+\$5)/1024) title "mem+disk" with lines,\
-           "" using 12:(\$8/1024)  title "swap" with lines
+plot "${CSV}" using 12:(\$10/1024)     title "y2start RSS"          with lines,\
+           "" using 12:(\$11/1024)     title "y2start+children RSS" with lines,\
+           "" using 12:(\$2/1024)      title "disk"                 with lines,\
+           "" using 12:(\$5/1024)      title "mem"                  with lines,\
+           "" using 12:((\$2+\$5)/1024) title "mem+disk"            with lines,\
+           "" using 12:(\$8/1024)      title "swap"                 with lines
 EOS

--- a/doc/memory-profile-valgrind-massif.md
+++ b/doc/memory-profile-valgrind-massif.md
@@ -4,7 +4,7 @@ Valgrind is an instrumentation framework that runs a program by simulating
 every instruction.  It has several tools. Memcheck is the original one, used
 for detecting memory errors. Massif is a memory profiler.
 
-(The output it produces, example: https://gist.github.com/mvidner/4e8ed01c7dabb648a50e0dd5f0fdcc62 )
+(The output it produces, example: https://github.com/yast/yast-installation/wiki/Massif-Sample-Output )
 
 The basic invocation of Massif is simple,
 `valgrind --tool=massif my_program its_arguments`, so for YaST it is

--- a/doc/memory-profile-valgrind-massif.md
+++ b/doc/memory-profile-valgrind-massif.md
@@ -1,0 +1,50 @@
+## Massif Basics
+
+Valgrind is an instrumentation framework that runs a program by simulating
+every instruction.  It has several tools. Memcheck is the original one, used
+for detecting memory errors. Massif is a memory profiler.
+
+(The output it produces, example: https://gist.github.com/mvidner/4e8ed01c7dabb648a50e0dd5f0fdcc62 )
+
+The basic invocation of Massif is simple,
+`valgrind --tool=massif my_program its_arguments`, so for YaST it is
+
+```console
+# valgrind --tool=massif /usr/lib/YaST2/bin/y2start sw_single qt
+```
+
+Or, if we don't want to dig in the startup scripts, we use a bigger gun:
+
+```console
+# valgrind --tool=massif --trace-children=yes yast2 sw_single
+```
+
+That writes out massif.out.99999 where 99999 is process ID.
+To make them somewhat more readable, use the included tool `ms_print`
+which adds an ASCII graph and computes percentages:
+
+```
+ms_print massif.out.19015 >  massif.out.19015.txt
+```
+
+### Debuginfo
+
+The backtraces will contain some names, at the boundaries of shared libraries
+But to see names inside libraries Massif needs debuginfo files.
+
+## Massif at Installation Time
+
+tl;dr: Boot with `extend=gdb MASSIF=1`.
+
+1. Install Massif. It is part of the [**gdb** extension][gdb-ext], so use
+   `extend=gdb` at the boot prompt, or in an inst-sys shell.
+
+2. Install Debuginfo. For Tumbleweed an automatic downloader is in place
+   from <https://debuginfod.opensuse.org/>.
+
+3. Wrap Massif around the main installer process.
+   The [startup/YaST2.call script][PR935] will do it if the environment
+   variable `MASSIF=1`, putting the logs where save_y2logs expects them.
+
+[gdb-ext]: https://github.com/openSUSE/installation-images/blob/master/data/root/gdb.file_list
+[PR935]: https://github.com/yast/yast-installation/pull/935

--- a/doc/memory-profile-valgrind-massif.md
+++ b/doc/memory-profile-valgrind-massif.md
@@ -37,7 +37,7 @@ But to see names inside libraries Massif needs debuginfo files.
 tl;dr: Boot with `extend=gdb MASSIF=1`.
 
 1. Install Massif. It is part of the [**gdb** extension][gdb-ext], so use
-   `extend=gdb` at the boot prompt, or in an inst-sys shell.
+   `extend=gdb` at the boot prompt, or run `extend gdb` in an inst-sys shell.
 
 2. Install Debuginfo. For Tumbleweed an automatic downloader is in place
    from <https://debuginfod.opensuse.org/>.

--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Thu Apr 29 15:59:52 UTC 2021 - Martin Vidner <mvidner@suse.com>
+
+- Allow memory profiling of the main installer process, via
+  boot parameters: (bsc#1182649)
+  - MASSIF=1 enables Valgrind/Massif (C/C++ level)
+  - MEMORY_PROFILER=1 enables Ruby level
+- 4.4.6
+
+-------------------------------------------------------------------
 Tue Apr 27 09:23:17 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
 
 - Remove Yast::LanItems dependency (bsc#1185338)

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation
-Version:        4.4.5
+Version:        4.4.6
 Release:        0
 Summary:        YaST2 - Installation Parts
 License:        GPL-2.0-only

--- a/startup/YaST2.call
+++ b/startup/YaST2.call
@@ -366,6 +366,16 @@ function start_yast () {
             Y2START="ruby-memory-profiler"
         fi
 
+        # https://www.valgrind.org/docs/manual/ms-manual.html
+        if [ "$MASSIF" = "1" ]; then
+            Y2START_ARGS="\
+                --tool=massif \
+                --massif-out-file=/var/log/YaST2/massif-%p.out \
+                $Y2START \
+                $Y2START_ARGS"
+            Y2START="valgrind"
+        fi
+
 	if [ "$Y2GDB" != "1" ]; then
 	    $OPT_FBITERM \
                 "$Y2START"		\

--- a/startup/YaST2.call
+++ b/startup/YaST2.call
@@ -355,6 +355,17 @@ function start_yast () {
         Y2START=/usr/lib/YaST2/bin/y2start
         Y2START_ARGS="$Y2_MODULE_NAME $Y2_MODE_FLAGS $Y2_MODULE_ARGS $Y2_MODE $Y2_UI_ARGS"
 
+        # https://rubygems.org/gems/memory_profiler
+        if [ "$MEMORY_PROFILER" = "1" ]; then
+            Y2START_ARGS="\
+                --color \
+                --out=/var/log/YaST2/memprof.txt \
+                $Y2START \
+                -- \
+                $Y2START_ARGS"
+            Y2START="ruby-memory-profiler"
+        fi
+
 	if [ "$Y2GDB" != "1" ]; then
 	    $OPT_FBITERM \
                 "$Y2START"		\

--- a/startup/YaST2.call
+++ b/startup/YaST2.call
@@ -352,24 +352,20 @@ function start_yast () {
 	log "\tUI_ARGS:      $Y2_UI_ARGS"
 	log "\tQT_IM_MODULE: $QT_IM_MODULE"
 
+        Y2START=/usr/lib/YaST2/bin/y2start
+        Y2START_ARGS="$Y2_MODULE_NAME $Y2_MODE_FLAGS $Y2_MODULE_ARGS $Y2_MODE $Y2_UI_ARGS"
+
 	if [ "$Y2GDB" != "1" ]; then
-	    $OPT_FBITERM y2start		\
-		"$Y2_MODULE_NAME"	\
-		$Y2_MODE_FLAGS		\
-		$Y2_MODULE_ARGS	        \
-		$Y2_MODE		\
-		$Y2_UI_ARGS
+	    $OPT_FBITERM \
+                "$Y2START"		\
+		$Y2START_ARGS
 	    Y2_EXIT_CODE=$?
 	else
 	    GDBCMDS=/var/lib/YaST2/gdb-cmds
 	    echo tty /dev/tty10 > $GDBCMDS
-	    echo set args "$Y2_MODULE_NAME"	\
-			$Y2_MODE_FLAGS		\
-			$Y2_MODULE_ARGS 	\
-			$Y2_MODE		\
-			$Y2_UI_ARGS >> $GDBCMDS
 	    echo set pagination off >> $GDBCMDS
-	    /usr/bin/gdb -x $GDBCMDS /usr/lib/YaST2/bin/y2start | \
+	    echo set args $Y2START_ARGS >> $GDBCMDS
+	    /usr/bin/gdb -x $GDBCMDS "$Y2START" | \
 		tee /var/log/YaST2/gdb-log
 	    Y2_EXIT_CODE=$?
 	fi


### PR DESCRIPTION
- https://bugzilla.suse.com/show_bug.cgi?id=1182649
- https://trello.com/c/oj8K4EPu

Allow memory profiling of the main installer process, via  boot parameters: 
- MASSIF=1 enables Valgrind/Massif (C/C++ level)
- MEMORY_PROFILER=1 enables Ruby level

see [doc/memory-profile-valgrind-massif.md](https://github.com/yast/yast-installation/blob/44835c83560a9820df424ca88cc0f32c90e5abbf/doc/memory-profile-valgrind-massif.md)

The necessary packages need to be present:
- Massif is pulled in with `extend=gdb`, done by https://github.com/openSUSE/installation-images/pull/506 (merged)
  (to test this before i-i is updated, extract /usr/bin/debuginfod-find from a TW debuginfod-client.rpm and copy it to a live inst-sys)
- memory_profiler.gem is TODO

