### PR TITLE
Fix displaying a custom proposal set in AY

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -3,7 +3,7 @@ Sun Sep 26 22:01:53 UTC 2021 - Martin Vidner <mvidner@suse.com>
 
 - Filter the installation proposals (in the Installation Settings
   screen) according to the AutoYaST profile even before
-  tab switching (bsc#1190294)
+  tab switching (related to bsc#1190294)
 - 4.1.55
 
 -------------------------------------------------------------------

--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Sun Sep 26 22:01:53 UTC 2021 - Martin Vidner <mvidner@suse.com>
+
+- Filter the installation proposals (in the Installation Settings
+  screen) according to the AutoYaST profile even before
+  tab switching (bsc#1190294)
+- 4.1.55
+
+-------------------------------------------------------------------
 Thu Apr 29 13:14:40 CEST 2021 - Jozef Pupava <jpupava@suse.com>
 
 - Use linuxrc option "reboot_timeout" to configure the timeout

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.1.54
+Version:        4.1.55
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/installation/proposal_runner.rb
+++ b/src/lib/installation/proposal_runner.rb
@@ -473,9 +473,8 @@ module Installation
           @html[submod] = prop
 
           # now do the complete html
-          presentation_modules = @store.presentation_order
-          presentation_modules = presentation_modules[@current_tab] if @store.tabs?
-          proposal = presentation_modules.reduce("") do |res, mod|
+          load_matching_submodules_list
+          proposal = @submodules_presentation.reduce("") do |res, mod|
             res << (@html[mod] || "")
           end
           display_proposal(div_with_direction(proposal))


### PR DESCRIPTION
- https://trello.com/c/Bnc4V82U
- https://bugzilla.suse.com/show_bug.cgi?id=1190294 (L3Q)

Filter the installation proposals (in the Installation Settings screen) according to the AutoYaST profile even before tab switching 

The filtering code was only used after a tab change (in `switch_to_tab`), here apply it also for the initial display.

## Manual Test

I tested the fix with a profile that limited the proposals to *software* and *language*:

```xml
<profile xmlns="http://www.suse.com/1.0/yast2ns"
  xmlns:config="http://www.suse.com/1.0/configns">
  <general>
    <mode>
      <confirm config:type="boolean">true</confirm>
    </mode>
    <proposals config:type="list">
      <proposal>software_proposal</proposal>
      <proposal>language_proposal</proposal>
    </proposals>
  </general>
...
```

(full profile at <https://gist.github.com/mvidner/909181a348483fd367ab2c689880a293#file-minimal-sle-15-proposalmodulebug-sw-lang-xml>)

### Screenshots of a Tabbed Proposal, Before and After

This test used a stock `control.xml` file which has Installation Settings show two tabs, Overview and Expert.

<table>
<tr>
<th>Initial display<th>Switched to 2nd tab<th>Switched back</tr>
<tr>
<td>

![without-1](https://user-images.githubusercontent.com/102056/134831994-52521b5b-c14b-45e5-bc51-d6d6871dba81.png)

<td>

![without-2](https://user-images.githubusercontent.com/102056/134831999-580212f1-63f5-4467-9a58-240720cc2124.png)

<td>

![without-3](https://user-images.githubusercontent.com/102056/134832012-6531b108-6434-4bcd-bafb-47350e0d50d1.png)

</tr>
<tr>
<td>

![with-1](https://user-images.githubusercontent.com/102056/134832034-d776a482-2d49-4ed9-bdfb-cdba70e113a1.png)

<td>

![with-2](https://user-images.githubusercontent.com/102056/134832044-7e9fcb78-c82c-413d-b35e-f95e6856bee3.png)

<td>

![with-3](https://user-images.githubusercontent.com/102056/134832054-1e3a0a90-8cff-4592-92b9-88f12e41007b.png)

</tr>
</table>

## Screenshots of a Non-Tabbed Proposal, Before and After

This test used a modified `control.xml` that limited the proposal set to *software*, *timezone*, *language*, presenting them without tabs.

- [control.xml.diff](https://gist.github.com/mvidner/909181a348483fd367ab2c689880a293#file-control-xml-diff)
- [the full new control.xml](https://gist.github.com/mvidner/909181a348483fd367ab2c689880a293#file-control-xml)

<table>
<tr>
<th>Before<th>After
<tr><td>

![without-notabs](https://user-images.githubusercontent.com/102056/134832185-df0cc566-e4b9-4cff-856d-32c654f3318f.png)

<td>

![with-notabs](https://user-images.githubusercontent.com/102056/134832199-9176d8bd-caee-448c-9af0-3438bc799d3f.png)

</tr>
</table>
