### PR TITLE
Allow to set IP forwarding defaults through the control file (bsc#1186280)

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon May 31 08:43:52 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
+
+- Modify IP forwarding network configuration using the defaults
+  defined in the control file when selecting the role (bsc#1186280)
+- 4.4.10
+
+-------------------------------------------------------------------
 Mon May 24 11:20:46 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
 
 - The InstallationData class has been moved to yast2-packager

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation
-Version:        4.4.9
+Version:        4.4.10
 Release:        0
 Summary:        YaST2 - Installation Parts
 License:        GPL-2.0-only
@@ -37,8 +37,8 @@ BuildRequires:  yast2-country >= 3.3.1
 BuildRequires:  yast2-devtools >= 3.1.10
 # For firewall widgets
 BuildRequires:  yast2-firewall
-# Dropped Yast::LanItems
-BuildRequires:  yast2-network >= 4.4.7
+# Y2Network::ProposalSettings #modify_defaults and #apply_defaults (forwarding configurable)
+BuildRequires:  yast2-network >= 4.4.12
 # Y2Packager::InstallationData
 BuildRequires:  yast2-packager >= 4.4.2
 # for AbortException and handle direct abort
@@ -78,8 +78,8 @@ Requires:       yast2-country >= 3.3.1
 # Language::GetLanguageItems and other API
 # Language::Set (handles downloading the translation extensions)
 Requires:       yast2-country-data >= 2.16.11
-# Dropped Yast::LanItems
-Requires:       yast2-network >= 4.4.7
+# Y2Network::ProposalSettings #modify_defaults and #apply_defaults (forwarding configurable)
+Requires:       yast2-network >= 4.4.12
 # Y2Packager::InstallationData
 Requires:       yast2-packager >= 4.4.2
 # Pkg::ProvidePackage

--- a/src/lib/installation/select_system_role.rb
+++ b/src/lib/installation/select_system_role.rb
@@ -22,6 +22,7 @@ require "ui/installation_dialog"
 require "ui/text_helpers"
 require "installation/services"
 require "installation/system_role"
+require "y2network/proposal_settings"
 
 Yast.import "GetInstArgs"
 Yast.import "Packages"
@@ -228,6 +229,7 @@ module Installation
       role = SystemRole.select(role_id)
       role.overlay_features
       adapt_services(role)
+      adapt_network_defaults(role)
 
       select_packages
     end
@@ -266,6 +268,14 @@ module Installation
       log.info "enable for #{role.id} these services: #{to_enable.inspect}"
 
       Installation::Services.enabled = to_enable
+    end
+
+    def adapt_network_defaults(role)
+      settings = Y2Network::ProposalSettings.instance
+
+      settings.modify_defaults # Load network global section defaults first
+      settings.modify_defaults(role["network"])
+      settings.apply_defaults
     end
 
     # Return the list of defined roles

--- a/src/lib/installation/select_system_role.rb
+++ b/src/lib/installation/select_system_role.rb
@@ -228,7 +228,7 @@ module Installation
 
       role = SystemRole.select(role_id)
       role.overlay_features
-      adapt_services(role)
+      role.adapt_services
       role.adapt_network
 
       select_packages
@@ -257,19 +257,6 @@ module Installation
       Yast::Packages.SelectSystemPackages(false)
 
       Yast::Pkg.PkgSolve(false)
-    end
-
-    # for given role sets in {::Installation::Services} list of services to enable
-    # according to its config. Do not use alone and use apply_role instead.
-    #
-    # FIXME: duplicate code?
-    def adapt_services(role)
-      services = role["services"] || []
-
-      to_enable = services.map { |s| s["name"] }
-      log.info "enable for #{role.id} these services: #{to_enable.inspect}"
-
-      Installation::Services.enabled = to_enable
     end
 
     # Return the list of defined roles

--- a/src/lib/installation/select_system_role.rb
+++ b/src/lib/installation/select_system_role.rb
@@ -229,7 +229,7 @@ module Installation
       role = SystemRole.select(role_id)
       role.overlay_features
       adapt_services(role)
-      adapt_network_defaults(role)
+      role.adapt_network
 
       select_packages
     end
@@ -261,6 +261,8 @@ module Installation
 
     # for given role sets in {::Installation::Services} list of services to enable
     # according to its config. Do not use alone and use apply_role instead.
+    #
+    # FIXME: duplicate code?
     def adapt_services(role)
       services = role["services"] || []
 
@@ -268,14 +270,6 @@ module Installation
       log.info "enable for #{role.id} these services: #{to_enable.inspect}"
 
       Installation::Services.enabled = to_enable
-    end
-
-    def adapt_network_defaults(role)
-      settings = Y2Network::ProposalSettings.instance
-
-      settings.modify_defaults # Load network global section defaults first
-      settings.modify_defaults(role["network"])
-      settings.apply_defaults
     end
 
     # Return the list of defined roles

--- a/src/lib/installation/system_role.rb
+++ b/src/lib/installation/system_role.rb
@@ -166,6 +166,7 @@ module Installation
 
         role["additional_dialogs"] = raw_role["additional_dialogs"]
         role["services"] = raw_role["services"] || []
+        role["network"] = raw_role["network"]
         role["no_default"] = raw_role["no_default"] || false
 
         role

--- a/src/lib/installation/system_role.rb
+++ b/src/lib/installation/system_role.rb
@@ -1,5 +1,5 @@
 # encoding: utf-8
-
+#
 # ------------------------------------------------------------------------------
 # Copyright (c) 2017 SUSE LLC
 #
@@ -22,6 +22,7 @@
 require "yast"
 require "installation/services"
 require "installation/system_role_handlers_runner"
+require "y2network/proposal_settings"
 
 Yast.import "ProductControl"
 Yast.import "ProductFeatures"
@@ -166,7 +167,7 @@ module Installation
 
         role["additional_dialogs"] = raw_role["additional_dialogs"]
         role["services"] = raw_role["services"] || []
-        role["network"] = raw_role["network"]
+        role["network"] = raw_role["network"] || {}
         role["no_default"] = raw_role["no_default"] || false
 
         role
@@ -186,9 +187,7 @@ module Installation
     #
     # @return [Array] the list of services to be enable
     def adapt_services
-      return [] if !self["services"]
-
-      to_enable = self["services"].map { |s| s["name"] }
+      to_enable = (self["services"] || []).map { |s| s["name"] }
 
       log.info "enable for #{id} these services: #{to_enable.inspect}"
 
@@ -212,6 +211,14 @@ module Installation
 
       NON_OVERLAY_ATTRIBUTES.each { |a| features.delete(a) }
       Yast::ProductFeatures.SetOverlay(features)
+    end
+
+    def adapt_network
+      settings = Y2Network::ProposalSettings.instance
+      network = Yast::ProductFeatures.GetSection("network")
+
+      settings.modify_defaults(network.merge(self["network"] || {}))
+      settings.apply_defaults
     end
   end
 end

--- a/test/system_role_test.rb
+++ b/test/system_role_test.rb
@@ -21,7 +21,7 @@ describe Installation::SystemRole do
       },
       {
         "id"      => "role_three",
-        "network" => { "ipv4_forwarding" => true, "ipv6_forwarding" => true },
+        "network" => { "ipv4_forward" => true, "ipv6_forward" => true },
         "order"   => "50"
       }
 
@@ -141,12 +141,12 @@ describe Installation::SystemRole do
     before do
       allow(Yast::ProductFeatures).to receive(:GetSection)
       allow(Yast::ProductFeatures).to receive(:GetSection).with("network")
-        .and_return("ipv6_forwarding" => false)
+        .and_return("ipv6_forward" => false)
     end
 
     it "modifies the network proposal settings with defaults from the control file" do
       expect(settings).to receive(:modify_defaults)
-        .with("ipv4_forwarding" => true, "ipv6_forwarding" => true)
+        .with("ipv4_forward" => true, "ipv6_forward" => true)
 
       role.adapt_network
     end

--- a/test/system_role_test.rb
+++ b/test/system_role_test.rb
@@ -3,6 +3,7 @@
 require_relative "./test_helper"
 require "installation/services"
 require "installation/system_role"
+require "y2network/proposal_settings"
 
 describe Installation::SystemRole do
   let(:system_roles) do
@@ -17,7 +18,13 @@ describe Installation::SystemRole do
         "id"       => "role_two",
         "services" => [{ "name" => "service_one" }, { "name" => "service_two" }],
         "order"    => "100"
+      },
+      {
+        "id"      => "role_three",
+        "network" => { "ipv4_forwarding" => true, "ipv6_forwarding" => true },
+        "order"   => "50"
       }
+
     ]
   end
 
@@ -30,26 +37,27 @@ describe Installation::SystemRole do
     it "returns the roles from the control file" do
       raw_roles = described_class.raw_roles
 
-      expect(raw_roles.size).to eql 2
+      expect(raw_roles.size).to eql 3
       expect(raw_roles.first["id"]).to eql "role_one"
     end
   end
 
   describe ".ids" do
     it "returns a list with all the role ids declared in the control file" do
-      expect(described_class.ids).to match_array(["role_one", "role_two"])
+      expect(described_class.ids).to match_array(["role_one", "role_two", "role_three"])
     end
   end
 
   describe ".all" do
     it "returns an array of SystemRole objects for all the declared roles " do
-      expect(described_class.all.size).to eql(2)
+      expect(described_class.all.size).to eql(3)
       expect(described_class.all.last.class).to eql(described_class)
     end
 
     it "returns array sorted by order" do
-      expect(described_class.all.first.id).to eql("role_two")
-      expect(described_class.all[1].id).to eql("role_one")
+      expect(described_class.all.first.id).to eql("role_three")
+      expect(described_class.all[1].id).to eql("role_two")
+      expect(described_class.all[2].id).to eql("role_one")
     end
   end
 
@@ -124,6 +132,28 @@ describe Installation::SystemRole do
       expect(Installation::Services).to receive(:enabled=).with(["service_one", "service_two"])
 
       role.adapt_services
+    end
+  end
+
+  describe "#adapt_network" do
+    let(:settings) { Y2Network::ProposalSettings.instance }
+    let(:role) { described_class.find("role_three") }
+    before do
+      allow(Yast::ProductFeatures).to receive(:GetSection)
+      allow(Yast::ProductFeatures).to receive(:GetSection).with("network")
+        .and_return("ipv6_forwarding" => false)
+    end
+
+    it "modifies the network proposal settings with defaults from the control file" do
+      expect(settings).to receive(:modify_defaults)
+        .with("ipv4_forwarding" => true, "ipv6_forwarding" => true)
+
+      role.adapt_network
+    end
+
+    it "applies the network proposal settings defaults" do
+      expect(settings).to receive(:apply_defaults)
+      role.adapt_network
     end
   end
 


### PR DESCRIPTION
## Problem

There is no way to influence IP forwarding defaults settings during installation, something that would be nice to be have (see https://github.com/yast/yast-network/pull/1229)

- https://bugzilla.suse.com/show_bug.cgi?id=1186280
- https://trello.com/c/Jao9dDKQ/2477-5-make-forwarding-configurable-for-installer

## Solution

- Modify IP forwarding network configuration using the defaults defined in the control file when a new role is selected.

It depends on yast/yast-network#1229
