### PR TITLE
Write proxy settings at the end of the First Stage and export https_proxy

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Jun  8 08:28:28 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
+
+- Export also the https_proxy environment variable when a proxy
+  config is given through linuxrc (bsc#1185016)
+- 4.3.40
+
+-------------------------------------------------------------------
 Mon Jun  7 13:19:09 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
 
 - Better evaluate the old and new repositories during upgrade,

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.3.39
+Version:        4.3.40
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -77,8 +77,8 @@ Requires:       yast2-packager >= 4.2.22
 Requires:       yast2-bootloader
 # use in startup scripts
 Requires:       initviocons
-# Proxy settings for 2nd stage (bnc#764951)
-Requires:       yast2-proxy
+# Use of Proxy.to_target (bsc#1185016).
+Requires:       yast2-proxy >= 4.3.3
 # Systemd default target and services. This version supports
 # writing settings in the first installation stage.
 Requires:       yast2-services-manager >= 3.2.1

--- a/src/lib/installation/clients/proxy_finish.rb
+++ b/src/lib/installation/clients/proxy_finish.rb
@@ -66,7 +66,7 @@ module Yast
           "when"  => [:installation, :update, :autoinst]
         }
       elsif @func == "Write"
-        if Stage.initial && Proxy.to_target
+        if write_to_target?
           proxy_settings = Proxy.Export
 
           log.info("Writing proxy settings to the target system: #{proxy_settings.inspect}")
@@ -83,6 +83,18 @@ module Yast
       Builtins.y2debug("ret=%1", @ret)
       Builtins.y2milestone("proxy_finish finished")
       deep_copy(@ret)
+    end
+
+  private
+
+    # Whether the configuration should be written to the target system or not
+    #
+    #  @return [Boolean]
+    def write_to_target?
+      return false unless Stage.initial
+
+      # In case of AutoYaST the configuration could have been imported but not written yet
+      Proxy.modified || Proxy.to_target
     end
   end
 end

--- a/src/lib/installation/clients/proxy_finish.rb
+++ b/src/lib/installation/clients/proxy_finish.rb
@@ -66,14 +66,12 @@ module Yast
           "when"  => [:installation, :update, :autoinst]
         }
       elsif @func == "Write"
-        if Stage.initial
-          # In case of written by linuxrc or by AutoYaST it should be copied to the target system
-          return if Proxy.GetEnvironment.reject { |_, v| v.to_s.empty? }.empty?
+        if Stage.initial && Proxy.to_target
+          proxy_settings = Proxy.Export
 
-          ex = Proxy.Export
-          log.info("Writing proxy settings to the target system: #{ex.inspect}")
+          log.info("Writing proxy settings to the target system: #{proxy_settings.inspect}")
 
-          Proxy.Import(ex)
+          Proxy.Import(proxy_settings)
           Proxy.WriteSysconfig
           Proxy.WriteCurlrc
         end

--- a/startup/common/misc.sh
+++ b/startup/common/misc.sh
@@ -24,6 +24,7 @@ function set_proxy() {
 # ---
 	if [ "$ProxyURL" ] ; then
 		export http_proxy="$ProxyURL"
+		export https_proxy="$ProxyURL"
 		export ftp_proxy="$ProxyURL"
 	fi
 }

--- a/test/lib/clients/proxy_finish_test.rb
+++ b/test/lib/clients/proxy_finish_test.rb
@@ -39,6 +39,7 @@ describe Yast::ProxyFinishClient do
   context "when the client is called with the 'Write' argument" do
     let(:initial_stage) { true }
     let(:to_target) { false }
+    let(:modified) { false }
     let(:args) { ["Write"] }
     let(:config) { { "http_proxy" => "http://proxy.example.com:3128/" } }
 
@@ -46,6 +47,7 @@ describe Yast::ProxyFinishClient do
       allow(Yast::Stage).to receive(:initial).and_return(initial_stage)
       allow(Yast::Proxy).to receive(:to_target).and_return(to_target)
       allow(Yast::Proxy).to receive(:Export).and_return(config)
+      allow(Yast::Proxy).to receive(:modified).and_return(modified)
     end
 
     context "when running on the first stage" do
@@ -53,6 +55,17 @@ describe Yast::ProxyFinishClient do
         it "does nothing" do
           expect(Yast::Proxy).to_not receive(:WriteSysconfig)
           expect(Yast::Proxy).to_not receive(:WriteCurlrc)
+          client.main
+        end
+      end
+
+      context "and the proxy settings have been modified but not written yet" do
+        let(:modified) { true }
+
+        it "writes the current sysconfig and curlrc configuration to the target system" do
+          expect(Yast::Proxy).to receive(:Import).with(config)
+          expect(Yast::Proxy).to receive(:WriteSysconfig)
+          expect(Yast::Proxy).to receive(:WriteCurlrc)
           client.main
         end
       end

--- a/test/lib/clients/proxy_finish_test.rb
+++ b/test/lib/clients/proxy_finish_test.rb
@@ -1,0 +1,72 @@
+#! /usr/bin/env rspec
+
+require_relative "./../../test_helper"
+
+require "installation/clients/proxy_finish"
+
+describe Yast::ProxyFinishClient do
+  let(:client) { described_class.new }
+  let(:func) { "Info" }
+  let(:parm) { nil }
+  let(:args) { [] }
+  let(:func) { args[0] }
+  let(:parms) { args[1] }
+
+  before do
+    allow(Yast::WFM).to receive(:Args).and_return(args)
+    allow(Yast::WFM).to receive(:Args).with(0).and_return(args[0])
+    allow(Yast::WFM).to receive(:Args).with(1).and_return(args[1])
+  end
+
+  context "when the client is called with 'Info' argument" do
+    let(:args) { ["Info"] }
+
+    it "returns a hash" do
+      expect(client.main).to be_a(Hash)
+    end
+
+    it "returns 1 step with 'Saving proxy configuration...' title" do
+      result = client.main
+      expect(result["steps"]).to eql(1)
+      expect(result["title"]).to eql("Saving proxy configuration...")
+    end
+
+    it "returns that the step is valid for :installation, :update and :autoinst modes" do
+      expect(client.main["when"]).to include(:installation, :update, :autoinst)
+    end
+  end
+
+  context "when the client is called with the 'Write' argument" do
+    let(:initial_stage) { true }
+    let(:to_target) { false }
+    let(:args) { ["Write"] }
+    let(:config) { { "http_proxy" => "http://proxy.example.com:3128/" } }
+
+    before do
+      allow(Yast::Stage).to receive(:initial).and_return(initial_stage)
+      allow(Yast::Proxy).to receive(:to_target).and_return(to_target)
+      allow(Yast::Proxy).to receive(:Export).and_return(config)
+    end
+
+    context "when running on the first stage" do
+      context "and the proxy settings were not written to the inst-sys during the installation" do
+        it "does nothing" do
+          expect(Yast::Proxy).to_not receive(:WriteSysconfig)
+          expect(Yast::Proxy).to_not receive(:WriteCurlrc)
+          client.main
+        end
+      end
+
+      context "and the proxy settings were written to the inst-sys during the installation" do
+        let(:to_target) { true }
+
+        it "writes the current sysconfig and curlrc configuration to the target system" do
+          expect(Yast::Proxy).to receive(:Import).with(config)
+          expect(Yast::Proxy).to receive(:WriteSysconfig)
+          expect(Yast::Proxy).to receive(:WriteCurlrc)
+          client.main
+        end
+      end
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -39,6 +39,7 @@ stub_module("Profile")
 stub_module("ProfileLocation")
 # we cannot depend on this module (circular dependency)
 stub_module("NtpClient")
+stub_module("Proxy")
 
 if ENV["COVERAGE"]
   require "simplecov"


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1185016
- https://trello.com/c/s9gfK64m/2499-sles15-sp2-p2-1185016-l3-autoyast-does-not-set-proxy-properly-ref00d1iglod5001ixjkyhref

During installation, the installation fails if http and https traffic is restricted allowing only connnections through a proxy. The current proxy settings export the **http_proxy** variable but not the **https_proxy** which is used for downloading the online updates.

- https://github.com/yast/yast-packager/blob/master/src/lib/y2packager/clients/inst_productsources.rb#L482

![Leap15.3_proxy](https://user-images.githubusercontent.com/7056681/121143186-aeb6c400-c834-11eb-94d3-778642ef94e9.png)

Related: 

- https://bugzilla.suse.com/show_bug.cgi?id=305163
- https://bugzilla.suse.com/show_bug.cgi?id=923788
- https://bugzilla.suse.com/show_bug.cgi?id=869640 (remove old inst_network_setup.rb client)

## Solution

Export also the **https_proxy** variable when proxy settings are established through **linuxrc** as it was already done by the old network setup client (removed here https://github.com/yast/yast-installation/pull/189/files#diff-c8deba4573493d51e3e8715788d69a6413de22a753ed38706e851bc261763087L1431)

![Screenshot_testing_2021-06-08_11:19:57](https://user-images.githubusercontent.com/7056681/121169092-8e463400-c84b-11eb-9cdf-751f3ec0e9fc.png)

## Tests

- Added unit test
- Tested manually with the changes in the other repositories (yast/yast-proxy#40 , yast/yast-network#1231 and yast/yast-autoinstallation#767) with a nomal installation and with AutoYaST (using before_proposal and without before_proposal)
