### PR TITLE
yupdate: Do not create overlays for non-existing directories

### DIFF
--- a/bin/yupdate
+++ b/bin/yupdate
@@ -191,7 +191,11 @@ HELP
       "/usr/share/icons"
     ].freeze
 
-    attr_reader :dir, :orig_dir
+    # @return [String] the original requested directory
+    attr_reader :orig_dir
+
+    # @return [String] expanded requested directory (i.e. symlink target)
+    attr_reader :dir
 
     # manage the OverlayFS for this directory
     # @param directory [String] the directory
@@ -263,6 +267,7 @@ HELP
       OverlayFS.escape_path("workdir", dir)
     end
 
+    # path pointing to the original directory content
     def origdir
       OverlayFS.escape_path("original", dir)
     end

--- a/bin/yupdate
+++ b/bin/yupdate
@@ -205,7 +205,7 @@ HELP
     # create an OverlayFS overlay for this directory if it is not writable
     def create
       # skip non-existing or already writable directories
-      return if !File.directory?(f) || File.writable?(dir)
+      return if !File.directory?(dir) || File.writable?(dir)
       msg "Adding overlay for #{orig_dir}..."
 
       FileUtils.mkdir_p(upperdir)

--- a/bin/yupdate
+++ b/bin/yupdate
@@ -35,7 +35,7 @@ module YUpdate
   class Version
     MAJOR = 0
     MINOR = 1
-    PATCH = 2
+    PATCH = 3
 
     STRING = "#{MAJOR}.#{MINOR}.#{PATCH}".freeze
   end
@@ -204,7 +204,8 @@ HELP
 
     # create an OverlayFS overlay for this directory if it is not writable
     def create
-      return if File.writable?(dir)
+      # skip non-existing or already writable directories
+      return if !File.directory?(f) || File.writable?(dir)
       msg "Adding overlay for #{orig_dir}..."
 
       FileUtils.mkdir_p(upperdir)


### PR DESCRIPTION
- https://bugzilla.suse.com/show_bug.cgi?id=1183795#c21
- The default overlay list includes the `/usr/lib64/YaST2` directory but that does not exist on 32-bit systems and it fails.
- If the target directory does not exist do not try creating an overlay for it, just skip it.
- Technical note: `File.writable?` returns `false` for non-existing paths, you have to explicitly check that the directory exists to catch this case.