### PR TITLE
Avoid "Terminated" message displayed at the end (bsc#1184491) (SP3)

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Apr 29 09:21:31 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
+
+- Start the "memsample" tool in a subshell to avoid "Terminated"
+  message displayed at the end (bsc#1184491)
+- 4.3.38
+
+-------------------------------------------------------------------
 Wed Apr 14 11:08:52 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
 
 - Show 'Default' in the proposal summary as the PolicyKit Default

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.3.37
+Version:        4.3.38
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/startup/First-Stage/F08-logging
+++ b/startup/First-Stage/F08-logging
@@ -65,7 +65,10 @@ else
     if pgrep -f memsample; then
         log "\talready running"
     else
-        memsample --sleep="${MEMSAMPLE-5}" --archive=/var/log/YaST2/memsample.zcat &
-        log "\tPID: $!"
+        # use a subshell to avoid "Terminated" message when killing the process at the end
+        (
+            memsample --sleep="${MEMSAMPLE-5}" --archive=/var/log/YaST2/memsample.zcat &
+            log "\tPID: $!"
+        )
     fi
 fi


### PR DESCRIPTION
Cherry-pick #941 from yast/memsample_terminated for SP3 (MU)

- https://bugzilla.suse.com/show_bug.cgi?id=1184491