### PR TITLE
Avoid "Terminated" message displayed at the end (bsc#1184491)

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Apr  9 16:21:31 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
+
+- Start the "memsample" tool in a subshell to avoid "Terminated"
+  message displayed at the end (bsc#1184491)
+- 4.4.1
+
+-------------------------------------------------------------------
 Wed Apr  7 10:54:58 UTC 2021 - David Diaz <dgonzalez@suse.com>
 
 - Hide the abort button when the network client is called

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.4.0
+Version:        4.4.1
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/startup/First-Stage/F08-logging
+++ b/startup/First-Stage/F08-logging
@@ -65,7 +65,10 @@ else
     if pgrep -f memsample; then
         log "\talready running"
     else
-        memsample --sleep="${MEMSAMPLE-5}" --archive=/var/log/YaST2/memsample.zcat &
-        log "\tPID: $!"
+        # use a subshell to avoid "Terminated" message when killing the process at the end
+        (
+            memsample --sleep="${MEMSAMPLE-5}" --archive=/var/log/YaST2/memsample.zcat &
+            log "\tPID: $!"
+        )
     fi
 fi


### PR DESCRIPTION
- https://bugzilla.suse.com/show_bug.cgi?id=1184491
- YaST displays a "Terminated" error message at the very end
- It is harmless but it looks awkward
- Fixed by starting the `memsample` tool in a subshell, the main shell process is then not connected to the `memsample` process and it does not care about it's termination status


### Original Behavior

![pkill_default](https://user-images.githubusercontent.com/907998/114211913-80feed00-9961-11eb-8f19-f103b172eb96.png)


### With the Fix

![pkill_subshell](https://user-images.githubusercontent.com/907998/114211695-3b422480-9961-11eb-857d-97837303917f.png)
