### PR TITLE
[SP3] Improve evaluating the old repositories (bsc#1185822)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -64,3 +64,8 @@ Style/VariableName:
     - src/lib/**/*.rb
   Exclude:
     - src/lib/installation/clients/*.rb
+
+Style/PredicateName:
+  Exclude:
+    # mocked Registration.is_registered?
+    - test/lib/upgrade_repo_manager_test.rb

--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Mon Jun  7 13:19:09 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
+
+- Better evaluate the old and new repositories during upgrade,
+  do not preselect new repositories for removal if they
+  accidentally use the same repository as already present in
+  the system (bsc#1185822)
+- 4.3.39
+
+-------------------------------------------------------------------
 Thu Apr 29 09:21:31 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
 
 - Start the "memsample" tool in a subshell to avoid "Terminated"

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.3.38
+Version:        4.3.39
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/test/lib/upgrade_repo_manager_test.rb
+++ b/test/lib/upgrade_repo_manager_test.rb
@@ -3,6 +3,20 @@
 require_relative "../test_helper"
 require "installation/upgrade_repo_manager"
 
+begin
+  # check if the registration package is present, it might not be available during RPM build
+  require "registration/registration"
+rescue LoadError
+  # mock the Registration class if missing
+  module Registration
+    class Registration
+      def self.is_registered?
+        false
+      end
+    end
+  end
+end
+
 describe Installation::UpgradeRepoManager do
   let(:repo1) do
     Y2Packager::Repository.new(repo_id: 1, repo_alias: "test1",
@@ -122,6 +136,7 @@ describe Installation::UpgradeRepoManager do
       allow(Y2Packager::Repository).to receive(:all).and_return([repo1, repo2])
       expect(Y2Packager::OriginalRepositorySetup.instance).to receive(:repositories)
         .and_return([repo1, repo2])
+      allow(Registration::Registration).to receive(:is_registered?).and_return(false)
     end
 
     it "initializes the UpgradeRepoManager from the stored old repositories" do


### PR DESCRIPTION
## The Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1185822
- During migration usually the new repositories have a different URL so they point to new package versions (e.g. the Basesystem Module for SLE15-SP2 is replaced with SLE15-SP3 repository with different name and URL)
- During migration YaST offers to remove the old repositories because the old repositories/packages could potentially cause conflicts or other dependency problems
- But the detection of the old repositories does not work properly if the new repository is the same as the old one (X replaced by X), in that case the repository looks like as if it was old and should not be used anymore


## The Solution

- The improved code loads the current (SP3) registered repositories and these repositories are excluded from the old ones

### Testing

- Tested manually, see below

### Screenshots

- The original behavior: the "new" SP3 repositories with the NVidia module are preselected for removal
![migration_old_repos_orig](https://user-images.githubusercontent.com/907998/121035512-40c7b980-c7ae-11eb-8f7d-61ac2622e6c6.png)


- The improved behavior: only the old SP2 repository is listed
![migration_old_repos_fixed](https://user-images.githubusercontent.com/907998/121031305-84202900-c7aa-11eb-9586-84d53824e69f.png)
