### PR TITLE
Drop support for subscription-tools (bsc#1193339)

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Dec  2 16:56:16 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
+
+- Drop support for subscription-tools, that package is not present
+  in SLE15 anymore (bsc#1193339)
+- 4.4.25
+
+-------------------------------------------------------------------
 Tue Nov 30 14:45:45 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Do not crash when it is not possible to fetch the package

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation
-Version:        4.4.24
+Version:        4.4.25
 Release:        0
 Summary:        YaST2 - Installation Parts
 License:        GPL-2.0-only

--- a/src/lib/installation/clients/copy_files_finish.rb
+++ b/src/lib/installation/clients/copy_files_finish.rb
@@ -33,7 +33,6 @@ Yast.import "Directory"
 Yast.import "Mode"
 Yast.import "Packages"
 Yast.import "ProductControl"
-Yast.import "ProductProfile"
 Yast.import "String"
 Yast.import "WorkflowManager"
 Yast.import "SystemFilesCopy"
@@ -87,7 +86,6 @@ module Yast
       # Copy /media.1/media to the installed system (fate#311377)
       # Formerly /media.1/build (bsc#1062297)
       copy_media_file
-      copy_product_profiles
 
       # List of files used as additional workflow definitions
       # TODO check if it is still needed
@@ -108,22 +106,6 @@ module Yast
     end
 
   private
-
-    def copy_product_profiles
-      all_profiles = ProductProfile.all_profiles
-      # copy all product profiles to the installed system (fate#310730)
-      return if all_profiles.empty?
-
-      target_dir = File.join(Installation.destdir, "/etc/productprofiles.d")
-      ::FileUtils.mkdir_p(target_dir)
-      all_profiles.each do |profile_path|
-        log.info "Copying '#{profile_path}' to #{target_dir}"
-        WFM.Execute(
-          path(".local.bash"),
-          "/usr/bin/cp -a #{profile_path.shellescape} #{target_dir.shellescape}/"
-        )
-      end
-    end
 
     def copy_hardware_status
       log.info "Copying hardware information"

--- a/src/lib/installation/clients/inst_system_analysis.rb
+++ b/src/lib/installation/clients/inst_system_analysis.rb
@@ -51,7 +51,6 @@ module Yast
       Yast.import "Packages"
       Yast.import "Popup"
       Yast.import "Product"
-      Yast.import "ProductProfile"
       Yast.import "ProductFeatures"
       Yast.import "Progress"
       Yast.import "Report"
@@ -155,9 +154,6 @@ module Yast
         return ret if ret == :restart_yast
       end
       Installation.probing_done = true
-
-      # the last step is hidden
-      return :abort if !skip_software && ProductProfile.CheckCompliance(nil) == false
 
       Progress.Finish
 

--- a/test/copy_files_finish_test.rb
+++ b/test/copy_files_finish_test.rb
@@ -217,17 +217,6 @@ describe Yast::CopyFilesFinishClient do
       subject.write
     end
 
-    it "copies all product profiles" do
-      allow(Yast::ProductProfile).to receive(:all_profiles).and_return(["/product1.xml", "/product2.xml"])
-      allow(::FileUtils).to receive(:mkdir_p)
-
-      expect(::FileUtils).to receive(:mkdir_p).with("/mnt/etc/productprofiles.d")
-      expect(::Yast::WFM).to receive(:Execute).with(path(".local.bash"), /cp.*\/product1.xml/)
-      expect(::Yast::WFM).to receive(:Execute).with(path(".local.bash"), /cp.*\/product2.xml/)
-
-      subject.write
-    end
-
     it "copies all used control files" do
       allow(Yast::WorkflowManager).to receive(:GetAllUsedControlFiles).and_return(["/control.xml", "/addon/addon.xml"])
 


### PR DESCRIPTION
- https://bugzilla.suse.com/show_bug.cgi?id=1193339
- The `subscription-tools` package is not present in SLE15 anymore
- 4.4.25