### PR TITLE
Activate devices

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Aug  2 14:31:22 UTC 2021 - José Iván López González <jlopez@suse.com>
+
+- Activate devices before probing (bsc#1187220).
+- 4.2.53
+
+-------------------------------------------------------------------
 Thu May 13 13:05:08 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Backport gh#872 by schubi@suse.de:

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.2.52
+Version:        4.2.53
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/src/lib/installation/clients/inst_disks_activate.rb
+++ b/src/lib/installation/clients/inst_disks_activate.rb
@@ -145,7 +145,11 @@ module Yast
         end
       end
 
-      Y2Storage::StorageManager.instance.probe if @disks_changed
+      if @disks_changed
+        storage = Y2Storage::StorageManager.instance
+        storage.activate
+        storage.probe
+      end
 
       Builtins.y2debug("ret=%1", @ret)
 

--- a/test/inst_disks_activate_test.rb
+++ b/test/inst_disks_activate_test.rb
@@ -21,6 +21,7 @@ describe Yast::InstDisksActivateClient do
       allow(Yast::Linuxrc).to receive(:InstallInf).with("WithFCoE").and_return("0")
       allow(Yast::UI).to receive(:UserInput).and_return(:abort)
 
+      allow(Y2Storage::StorageManager.instance).to receive(:activate)
       allow(Y2Storage::StorageManager.instance).to receive(:probe)
 
       allow(Yast::SCR).to receive(:Read).with(path(".probe.disk"))


### PR DESCRIPTION
## Problem

Storage devices are not activated before probing, see https://github.com/yast/yast-installation/commit/f6b5e9efb7cbc8074f94ca2613cd55fed7fbfb15.

* https://bugzilla.suse.com/show_bug.cgi?id=1187220

## Solution

Add missing call for activating devices.
