### PR TITLE
Backport handling of <files> section in 1st stage

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu May 13 13:05:08 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Backport gh#872 by schubi@suse.de:
+  - Moving <files> section handling from second installation stage
+    to first installation stage. (bsc#1174194)
+- 4.2.52
+
+-------------------------------------------------------------------
 Thu Mar 11 10:54:41 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Clean-up the unneeded installer updates (bsc#1182928).

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.2.51
+Version:        4.2.52
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only
@@ -111,6 +111,8 @@ Conflicts:      yast2-ycp-ui-bindings < 3.1.7
 Conflicts:      yast2-registration < 3.2.3
 # Mouse-related scripts moved to yast2-mouse
 Conflicts:      yast2-mouse < 2.18.0
+# new autoinst_files_finish call
+Conflicts:      autoyast2 < 4.2.52
 
 Obsoletes:      yast2-installation-devel-doc
 

--- a/src/lib/installation/clients/inst_finish.rb
+++ b/src/lib/installation/clients/inst_finish.rb
@@ -342,6 +342,7 @@ module Yast
         "ldconfig",
         "save_config",
         "live_save_config",
+        "autoinst_files",
         "security",
         "default_target",
         "desktop",


### PR DESCRIPTION
Backport #872 to fix [bsc#1174194](https://bugzilla.suse.com/show_bug.cgi?id=1174194).

* Moving <files> section handling to the first installation stage.
* See https://github.com/yast/yast-autoinstallation/pull/760
* Trello: https://trello.com/c/jgBnBQOU/