### PR TITLE
Adapt to Y2Users

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Jun 16 14:10:33 UTC 2021 - José Iván López González <jlopez@suse.com>
+
+- Adapt code to Y2Users (part of jsc#PM-2620).
+- 4.4.14
+
+-------------------------------------------------------------------
 Wed Jun 16 10:35:42 UTC 2021 - David Diaz <dgonzalez@suse.com>
 
 - Fix scope resolution for ::Users::UsersDatabase

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -47,8 +47,8 @@ BuildRequires:  yast2-ruby-bindings >= 4.0.6
 BuildRequires:  yast2-security
 # using /usr/bin/udevadm
 BuildRequires:  yast2-storage-ng >= 4.2.71
-# new root password cwm widget
-BuildRequires:  yast2-users >= 3.2.8
+# Y2Users
+BuildRequires:  yast2-users >= 4.4.2
 # needed for xml agent reading about products
 BuildRequires:  yast2-xml
 BuildRequires:  rubygem(%{rb_default_ruby_abi}:rspec)
@@ -93,7 +93,8 @@ Requires:       yast2-ruby-bindings >= 4.0.6
 Requires:       yast2-services-manager >= 3.2.1
 # Only in inst-sys
 Requires:       yast2-storage-ng >= 4.0.175
-Requires:       yast2-users >= 3.2.8
+# Y2Users
+Requires:       yast2-users >= 4.4.2
 PreReq:         %fillup_prereq
 Recommends:     yast2-add-on
 Recommends:     yast2-firewall

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation
-Version:        4.4.13
+Version:        4.4.14
 Release:        0
 Summary:        YaST2 - Installation Parts
 License:        GPL-2.0-only

--- a/src/lib/installation/security_settings.rb
+++ b/src/lib/installation/security_settings.rb
@@ -1,26 +1,25 @@
-# ------------------------------------------------------------------------------
-# Copyright (c) 2017 SUSE LLC
+# Copyright (c) [2017-2021] SUSE LLC
 #
+# All Rights Reserved.
 #
-# This program is free software; you can redistribute it and/or modify it under
-# the terms of version 2 of the GNU General Public License as published by the
-# Free Software Foundation.
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
 #
 # This program is distributed in the hope that it will be useful, but WITHOUT
-# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
-# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
 #
-# You should have received a copy of the GNU General Public License along with
-# this program; if not, contact SUSE.
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
 #
-# To contact SUSE about this file by physical or electronic mail, you may find
-# current contact information at www.suse.com.
-# ------------------------------------------------------------------------------
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
 
 require "yast"
 require "y2security/selinux"
-
-Yast.import "UsersSimple"
+require "y2users"
 
 module Installation
   # Class that stores the security proposal settings during installation.
@@ -191,7 +190,22 @@ module Installation
     #   key in order to log into the system. In such a case, we need to enable the SSH
     #   service (including opening the port).
     def only_public_key_auth
-      Yast::UsersSimple.GetRootPassword.empty?
+      return true unless root_user
+
+      password = root_user.password_content || ""
+
+      password.empty?
+    end
+
+    # Root user from the target config
+    #
+    # @return [Y2Users::User, nil]
+    def root_user
+      config = Y2Users::ConfigManager.instance.target
+
+      return nil unless config
+
+      config.users.root
     end
 
     class << self


### PR DESCRIPTION
## Problem

*yast2-users* code is being adapted to use *shadow tools*. This module uses some API methods that are going to be dropped in favor of new `Y2Users` classes.

## Solution

Adapt code to use the new `Y2Users` classes.

NOTE: this PR should not be merged yet. It requires [*yast-users/y2users*](https://github.com/yast/yast-users/tree/y2users) branch to be merged before.

## Test

* Unit tests adapted
* Manually tested
 