### PR TITLE
Drop Yast::LanItems dependency

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Apr 27 09:23:17 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
+
+- Remove Yast::LanItems dependency (bsc#1185338)
+- 4.4.5
+
+-------------------------------------------------------------------
 Fri Apr 16 10:19:04 UTC 2021 - Dirk Müller <dmueller@suse.com>
 
 - spec-cleaner part five out of five: sort and deduplicate requires

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -37,8 +37,8 @@ BuildRequires:  yast2-country >= 3.3.1
 BuildRequires:  yast2-devtools >= 3.1.10
 # For firewall widgets
 BuildRequires:  yast2-firewall
-# Y2Network::NtpServer
-BuildRequires:  yast2-network >= 4.2.55
+# Dropped Yast::LanItems
+BuildRequires:  yast2-network >= 4.4.7
 # Y2Packager::MediumType
 BuildRequires:  yast2-packager >= 4.2.27
 # for AbortException and handle direct abort
@@ -78,8 +78,8 @@ Requires:       yast2-country >= 3.3.1
 # Language::GetLanguageItems and other API
 # Language::Set (handles downloading the translation extensions)
 Requires:       yast2-country-data >= 2.16.11
-# Y2Network::NtpServer
-Requires:       yast2-network >= 4.2.55
+# Dropped Yast::LanItems
+Requires:       yast2-network >= 4.4.7
 # Y2Packager::MediumType
 Requires:       yast2-packager >= 4.2.22
 # Pkg::ProvidePackage

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation
-Version:        4.4.4
+Version:        4.4.5
 Release:        0
 Summary:        YaST2 - Installation Parts
 License:        GPL-2.0-only

--- a/src/lib/installation/dialogs/ntp_setup.rb
+++ b/src/lib/installation/dialogs/ntp_setup.rb
@@ -32,7 +32,6 @@ module Installation
         textdomain "installation"
 
         Yast.import "Lan"
-        Yast.import "LanItems"
         Yast.import "Product"
         Yast.import "ProductFeatures"
 
@@ -68,26 +67,10 @@ module Installation
       def ntp_servers
         # TODO: use Yast::NtpClient.ntp_conf if configured
         # to better handle going back
-        servers = dhcp_ntp_servers
+        servers = Yast::Lan.dhcp_ntp_servers
         servers = [ntp_fallback.hostname] if servers.empty? && default_ntp_setup_enabled?
 
         servers
-      end
-
-      # List of NTP servers from DHCP
-      #
-      # @return [Array<String>] List of servers (IP or host names), empty if not provided
-      def dhcp_ntp_servers
-        # When proposing NTP servers we need to know
-        #
-        #   1) list of (dhcp) interfaces
-        #   2) network service in use
-        #
-        # We can either use networking submodule for network service handling and get list of
-        # interfaces e.g. using a bash command or initialize whole networking module.
-        Yast::Lan.ReadWithCacheNoGUI
-
-        Yast::LanItems.dhcp_ntp_servers.values.flatten.uniq
       end
 
       # Whether the a default (fallback) NTP setup is enabled in the control.xml

--- a/test/lib/dialogs/ntp_setup_test.rb
+++ b/test/lib/dialogs/ntp_setup_test.rb
@@ -17,8 +17,7 @@ describe ::Installation::Dialogs::NtpSetup do
       allow(Yast::Wizard).to receive(:CreateDialog)
       allow(Yast::Wizard).to receive(:CloseDialog)
       allow(Yast::CWM).to receive(:show).and_return(:next)
-      allow(Yast::Lan).to receive(:ReadWithCacheNoGUI)
-      allow(Yast::LanItems).to receive(:dhcp_ntp_servers).and_return({})
+      allow(Yast::Lan).to receive(:dhcp_ntp_servers).and_return([])
       allow(Yast::ProductFeatures).to receive(:GetBooleanFeature)
     end
 
@@ -28,7 +27,7 @@ describe ::Installation::Dialogs::NtpSetup do
       let(:ntp_servers) { ["ntp.example.com"] }
 
       it "proposes to use it by default" do
-        expect(Yast::LanItems).to receive(:dhcp_ntp_servers).and_return("eth0" => ntp_servers)
+        expect(Yast::Lan).to receive(:dhcp_ntp_servers).and_return(ntp_servers)
         expect(::Installation::Widgets::NtpServer).to receive(:new)
           .with(ntp_servers).and_call_original
         subject.run


### PR DESCRIPTION
## Problem

We have been preparing the drop of **Yast::LanItems** adapting the some code in network which is still used by this module so we need to adapt it to.

- see https://github.com/yast/yast-network/pull/1216
- https://bugzilla.suse.com/show_bug.cgi?id=1185338

## Solution

- Drop Yast::LanItems dependency completely.