### PR TITLE
Display release notes during upgrade (bsc#1186044)

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Sep  8 15:20:21 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
+
+- Display release notes during upgrade (bsc#1186044)
+- 4.3.42
+
+-------------------------------------------------------------------
 Mon Aug  2 14:31:22 UTC 2021 - José Iván López González <jlopez@suse.com>
 
 - Activate devices before probing (bsc#1187220).

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.3.41
+Version:        4.3.42
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/src/lib/installation/clients/inst_download_release_notes.rb
+++ b/src/lib/installation/clients/inst_download_release_notes.rb
@@ -77,7 +77,8 @@ module Yast
     def main
       textdomain "installation"
 
-      return :auto unless Packages.init_called
+      # Packages.Init is not called during upgrade
+      return :auto if !Packages.init_called && !Stage.initial && !Mode.update
 
       return :back if GetInstArgs.going_back
 

--- a/test/lib/clients/inst_download_release_notes_test.rb
+++ b/test/lib/clients/inst_download_release_notes_test.rb
@@ -39,6 +39,7 @@ describe Yast::InstDownloadReleaseNotesClient do
       allow(sles).to receive(:status?).with(:available).and_return(false)
       allow(sdk).to receive(:status?).with(:available).and_return(!sdk_selected)
       allow(Yast::Stage).to receive(:initial).and_return(true)
+      allow(Yast::Mode).to receive(:update).and_return(false)
       allow(Yast::Packages).to receive(:init_called).and_return(packages_init_called)
       stub_const("Yast::Language", language)
 


### PR DESCRIPTION
## The Problem

- During upgrade the `Release Notes` button is not displayed.

![upgrade_relase_notes_missing_registered](https://user-images.githubusercontent.com/907998/132698774-8a79cbf2-69c7-4514-87f6-e3aab04dc72e.png)

## Details

- It turned out that the `inst_download_release_notes` client is called but it exits early, it does not even try downloading the release notes at all.
- The `Packages.Init` call is not used during upgrade and the [test at the beginning](https://github.com/yast/yast-installation/blob/0a258deb0d516a606fa9ea5962c80947063a6b42/src/lib/installation/clients/inst_download_release_notes.rb#L80) is always evaluated to `false` resulting in immediate exit without doing anything
- The upgrade process [only calls some parts](https://github.com/yast/yast-registration/blob/160c236de58b72505ce29acad8dfbaaed2878775/src/lib/registration/ui/migration_repos_workflow.rb#L737-L743) of the `Packages.Init` from outside (esp. `Packages.Initialize_StageInitial`) so the `Packages` module does not set the internal "initialized" flag

## The Fix

- The check for initialized `Packages` module is skipped during upgrade
- As written above it is not called during upgrade so we should not check it in that case

## Testing

- Tested manually with both Online and Full media (with registered/not registered system)
- The `Release Notes` button is displayed correctly, after pressing it displays the SP3 release notes

![upgrade_relase_notes_fixed_scc](https://user-images.githubusercontent.com/907998/132699346-10516470-3918-42e0-b5dd-acf00cd7c66e.png)
![upgrade_relase_notes_fixed2_scc](https://user-images.githubusercontent.com/907998/132699398-f03b0657-65c1-4f65-bc80-bf099e7609a0.png)



