### PR TITLE
Fix version and changelog

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -13,7 +13,7 @@ Mon Mar 29 16:25:00 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
     fix for job control error messages bsc#1183648)
   - Override TERM to "vt100" when running in fbiterm,
     a workaround for frozen vim (bsc#1183652)
-- 4.4.0
+- 4.3.36
 
 -------------------------------------------------------------------
 Wed Mar 17 16:53:42 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.3.36
+Version:        4.4.0
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only


### PR DESCRIPTION
Wrongly changed at https://github.com/yast/yast-installation/pull/937 but detected at https://ci.opensuse.org/job/yast-yast-installation-master/154/console 