### PR TITLE
Use empty string instead of 'default' as the 'Default' id

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Apr 14 11:08:52 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
+
+- Show 'Default' in the proposal summary as the PolicyKit Default
+  Privileges to be used when it is not specified or specified as
+  empty in the control file (bsc#1184277)
+- 4.3.37
+
+-------------------------------------------------------------------
 Mon Mar 29 16:25:00 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
 
 - Expert console: fixed "shell" command

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.3.36
+Version:        4.3.37
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/src/lib/installation/clients/security_proposal.rb
+++ b/src/lib/installation/clients/security_proposal.rb
@@ -232,7 +232,7 @@ module Installation
       end
 
       def polkit_default_priv_proposal
-        value = @settings.polkit_default_privileges || "default"
+        value = @settings.polkit_default_privileges.to_s
         human_value = @settings.human_polkit_privileges[value]
 
         format(_("PolicyKit Default Privileges: %s"), human_value)

--- a/src/lib/installation/security_settings.rb
+++ b/src/lib/installation/security_settings.rb
@@ -146,7 +146,7 @@ module Installation
 
     def human_polkit_privileges
       {
-        "default"     => _("Default"),
+        ""            => _("Default"),
         # TRANSLATORS: restrictive in sense the most restrictive policy
         "restrictive" => _("Restrictive"),
         "standard"    => _("Standard"),

--- a/src/lib/installation/widgets/polkit_default_priv.rb
+++ b/src/lib/installation/widgets/polkit_default_priv.rb
@@ -18,6 +18,7 @@
 # ------------------------------------------------------------------------------
 
 require "cwm/common_widgets"
+require "installation/security_settings"
 
 module Installation
   module Widgets
@@ -59,12 +60,11 @@ module Installation
       end
 
       def init
-        self.value = @settings.polkit_default_privileges || "default"
+        self.value = @settings.polkit_default_privileges.to_s
       end
 
       def store
-        res = value == "default" ? nil : value
-        @settings.polkit_default_privileges = res
+        @settings.polkit_default_privileges = value.empty? ? nil : value
       end
     end
   end

--- a/src/lib/installation/widgets/polkit_default_priv.rb
+++ b/src/lib/installation/widgets/polkit_default_priv.rb
@@ -54,7 +54,7 @@ module Installation
           "to allow a more seamless user experience without" \
           " interruptions in the workflow due to password " \
           "prompts.</li></ul><br>" \
-          "The \"default\" is to keep value empty and it will be" \
+          "The \"default\" is to keep value empty and it will be " \
           "assigned automatically.</p>"
         )
       end

--- a/test/lib/clients/security_proposal_test.rb
+++ b/test/lib/clients/security_proposal_test.rb
@@ -184,5 +184,39 @@ describe Installation::Clients::SecurityProposal do
         end
       end
     end
+
+    context "when showing the PolicyKit Default privileges selected" do
+      let(:selected) { "" }
+
+      before do
+        allow(proposal_settings).to receive(:polkit_default_privileges).and_return(selected)
+      end
+
+      context "and it is not set" do
+        let(:selected) { nil }
+
+        it "shows it as 'Default'" do
+          proposal = client.make_proposal({})
+          expect(proposal["preformatted_proposal"]).to include("Privileges: Default")
+        end
+      end
+
+      context "and it is empty" do
+        let(:selected) { nil }
+
+        it "shows it as 'Default'" do
+          proposal = client.make_proposal({})
+          expect(proposal["preformatted_proposal"]).to include("Privileges: Default")
+        end
+      end
+      context "and it is restrictive" do
+        let(:selected) { "restrictive" }
+
+        it "shows it as 'Restrictive'" do
+          proposal = client.make_proposal({})
+          expect(proposal["preformatted_proposal"]).to include("Privileges: Restrictive")
+        end
+      end
+    end
   end
 end

--- a/test/lib/widgets/polkit_default_priv_test.rb
+++ b/test/lib/widgets/polkit_default_priv_test.rb
@@ -5,7 +5,32 @@ require "installation/widgets/polkit_default_priv"
 require "cwm/rspec"
 
 describe Installation::Widgets::PolkitDefaultPriv do
-  subject { described_class.new(Installation::SecuritySettings.create_instance) }
+  let(:settings) { Installation::SecuritySettings.create_instance }
+  subject { described_class.new(settings) }
 
   include_examples "CWM::ComboBox"
+
+  describe ".store" do
+    let(:selected) { "" }
+
+    before do
+      allow(subject).to receive(:value).and_return(selected)
+    end
+
+    context "when the value selected is the 'Default'" do
+      it "sets the settings polkit_default_privileges to nil" do
+        expect(settings).to receive(:polkit_default_privileges=).with(nil)
+        subject.store
+      end
+    end
+
+    context "when the value selected is other" do
+      let(:selected) { "restrictive" }
+
+      it "sets the settings with the selected value" do
+        expect(settings).to receive(:polkit_default_privileges=).with("restrictive")
+        subject.store
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1184277

## Solution

- Use empty string instead of 'default' as the 'Default' id being shown correctly in the proposal when there is no polkit_default_privs selected in the profile. 

## Screenshot

![PolicyKitDefault](https://user-images.githubusercontent.com/7056681/114691569-b9ab1780-9d0f-11eb-920c-721d9d912a7f.png)
![ComboBox](https://user-images.githubusercontent.com/7056681/114705848-1c0c1400-9d20-11eb-9a5f-2fec393c584f.png)
![PolicyKitComboBoxHelp](https://user-images.githubusercontent.com/7056681/114720880-4ebe0880-9d30-11eb-9a9e-92e176095dc4.png)

