### PR TITLE
Fix ::Users::UsersDatabase call

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Jun 16 10:35:42 UTC 2021 - David Diaz <dgonzalez@suse.com>
+
+- Fix scope resolution for ::Users::UsersDatabase
+  (related to fate#319624)
+- 4.4.13
+
+-------------------------------------------------------------------
 Tue Jun  8 08:28:28 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
 
 - Export also the https_proxy environment variable when a proxy

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation
-Version:        4.4.12
+Version:        4.4.13
 Release:        0
 Summary:        YaST2 - Installation Parts
 License:        GPL-2.0-only

--- a/src/lib/installation/clients/inst_pre_install.rb
+++ b/src/lib/installation/clients/inst_pre_install.rb
@@ -119,7 +119,7 @@ module Yast
     def can_read_users?
       @can_read_users ||= begin
         require_users_database
-        defined? Users::UsersDatabase
+        defined? ::Users::UsersDatabase
       end
     end
 
@@ -137,7 +137,7 @@ module Yast
     # @param mount_point [String] path where the filesystem is mounted
     def read_users(device, mount_point)
       log.info "Reading users information from #{device}"
-      Users::UsersDatabase.import(mount_point)
+      ::Users::UsersDatabase.import(mount_point)
     end
 
     # Stores the SSH configuration of a given partition in the SSH importer

--- a/test/ssh_import_auto_test.rb
+++ b/test/ssh_import_auto_test.rb
@@ -139,14 +139,6 @@ describe ::Installation::SSHImportAutoClient do
       end
     end
 
-    context "Read" do
-      let(:func) { "Read" }
-
-      it "returns true" do
-        expect(subject.run).to eq(true)
-      end
-    end
-
     context "Reset" do
       let(:func) { "Reset" }
 


### PR DESCRIPTION
> For some reason, the scope resolution operator in ::Users::UsersDatabase
 was forgotten/omitted in #371, but it is needed to avoid resolving to Yast::Users::UsersDatabase.