### PR TITLE
[WIP] Self-update: faster product scanning on Full medium

### DIFF
--- a/src/lib/installation/update_repositories_finder.rb
+++ b/src/lib/installation/update_repositories_finder.rb
@@ -15,7 +15,7 @@
 
 require "yast"
 require "installation/update_repository"
-require "y2packager/product_location"
+require "y2packager/product_spec_readers/full"
 require "uri"
 
 Yast.import "Pkg"
@@ -186,8 +186,9 @@ module Installation
     end
 
     def update_product_dir(url)
+      reader = Y2Packager::ProductSpecReaders::Full.new
       # this scan is faster, but skips all GPG/checksum checks!
-      products = Y2Packager::ProductLocation.scan(url)
+      products = reader.products(url)
 
       # none or only one repository at the URL, use full scan
       return "" if products.empty?


### PR DESCRIPTION
## The Problem

When evaluating the self update repository YaST needs to detect the version of the product which is sent to SCC/SMT. This needs adding the installation repository and finding the product there.
But the SLE Full medium contains 23 subrepositories (for each product/module/extension) and YaST needs to load all of them because it does not know which one contains the requested product. And that takes quite a lot of time because `libzypp` verifies GPG signatures and SHA1 checksums of each downloaded file and then builds a binary cache.

## The Improvement

We could use the same trick as in the repository selection dialog which scans all products on the Full medium. The point is that scan uses `libsolv` directly and skips GPG checks and building the binary cache. This scan is used to find which repository (out of that 23) contains the requested product. Then the found repository is passed to `libzypp` which does all that GPG and SHA1 checks to avoid some potential security problems and the product version is evaluated just like before, but as `libzypp` needs to build only one cache for a small repository it is much faster.

This reduces the product scan from about 16 seconds to about 1 second, making the self update process about 15 seconds faster!

## Screencasts

The original SP3 installation using Full medium with self-update enabled, notice that "Building repository..." steps:
![self_update_slow2](https://user-images.githubusercontent.com/907998/143616871-a265c1e6-d710-4718-a1ae-ffe1702badf4.gif)

The patched installer is *much* faster:
![self_update_quick2](https://user-images.githubusercontent.com/907998/143616900-274186c8-fdb4-4569-b6b3-f35af5df2e71.gif)

## TODO

- [ ] Fix unit tests
- [ ] Add more comments