### PR TITLE
Hide the abort button when calling the network client

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Apr  7 10:54:58 UTC 2021 - David Diaz <dgonzalez@suse.com>
+
+- Hide the abort button when the network client is called
+  (bsc#1183586).
+- 4.4.0
+
+-------------------------------------------------------------------
 Mon Mar 29 16:25:00 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
 
 - Expert console: fixed "shell" command
@@ -6,7 +13,7 @@ Mon Mar 29 16:25:00 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
     fix for job control error messages bsc#1183648)
   - Override TERM to "vt100" when running in fbiterm,
     a workaround for frozen vim (bsc#1183652)
-- 4.3.36
+- 4.4.0
 
 -------------------------------------------------------------------
 Wed Mar 17 16:53:42 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>

--- a/src/lib/installation/clients/inst_disks_activate.rb
+++ b/src/lib/installation/clients/inst_disks_activate.rb
@@ -133,7 +133,10 @@ module Yast
           WFM.call("inst_fcoe-client", [@argmap])
           @ret = :redraw
         when :network
-          WFM.call("inst_lan", [@argmap.merge("skip_detection" => true)])
+          WFM.call(
+            "inst_lan",
+            [@argmap.merge("skip_detection" => true, "hide_abort_button" => true)]
+          )
           @ret = :redraw
         when :abort
           @ret = nil unless Popup.ConfirmAbort(:painless)

--- a/src/lib/installation/clients/inst_network_check.rb
+++ b/src/lib/installation/clients/inst_network_check.rb
@@ -168,7 +168,10 @@ module Yast
           # run net setup
           if @option_selected == "yes_do_run_setup"
             Builtins.y2milestone("Running inst_lan")
-            @ret2 = WFM.call("inst_lan", [GetInstArgs.argmap.merge("skip_detection" => true)])
+            @ret2 = WFM.call(
+              "inst_lan",
+              [GetInstArgs.argmap.merge("skip_detection" => true), "hide_abort_button" => true]
+            )
             Builtins.y2milestone("inst_lan ret: %1", @ret2)
 
             # everything went fine

--- a/src/lib/installation/clients/inst_update_installer.rb
+++ b/src/lib/installation/clients/inst_update_installer.rb
@@ -263,7 +263,10 @@ module Yast
         "and try installing the updates again?")
 
       if Popup.YesNo(msg)
-        Yast::WFM.CallFunction("inst_lan", [{ "skip_detection" => true }])
+        Yast::WFM.CallFunction(
+          "inst_lan",
+          [{ "skip_detection" => true, "hide_abort_button" => true }]
+        )
         true
       else
         false

--- a/test/inst_disks_activate_test.rb
+++ b/test/inst_disks_activate_test.rb
@@ -147,7 +147,8 @@ describe Yast::InstDisksActivateClient do
       end
 
       it "calls inst_lan client" do
-        expect(Yast::WFM).to receive(:call).with("inst_lan", ["skip_detection" => true])
+        expect(Yast::WFM).to receive(:call)
+          .with("inst_lan", ["skip_detection" => true, "hide_abort_button" => true])
         expect(subject).to receive(:show_base_dialog).twice
 
         subject.main


### PR DESCRIPTION
### Problem

> When user presses Abort button on Network settings page, it works same way as "Back" button and returns to the previous dialog. — https://bugzilla.suse.com/show_bug.cgi?id=1183586

As stated in the [second comment](https://bugzilla.suse.com/show_bug.cgi?id=1183586#c2), this happens

>  because the network **subworkflow** should not use [Abort] (...) It should be possible to **abort only in the main workflow**.

### Solution

To use an installation argument (`hide_abort_button`) when calling the _inst\_lan_ client to force it hiding the abort button during the installation. **See https://github.com/yast/yast-network/pull/1195** for more details.