### PR TITLE
Fixes for tumbleweed

### DIFF
--- a/bin/memsample-csv-plot
+++ b/bin/memsample-csv-plot
@@ -5,7 +5,7 @@ CSV="${1-memsample.csv}"
 PNG="${2-memsample.png}"
 echo >&2 "Plotting from $CSV to $PNG"
 cat <<EOS | gnuplot > "$PNG"
-set title "YaST instaler memory usage"
+set title "YaST installer memory usage"
 set datafile separator comma
 set timefmt "%Y-%m-%dT%H:%M:%S+00:00"
 set xdata time

--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Apr 14 09:46:38 UTC 2021 - Ludwig Nussel <lnussel@suse.com>
+
+- Check for usr/lib/modules to handle usrmerge (bsc#1029961)
+- 4.4.2
+
+-------------------------------------------------------------------
 Wed Apr 14 08:44:31 UTC 2021 - Dominique Leuenberger <dimstar@opensuse.org>
 
 - Do not own system directories (like /usr/bin):
@@ -7,7 +13,6 @@ Wed Apr 14 08:44:31 UTC 2021 - Dominique Leuenberger <dimstar@opensuse.org>
     races/conflicts.
   + As a result: expand the files section for bindir and unitdir to
     be exact on the files.
-- 4.4.2
 
 -------------------------------------------------------------------
 Fri Apr  9 16:21:31 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>

--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -8,7 +8,7 @@ Wed Apr 14 09:46:38 UTC 2021 - Ludwig Nussel <lnussel@suse.com>
 Wed Apr 14 08:44:31 UTC 2021 - Dominique Leuenberger <dimstar@opensuse.org>
 
 - Do not own system directories (like /usr/bin):
-  + filesystem is reasponsible to bring those directories with the
+  + filesystem is responsible to bring those directories with the
     correct permission flags. Owning them here only introduces
     races/conflicts.
   + As a result: expand the files section for bindir and unitdir to

--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,15 @@
 -------------------------------------------------------------------
+Wed Apr 14 08:44:31 UTC 2021 - Dominique Leuenberger <dimstar@opensuse.org>
+
+- Do not own system directories (like /usr/bin):
+  + filesystem is reasponsible to bring those directories with the
+    correct permission flags. Owning them here only introduces
+    races/conflicts.
+  + As a result: expand the files section for bindir and unitdir to
+    be exact on the files.
+- 4.4.2
+
+-------------------------------------------------------------------
 Fri Apr  9 16:21:31 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
 
 - Start the "memsample" tool in a subshell to avoid "Terminated"

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.4.1
+Version:        4.4.2
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only
@@ -199,9 +199,13 @@ systemctl enable YaST2-Firstboot.service
 %files
 
 # systemd service files
-%{_unitdir}
+%{_unitdir}/YaST2-Firstboot.service
+%{_unitdir}/YaST2-Second-Stage.service
+%{_bindir}/memsample
+%{_bindir}/memsample-archive-to-csv
+%{_bindir}/memsample-csv-plot
 # yupdate script
-%{_bindir}/
+%{_bindir}/yupdate
 %{yast_clientdir}
 %{yast_moduledir}
 %{yast_desktopdir}

--- a/src/lib/installation/instsys_cleaner.rb
+++ b/src/lib/installation/instsys_cleaner.rb
@@ -61,7 +61,7 @@ module Installation
     # kernel modules can vary significantly. This saves about 29MB on x86_64
     # and about 5MB on s390x.
     def self.unmount_kernel_modules
-      if !File.exist?(File.join(KERNEL_MODULES_MOUNT_POINT, "lib/modules"))
+      if !File.exist?(File.join(KERNEL_MODULES_MOUNT_POINT, "lib/modules")) && !File.exist?(File.join(KERNEL_MODULES_MOUNT_POINT, "usr/lib/modules"))
         log.warn("Kernel modules not found at #{KERNEL_MODULES_MOUNT_POINT}")
         log.warn("Skipping module cleanup")
         return


### PR DESCRIPTION
This tries to consolidate all the recent contributions in a single pull request that is easy to review:

- #943 was nice to review, but lacked the changes in #940 
- #940 lacked the changelog entry and was closed in favor of #939 (which had its own problems)
- #939 was hard to review and included some side effects like the removal of a `BuildRequires:  yast2-bootloader` that was pretty hard to spot and likely not wanted.

So this PR should bring the good parts of #943 and #940, without the extensive cleanup of #939.