### PR TITLE
Ensure PReP partition alignment

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Jul  5 15:45:33 UTC 2021 - José Iván López González <jlopez@suse.com>
+
+- Ensure correct alignment when shrinking a PReP partition.
+- bsc#1186371
+- 3.4.2
+
+-------------------------------------------------------------------
 Fri Apr 17 16:10:19 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
 
 - Force the use of en_US.UTF-8 when running firstboot or the

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation
-Version:        3.4.1
+Version:        3.4.2
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
### Problem

When shrinking a PReP partition, the resulting partition is not correctly aligned according to the block size. The problem comes from the *end* value passed to the *parted resize* command. *Parted* tries to align the end of the partition. But, for some reason, the resulting alignment is not correct. 

* https://bugzilla.suse.com/show_bug.cgi?id=1186371

## Solution

Avoid *parted* misalignment by indicating a proper end of the partition in KiB unit. 

Note: The current logic for shrinking a PReP partition always expects to find the PReP partition at the beginning of the disk. 

## Testing

~~It was not possible to reproduce this bug in a ppc64le virtual machine (qemu). A disk with 8 KiB system and logical block sizes was used, as in the scenario of the reported bug.~~

As [Steffen pointed](https://github.com/yast/yast-installation/pull/971#issuecomment-875758136), the error can be reproduced when the partition is created on top of a dm device. It does not strictly depends on the architecture.
