### PR TITLE
Fixed Jenkins build failure (weird system mounts)

### DIFF
--- a/test/unmounter_test.rb
+++ b/test/unmounter_test.rb
@@ -37,8 +37,12 @@ describe Installation::Unmounter do
     context "when reading the actual /proc/mounts file" do
       let(:proc_mounts) { "/proc/mounts" }
 
-      it "ignores /, /proc, /sys, /dev" do
-        expect(subject.ignored_paths).to include("/", "/proc", "/sys", "/dev")
+      it "ignores /proc and /sys" do
+        expect(subject.ignored_paths).to include("/proc", "/sys")
+        # With checking for /, /proc, /sys, /dev this failed in Jenkins
+        # because that environment only seems to have /proc, /sys, /dev/pts, /dev/shm,
+        # so this test checks only for the least common denominator between
+        # a sane Linux system and that Jenkins environment.
       end
 
       # Don't check in this context that there is nothing to unmount:


### PR DESCRIPTION
This is a fix for PR #975 that fixes the build failure in Jenkins:

Jenkins obviously has very strange system mounts, so the unit test that checked for common Linux mounts failed:

```
[  116s]   1) Installation::Unmounter#new when reading the actual /proc/mounts file ignores /, /proc, /sys, /dev
[  116s]      Failure/Error: expect(subject.ignored_paths).to include("/", "/proc", "/sys", "/dev")
[  116s]        expected ["/proc", "/sys", "/dev/pts", "/dev/shm"] to include "/" and "/dev"
[  116s]      # ./test/unmounter_test.rb:41:in `block (4 levels) in <top (required)>'
```

So that environment does not appear to have a mount for `/` or for `/dev`, so this change uses only the paths that a normal Linux and Jenkins have in common.

The alternative would be to drop that one test completely, but then we would have _no_ unit test testing the real `/proc/mounts`, only stored copies of a `/proc/mounts` file.