### PR TITLE
Fix complex welcome

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Fri Dec  3 06:53:52 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Display the product's license when only 1 product is available
+  in the online medium (bsc#1193223).
+- Do not display the product's selector during upgrade
+  (kanderssen@suse.com, bsc#1192230).
+- 4.2.26
+
+-------------------------------------------------------------------
 Thu Dec  2 16:56:16 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
 
 - Drop support for subscription-tools, that package is not present

--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -5,7 +5,7 @@ Fri Dec  3 06:53:52 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
   in the online medium (bsc#1193223).
 - Do not display the product's selector during upgrade
   (kanderssen@suse.com, bsc#1192230).
-- 4.2.26
+- 4.4.26
 
 -------------------------------------------------------------------
 Thu Dec  2 16:56:16 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation
-Version:        4.4.25
+Version:        4.4.26
 Release:        0
 Summary:        YaST2 - Installation Parts
 License:        GPL-2.0-only

--- a/src/lib/installation/clients/inst_complex_welcome.rb
+++ b/src/lib/installation/clients/inst_complex_welcome.rb
@@ -68,6 +68,9 @@ module Yast
 
       Yast::Wizard.EnableAbortButton
 
+      # Preselect the product if there is only one so the license can be shown.
+      products.first.select if products.size == 1 && !products.first.selected?
+
       loop do
         dialog_result = ::Installation::Dialogs::ComplexWelcome.run(
           products, disable_buttons: disable_buttons

--- a/src/lib/installation/clients/inst_complex_welcome.rb
+++ b/src/lib/installation/clients/inst_complex_welcome.rb
@@ -69,6 +69,8 @@ module Yast
       Yast::Wizard.EnableAbortButton
 
       # Preselect the product if there is only one so the license can be shown.
+      # As selecting a product can have side effects (especially in the full
+      # medium), do not select it twice.
       products.first.select if products.size == 1 && !products.first.selected?
 
       loop do

--- a/src/lib/installation/dialogs/complex_welcome.rb
+++ b/src/lib/installation/dialogs/complex_welcome.rb
@@ -153,7 +153,7 @@ module Installation
       #
       # @return [Boolean] true if the license must be shown; false otherwise
       def show_license?
-        products.size == 1 && products.first.respond_to?(:license)
+        products.size == 1 && products.first.license?
       end
 
       # Determine whether some product is available or not

--- a/src/lib/installation/dialogs/complex_welcome.rb
+++ b/src/lib/installation/dialogs/complex_welcome.rb
@@ -171,8 +171,9 @@ module Installation
       # @return [Yast::Term] Product selection content; Empty() if no products
       def license_or_product_content
         return Empty() unless available_products?
+        return product_selector if products.size > 1
 
-        show_license? ? product_license : product_selector
+        show_license? ? product_license : Empty()
       end
 
       # UI to fill space if needed

--- a/src/lib/installation/widgets/product_selector.rb
+++ b/src/lib/installation/widgets/product_selector.rb
@@ -52,7 +52,7 @@ module Installation
 
         return unless @product
 
-        @product.select
+        @product.select unless @product.selected?
       end
 
       def validate

--- a/test/lib/clients/inst_complex_welcome_test.rb
+++ b/test/lib/clients/inst_complex_welcome_test.rb
@@ -257,7 +257,7 @@ describe Yast::InstComplexWelcomeClient do
       end
     end
 
-    context "when only 1n product is available" do
+    context "when only 1 product is available" do
       let(:product_specs) { [product_spec] }
       let(:selected?) { false }
 

--- a/test/lib/clients/inst_complex_welcome_test.rb
+++ b/test/lib/clients/inst_complex_welcome_test.rb
@@ -19,7 +19,9 @@ describe Yast::InstComplexWelcomeClient do
       arch:                           "x86_64",
       base:                           true,
       order:                          1,
-      to_product:                     product
+      to_product:                     product,
+      selected?:                      false,
+      select:                         nil
     )
   end
 
@@ -31,7 +33,8 @@ describe Yast::InstComplexWelcomeClient do
       version:      "15.3",
       arch:         "x86_64",
       base:         true,
-      order:        2
+      order:        2,
+      selected?:    false
     )
   end
 
@@ -254,6 +257,12 @@ describe Yast::InstComplexWelcomeClient do
       end
     end
 
+    context "when only 1n product is available" do
+      let(:product_specs) { [product_spec] }
+      let(:selected?) { false }
+
+    end
+
     describe "dialog content" do
       context "when running on install mode" do
         let(:update_mode) { false }
@@ -276,6 +285,22 @@ describe Yast::InstComplexWelcomeClient do
               .with(product_specs, anything)
             subject.main
           end
+
+          it "preselects the product" do
+            expect(product_spec).to receive(:select)
+            subject.main
+          end
+
+          context "and the product is already selected" do
+            before do
+              allow(product_spec).to receive(:selected?).and_return(true)
+            end
+
+            it "does not preselect the product again" do
+              expect(product_spec).to_not receive(:select)
+              subject.main
+            end
+          end
         end
 
         # Test the behavior when the product name is hardcoded in the control file, which solves the
@@ -288,6 +313,7 @@ describe Yast::InstComplexWelcomeClient do
           it "runs the complex welcome dialog with the selected product" do
             expect(Installation::Dialogs::ComplexWelcome).to receive(:run)
               .with([other_product_spec], anything)
+            expect(other_product_spec).to receive(:select)
             subject.main
           end
         end

--- a/test/lib/dialogs/complex_welcome_test.rb
+++ b/test/lib/dialogs/complex_welcome_test.rb
@@ -48,12 +48,35 @@ describe Installation::Dialogs::ComplexWelcome do
 
   describe "#contents" do
     let(:license) { instance_double("Y2Packager::ProductLicense") }
-    let(:sles_product) { instance_double("Y2Packager::ProductSpec", label: "SLES", license: license) }
-    let(:sles_online_product) { instance_double("Y2Packager::ControlProductSpec", label: "SLES", license: license) }
-    let(:sles_offline_product) { instance_double("Y2Packager::RepoProductSpec", label: "SLES") }
-    let(:sled_product) { instance_double("Y2Packager::Product", label: "SLED", license: license) }
-    let(:sled_online_product) { instance_double("Y2Packager::ControlProductSpec", label: "SLED", license: license) }
-    let(:sled_offline_product) { instance_double("Y2Packager::RepoProductSpec", label: "SLED") }
+
+    let(:sles_product) do
+      instance_double("Y2Packager::ProductSpec", label: "SLES", license: license, license?: true)
+    end
+
+    let(:sles_online_product) do
+      instance_double(
+        "Y2Packager::ControlProductSpec", label: "SLES", license: license, license?: true
+      )
+    end
+
+    let(:sles_offline_product) do
+      instance_double("Y2Packager::RepoProductSpec", label: "SLES", license?: true)
+    end
+
+    let(:sled_product) do
+      instance_double("Y2Packager::Product", label: "SLED", license: license, license?: true)
+    end
+
+    let(:sled_online_product) do
+      instance_double(
+        "Y2Packager::ControlProductSpec", label: "SLED", license: license, license?: true
+      )
+    end
+
+    let(:sled_offline_product) do
+      instance_double("Y2Packager::RepoProductSpec", label: "SLED", license?: true)
+    end
+
     let(:language_widget) { Yast::Term.new(:language_widget) }
     let(:keyboard_widget) { Yast::Term.new(:keyboard_widget) }
     let(:license_widget) { Yast::Term.new(:license_widget) }
@@ -80,14 +103,25 @@ describe Installation::Dialogs::ComplexWelcome do
         let(:products) { [sles_product] }
         include_examples "show_license"
       end
+
       context "when it is the online medium" do
         let(:products) { [sles_online_product] }
         include_examples "show_license"
       end
+
       context "when it is the offline medium" do
         let(:products) { [sles_offline_product] }
+        include_examples "show_license"
+      end
 
-        it "does not show the license or the product selection" do
+      context "when the license is not available" do
+        let(:products) { [sles_product] }
+
+        before do
+          allow(sles_product).to receive(:license?).and_return(false)
+        end
+
+        it "does not show neither the license nor the product selection" do
           expect(Y2Packager::Widgets::ProductLicense).to_not receive(:new)
           expect(Installation::Widgets::ProductSelector).to_not receive(:new)
 

--- a/test/lib/dialogs/complex_welcome_test.rb
+++ b/test/lib/dialogs/complex_welcome_test.rb
@@ -46,7 +46,7 @@ describe Installation::Dialogs::ComplexWelcome do
     end
   end
 
-  describe "#content" do
+  describe "#contents" do
     let(:license) { instance_double("Y2Packager::ProductLicense") }
     let(:sles_product) { instance_double("Y2Packager::ProductSpec", label: "SLES", license: license) }
     let(:sles_online_product) { instance_double("Y2Packager::ControlProductSpec", label: "SLES", license: license) }
@@ -86,7 +86,13 @@ describe Installation::Dialogs::ComplexWelcome do
       end
       context "when it is the offline medium" do
         let(:products) { [sles_offline_product] }
-        include_examples "show_selector"
+
+        it "does not show the license or the product selection" do
+          expect(Y2Packager::Widgets::ProductLicense).to_not receive(:new)
+          expect(Installation::Widgets::ProductSelector).to_not receive(:new)
+
+          widget.contents
+        end
       end
     end
 

--- a/test/lib/widgets/product_selector_test.rb
+++ b/test/lib/widgets/product_selector_test.rb
@@ -86,5 +86,16 @@ describe ::Installation::Widgets::ProductSelector do
       expect(product2).to_not receive(:select)
       subject.store
     end
+
+    context "when the product was already selected" do
+      before do
+        allow(product1).to receive(:selected?).and_return(true)
+      end
+
+      it "does not select the product again" do
+        expect(product1).to_not receive(:select)
+        subject.store
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR fixes [bsc#1193223](https://bugzilla.suse.com/show_bug.cgi?id=1193223) and [bsc#1192230](https://bugzilla.suse.com/show_bug.cgi?id=1192230).

* When a single product is found, preselect the product and show the license.
* When a single product is found *during upgrade* and the license is not available, do not try to show the license.

Trello:

* https://trello.com/c/fhSncPcg/
* https://trello.com/c/jAaewORI/

## TODO

- Tests
  - [x] Online medium s390 with a single product
  - [x] Full medium s390 with a single product
  - [x] Online medium with multiple products (e.g., x86_64)
  - [ ] Full medium with multiple products (e.g., x86_64)
  - [x] Standard medium (openSUSE)