### PR TITLE
Expert console: fixed "shell" command

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,14 @@
 -------------------------------------------------------------------
+Mon Mar 29 16:25:00 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
+
+- Expert console: fixed "shell" command
+  - Run X terminal in GUI instead of "dash" (related to the previous
+    fix for job control error messages bsc#1183648)
+  - Override TERM to "vt100" when running in fbiterm,
+    a workaround for frozen vim (bsc#1183652)
+- 4.3.36
+
+-------------------------------------------------------------------
 Wed Mar 17 16:53:42 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
 
 - Expert console: use "dash" if available instead of "bash" shell

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.3.35
+Version:        4.3.36
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/src/lib/installation/console.rb
+++ b/src/lib/installation/console.rb
@@ -49,7 +49,7 @@ module Installation
     class << self
       # open a console and run an interactive IRB session in it
       # testing in installed system:
-      # ruby -I src/lib -r installation/console.rb -e ::Installation::Console.run
+      # Y2DIR=./src ruby -I src/lib -r installation/console.rb -e ::Installation::Console.run
       def run
         console = Yast::UI.TextMode ? Console::Tui.new : Console::Gui.new
         console.run do

--- a/src/lib/installation/console/plugins/shell_command.rb
+++ b/src/lib/installation/console/plugins/shell_command.rb
@@ -28,8 +28,9 @@ module Installation
       def tui_shell
         puts quit_hint
 
-        # some interactive tools like "vim" get stuck when running in "fbiterm",
-        # the workaround is to override TERM to "vt100" (bsc#1183652)
+        # some interactive tools like "vim" get stuck when running in "fbiterm"
+        # "fbiterm" sets TERM to "iterm", the workaround is to override it
+        # to "vt100" (bsc#1183652)
         term = ENV["TERM"] == "iterm" ? "TERM=vt100" : ""
 
         system("#{term} /bin/bash")

--- a/src/lib/installation/console/plugins/shell_command.rb
+++ b/src/lib/installation/console/plugins/shell_command.rb
@@ -16,24 +16,47 @@ module Installation
     # define the "shell" command in the expert console
     class Commands
       def shell
-        # dash is a simple shell and needs less memory, also it does not complain
-        # about missing job control terminal
-        if File.exist?("/bin/dash")
-          system("/bin/dash")
-        # use full featured bash
-        elsif File.exist?("/bin/bash")
-          system("/bin/bash")
-        # fallback
+        if Yast::UI.TextMode
+          tui_shell
         else
-          system("/bin/sh")
+          gui_shell
         end
       end
 
     private
 
+      def tui_shell
+        puts quit_hint
+
+        # some interactive tools like "vim" get stuck when running in "fbiterm",
+        # the workaround is to override TERM to "vt100" (bsc#1183652)
+        term = ENV["TERM"] == "iterm" ? "TERM=vt100" : ""
+
+        system("#{term} /bin/bash")
+      end
+
+      def gui_shell
+        terms = ["/usr/bin/xterm", "/usr/bin/konsole", "/usr/bin/gnome-terminal"]
+        cmd = terms.find { |s| File.exist?(s) }
+
+        if cmd
+          puts "Starting a terminal application (#{cmd})..."
+          puts quit_hint
+          puts
+          # hide possible errors, xterm complains about some missing fonts
+          # in the inst-sys
+          system("#{cmd} 2> /dev/null")
+        else
+          puts "ERROR: Cannot find any X terminal application"
+        end
+      end
+
+      def quit_hint
+        "Use the \"exit\" command or press Ctrl+D to return back to the YaST console."
+      end
+
       def shell_description
-        "Starts a shell session, use the \"exit\" command\n" \
-        "or press Ctrl+D to return back to the YaST console"
+        "Starts a shell session.\n#{quit_hint}"
       end
     end
   end


### PR DESCRIPTION
- Fixes frozen `vim` when running from shell in the expert console in text mode
  - https://bugzilla.suse.com/show_bug.cgi?id=1183652
  - It turned out to be a `fbiterm` issue, it can be reproduced with a simple `fbiterm vim` command
  - The workaround is to set `TERM=vt100`
- Improved `shell` in GUI (Qt)
  - The previous fix to avoid "cannot set terminal process group" error messages printed by `bash`
     was to use `dash` instead (see PR #934)
  - But it turned out that `dash` is very limited, for example it does not suport <Tab> auto completion so it is quite
    difficult to use it as an interactive shell
  - The fix is to run `bash` but in a separate `xterm` window so it can activate the job control correctly