### PR TITLE
Close the libzypp cache (bsc#1189793)

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Sep 29 16:13:17 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
+
+- Release the sources and close the libzypp cache to allow
+  cleanly unmounting /mnt/var/cache/zypp directory (bsc#1189793)
+- 4.4.19
+
+-------------------------------------------------------------------
 Thu Sep  9 15:54:57 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
 
 - Display release notes during upgrade (bsc#1186044)

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation
-Version:        4.4.18
+Version:        4.4.19
 Release:        0
 Summary:        YaST2 - Installation Parts
 License:        GPL-2.0-only

--- a/src/lib/installation/clients/pre_umount_finish.rb
+++ b/src/lib/installation/clients/pre_umount_finish.rb
@@ -59,6 +59,9 @@ module Installation
       # save all sources and finish target
       # bnc #398315
       Pkg.SourceSaveAll
+      # release the sources and unload the pool so the libzypp cache can be closed
+      # and /mnt/var/cache/zypp unmounted
+      Pkg.SourceFinishAll
       Pkg.TargetFinish
 
       # BNC #692799: Preserve the randomness state before umounting


### PR DESCRIPTION
- https://bugzilla.suse.com/show_bug.cgi?id=1189793
- Close the libzypp cache to allow cleanly unmounting `/mnt/var/cache/zypp` directory

### Debugging

- I have manually tested with the debugger that after calling `Pkg.SourceFinishAll` the `/mnt/var` directory can be cleanly unmounted:
![drop_zypp_cache](https://user-images.githubusercontent.com/907998/135309355-dc9015e4-3f37-4f2d-92cb-9c72e5a1aa1b.png)

### Testing

- Tested manually with patched installer (using `yupdate`), the `y2log` did not contain any error and the `/mnt/var` directory was cleanly unmounted.