### PR TITLE
Handle release notes error

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Nov 30 14:45:45 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Do not crash when it is not possible to fetch the package
+  containing the release notes (bsc#1193148).
+- 4.4.24
+
+-------------------------------------------------------------------
 Wed Nov 24 15:13:23 UTC 2021 - David Diaz <dgonzalez@suse.com>
 
 - Remove no longer used extra warning about destructive actions

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -28,8 +28,8 @@ Source1:        YaST2-Second-Stage.service
 Source2:        YaST2-Firstboot.service
 
 BuildRequires:  update-desktop-files
-# ProductSpec API
-BuildRequires:  yast2 >= 4.4.21
+# y2packager/exceptions
+BuildRequires:  yast2 >= 4.4.24
 # CIOIgnore
 BuildRequires:  yast2-bootloader
 # storage-ng based version
@@ -70,8 +70,8 @@ Requires:       iproute2
 Requires:       pciutils
 # tar-gzip some system files and untar-ungzip them after the installation (FATE #300421, #120103)
 Requires:       tar
-# ProductSpec API
-Requires:       yast2 >= 4.4.21
+# y2packager/exceptions
+Requires:       yast2 >= 4.4.24
 # CIOIgnore
 Requires:       yast2-bootloader
 Requires:       yast2-country >= 3.3.1

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation
-Version:        4.4.23
+Version:        4.4.24
 Release:        0
 Summary:        YaST2 - Installation Parts
 License:        GPL-2.0-only

--- a/src/lib/installation/clients/inst_download_release_notes.rb
+++ b/src/lib/installation/clients/inst_download_release_notes.rb
@@ -151,7 +151,7 @@ module Yast
     def display_warning(products)
       # TRANSLATORS: 'product' stands for the product's name
       msg = HTML.Para(_("An error occurred when retrieving the release notes for the following products:")) +
-        HTML.List(products.map(&:name))
+        HTML.List(products.map(&:display_name))
       Yast::Report.LongWarning(msg)
     end
   end

--- a/src/lib/installation/clients/inst_download_release_notes.rb
+++ b/src/lib/installation/clients/inst_download_release_notes.rb
@@ -150,7 +150,7 @@ module Yast
     # Displays
     def display_warning(products)
       # TRANSLATORS: 'product' stands for the product's name
-      msg = HTML.Para(_("An error occurred when retrieving the release notes for the following products:")) +
+      msg = HTML.Para(_("The release notes for the following products could not be retrieved:")) +
         HTML.List(products.map(&:display_name))
       Yast::Report.LongWarning(msg)
     end

--- a/src/lib/installation/clients/inst_download_release_notes.rb
+++ b/src/lib/installation/clients/inst_download_release_notes.rb
@@ -152,7 +152,7 @@ module Yast
       # TRANSLATORS: 'product' stands for the product's name
       msg = HTML.Para(_("An error occurred when retrieving the release notes for the following products:")) +
         HTML.List(products.map(&:name))
-      Yast::Report.Warning(msg)
+      Yast::Report.LongWarning(msg)
     end
   end
 end

--- a/src/lib/installation/update_repository.rb
+++ b/src/lib/installation/update_repository.rb
@@ -20,6 +20,7 @@ require "packages/package_downloader"
 require "packages/package_extractor"
 require "y2packager/self_update_addon_filter"
 require "y2packager/resolvable"
+require "y2packager/exceptions"
 
 Yast.import "Pkg"
 Yast.import "Progress"
@@ -197,7 +198,7 @@ module Installation
         end
         @updates_file = build_squashfs(workdir, next_name(path, length: 3))
       end
-    rescue Packages::PackageDownloader::FetchError, Packages::PackageExtractor::ExtractionFailed,
+    rescue Y2Packager::PackageFetchError, Y2Packager::PackageExtractionError,
            CouldNotSquashPackage => e
       log.error("Could not fetch update: #{e.inspect}. Rolling back.")
       raise CouldNotFetchUpdate

--- a/test/lib/clients/inst_download_release_notes_test.rb
+++ b/test/lib/clients/inst_download_release_notes_test.rb
@@ -14,13 +14,15 @@ describe Yast::InstDownloadReleaseNotesClient do
 
     let(:sles) do
       instance_double(
-        Y2Packager::Product, name: "SUSE Linux Enteprise Server", short_name: "SLES", release_notes: sles_relnotes
+        Y2Packager::Product, name: "SLES", display_name: "SUSE Linux Enteprise Server",
+        short_name: "SLES", release_notes: sles_relnotes
       )
     end
 
     let(:sdk) do
       instance_double(
-        Y2Packager::Product, name: "Development Kit", short_name: "SDK", release_notes: sdk_relnotes
+        Y2Packager::Product, name: "sle-development-tools", display_name: "Development Kit",
+        short_name: "SDK", release_notes: sdk_relnotes
       )
     end
 
@@ -87,7 +89,7 @@ describe Yast::InstDownloadReleaseNotesClient do
       end
 
       it "warns the user" do
-        expect(Yast::Report).to receive(:LongWarning).with(/An error occurred/)
+        expect(Yast::Report).to receive(:LongWarning).with(/The release notes for/)
         client.main
       end
     end
@@ -98,7 +100,7 @@ describe Yast::InstDownloadReleaseNotesClient do
       end
 
       it "warns the user" do
-        expect(Yast::Report).to receive(:LongWarning).with(/An error occurred/)
+        expect(Yast::Report).to receive(:LongWarning).with(/The release notes for/)
         client.main
       end
     end

--- a/test/lib/clients/inst_download_release_notes_test.rb
+++ b/test/lib/clients/inst_download_release_notes_test.rb
@@ -87,7 +87,7 @@ describe Yast::InstDownloadReleaseNotesClient do
       end
 
       it "warns the user" do
-        expect(Yast::Report).to receive(:Warning).with(/An error occurred/)
+        expect(Yast::Report).to receive(:LongWarning).with(/An error occurred/)
         client.main
       end
     end
@@ -98,7 +98,7 @@ describe Yast::InstDownloadReleaseNotesClient do
       end
 
       it "warns the user" do
-        expect(Yast::Report).to receive(:Warning).with(/An error occurred/)
+        expect(Yast::Report).to receive(:LongWarning).with(/An error occurred/)
         client.main
       end
     end

--- a/test/lib/clients/inst_download_release_notes_test.rb
+++ b/test/lib/clients/inst_download_release_notes_test.rb
@@ -13,11 +13,15 @@ describe Yast::InstDownloadReleaseNotesClient do
     let(:language) { double("Yast::Language", language: "en_US") }
 
     let(:sles) do
-      instance_double(Y2Packager::Product, short_name: "SLES", release_notes: sles_relnotes)
+      instance_double(
+        Y2Packager::Product, name: "SUSE Linux Enteprise Server", short_name: "SLES", release_notes: sles_relnotes
+      )
     end
 
     let(:sdk) do
-      instance_double(Y2Packager::Product, short_name: "SDK", release_notes: sdk_relnotes)
+      instance_double(
+        Y2Packager::Product, name: "Development Kit", short_name: "SDK", release_notes: sdk_relnotes
+      )
     end
 
     let(:prod_reader) do
@@ -73,6 +77,28 @@ describe Yast::InstDownloadReleaseNotesClient do
       it "does not enable the release notes button" do
         expect(Yast::UI).to receive(:SetReleaseNotes).with({})
         expect(Yast::Wizard).to_not receive(:ShowReleaseNotesButton)
+        client.main
+      end
+    end
+
+    context "when it was not possible to fetch the package containing the release notes" do
+      before do
+        allow(sles).to receive(:release_notes).and_raise(Y2Packager::PackageFetchError)
+      end
+
+      it "warns the user" do
+        expect(Yast::Report).to receive(:Warning).with(/An error occurred/)
+        client.main
+      end
+    end
+
+    context "when it was not possible to extract the package containing the release notes" do
+      before do
+        allow(sles).to receive(:release_notes).and_raise(Y2Packager::PackageExtractionError)
+      end
+
+      it "warns the user" do
+        expect(Yast::Report).to receive(:Warning).with(/An error occurred/)
         client.main
       end
     end

--- a/test/update_repository_test.rb
+++ b/test/update_repository_test.rb
@@ -6,6 +6,7 @@ require "installation/update_repository"
 require "uri"
 require "pathname"
 require "stringio"
+require "y2packager/exceptions"
 
 describe Installation::UpdateRepository do
   TEMP_DIR = Pathname.new(__FILE__).dirname.join("tmp")
@@ -180,7 +181,7 @@ describe Installation::UpdateRepository do
     context "when a package can't be retrieved" do
       before do
         allow(downloader).to receive(:download)
-          .and_raise(Packages::PackageDownloader::FetchError)
+          .and_raise(Y2Packager::PackageFetchError)
       end
 
       it "raises a CouldNotFetchUpdate error" do
@@ -192,7 +193,7 @@ describe Installation::UpdateRepository do
     context "when a package can't be extracted" do
       it "raises a CouldNotFetchUpdate error" do
         expect(extractor).to receive(:extract)
-          .and_raise(Packages::PackageExtractor::ExtractionFailed)
+          .and_raise(Y2Packager::PackageExtractionError)
 
         expect { repo.fetch(download_path) }
           .to raise_error(Installation::UpdateRepository::CouldNotFetchUpdate)


### PR DESCRIPTION
Displays an error message when retrieving the release notes caused an error. See https://github.com/yast/yast-yast2/pull/1205.

![release-notes-errors](https://user-images.githubusercontent.com/15836/144271458-e6ec7149-bac1-4e30-9f36-7d909a6a3220.png)
