### PR TITLE
Self-update: do not scan the installation medium (bsc#1193536)

### DIFF
--- a/doc/SELF_UPDATE.md
+++ b/doc/SELF_UPDATE.md
@@ -164,10 +164,10 @@ The URL of the update repository is evaluated in this order:
    - `$arch` - is replaced by the RPM package architecture used by the machine
      (like `x86_64` or `ppc64le`)
    - These variables are replaced by the value from the `/etc/os-release` file:
-     - `$os_release_name`       => `NAME`
-     - `$os_release_id`         => `ID`
-     - `$os_release_version`    => `VERSION`
-     - `$os_release_version_id` => `VERSION_ID`
+     - `$os_release_name`       => `NAME`       (e.g. `SLE`)
+     - `$os_release_id`         => `ID`         (e.g. `sle`)
+     - `$os_release_version`    => `VERSION`    (e.g. `15-SP4`)
+     - `$os_release_version_id` => `VERSION_ID` (e.g. `15.4`)
 
 The first suitable URL will be used. There are two exceptions:
 

--- a/doc/SELF_UPDATE.md
+++ b/doc/SELF_UPDATE.md
@@ -8,9 +8,9 @@ installation even after the media has been released. Check
 ### :information_source: Note
 
 The self update feature is removed from the updated SLE Service Pack media
-(the updated media released after the initial SP release), these media already
-contain the updated installer and the included updates could conflict with
-the self updates.
+(the updated media released after the initial SP release, so called "quarterly
+updates"), these media already contain the updated installer and the included
+updates could conflict with the self updates.
 
 If you need to patch the installer on these updated media you have to use
 a driver update disk (DUD).
@@ -31,7 +31,7 @@ using AutoYaST, it is also possible to disable this feature using the
 Please, take into account that self-update will be skipped if any option
 disables it (boot parameter *or* AutoYaST profile).
 
-During the rest of this document it is assumed that self-update is enabled.
+For the rest of this document it is assumed that the self-update is enabled.
 
 ## Basic Workflow
 
@@ -136,17 +136,20 @@ The URL of the update repository is evaluated in this order:
 
    The registration server is then asked for the list of update repositories.
    In order to determine such list, the product `name`, `version` and
-   `architecture` are used
+   `architecture` are used.
 
-   In case of a multi-product installation medium, as the installer is the same
-   for all the included products, the product `name` can be hard-coded in the
-   `control.xml` file with the `/globals/self_update_id` XML node.
+   The product `name` and `version` are hard-coded in the
+   `control.xml` file in the `/globals/self_update_id` and
+   `/globals/self_update_version` XML nodes.
 
    ```xml
    <globals>
      <self_update_id>SLES</self_update_id>
    </globals>
    ```
+
+   If the `self_update_version` value is missing then the `VERSION_ID` value
+   from the `/etc/os-release` file is used as a fallback.
 
 4. Hard-coded in the `control.xml` file on the installation medium (thus it
    depends on the base product):
@@ -156,6 +159,12 @@ The URL of the update repository is evaluated in this order:
      <self_update_url>https://updates.suse.com/SUSE/Updates/SLE-INSTALLER/$os_release_version/$arch/update</self_update_url>
    </globals>
    ```
+
+   This URL can contain these variables which are replaced by YaST:
+   - `$os_release_version` - is replaced by the `VERSION` value from the
+     `/etc/os-release` file
+   - `$arch` - is replaced by the RPM package architecture used by the machine
+     (like `x86_64` or `ppc64le`)
 
 The first suitable URL will be used. There are two exceptions:
 
@@ -201,9 +210,6 @@ SSL certificate should be preferred.
 The URL can contain a variable `$arch` that will be replaced by the system's
 architecture, such as `x86_64`, `i586`, `s390x`, etc.
 
-YaST uses [libzypp](https://github.com/openSUSE/libzypp/blob/e68b5df6c96e3f1d140ba15e2a9e85a990210f37/zypp/ZConfig.cc#L63)
-for detecting the system architecture so the `$arch` expansion is compatible
-with the expansion used in usual repository URLs.
 
 ### Actual URLs
 
@@ -211,7 +217,8 @@ When using registration servers, the regular update URLs have the form
 `https://updates.suse.com/SUSE/Updates/$PRODUCT/$VERSION/$ARCH/update` where
 - PRODUCT is like OpenStack-Cloud, SLE-DESKTOP, SLE-SDK, SLE-SERVER,
 - VERSION (for SLE-SERVER) is like 12, 12-SP1,
-- ARCH is one of `aarch64` `ppc64le` `s390x` `x86_64`
+- ARCH is one of `aarch64`, `ppc64le`, `s390x` or `x86_64`
+  (all archs supported by the SLE product line)
 
 For the self-update the *PRODUCT* is replaced
 with *PRODUCT*-INSTALLER, producing these repository paths
@@ -230,7 +237,7 @@ versions of some specific packages in the self-update repository and in the inst
 If any unexpected version is found then an error is displayed and the self-update
 step is completely skipped.
 
-Is is possible to skip this validation is special cases and force applying the
+It is possible to skip this validation is special cases and force applying the
 updates despite the version mismatch by setting environment variable
 `Y2_FORCE_SELF_UPDATE=1`. *This should be done only in special cases (testing)
 when you know what you are doing!*

--- a/doc/SELF_UPDATE.md
+++ b/doc/SELF_UPDATE.md
@@ -160,14 +160,8 @@ The URL of the update repository is evaluated in this order:
    </globals>
    ```
 
-   This URL can contain these variables which are replaced by YaST:
-   - `$arch` - is replaced by the RPM package architecture used by the machine
-     (like `x86_64` or `ppc64le`)
-   - These variables are replaced by the value from the `/etc/os-release` file:
-     - `$os_release_name`       => `NAME`       (e.g. `SLE`)
-     - `$os_release_id`         => `ID`         (e.g. `sle`)
-     - `$os_release_version`    => `VERSION`    (e.g. `15-SP4`)
-     - `$os_release_version_id` => `VERSION_ID` (e.g. `15.4`)
+   The variables are documented in the [variable expansion](#variable-expansion)
+   section below.
 
 The first suitable URL will be used. There are two exceptions:
 
@@ -212,6 +206,15 @@ SSL certificate should be preferred.
 
 The URL can contain a variable `$arch` that will be replaced by the system's
 architecture, such as `x86_64`, `i586`, `s390x`, etc.
+
+The URLs can contain these variables which are replaced by YaST:
+- `$arch` - is replaced by the RPM package architecture used by the machine
+ (like `x86_64` or `ppc64le`)
+- These variables are replaced by the value from the `/etc/os-release` file:
+ - `$os_release_name`       => `NAME`       (e.g. `SLE`)
+ - `$os_release_id`         => `ID`         (e.g. `sle`)
+ - `$os_release_version`    => `VERSION`    (e.g. `15-SP4`)
+ - `$os_release_version_id` => `VERSION_ID` (e.g. `15.4`)
 
 
 ### Actual URLs

--- a/doc/SELF_UPDATE.md
+++ b/doc/SELF_UPDATE.md
@@ -161,10 +161,13 @@ The URL of the update repository is evaluated in this order:
    ```
 
    This URL can contain these variables which are replaced by YaST:
-   - `$os_release_version` - is replaced by the `VERSION` value from the
-     `/etc/os-release` file
    - `$arch` - is replaced by the RPM package architecture used by the machine
      (like `x86_64` or `ppc64le`)
+   - These variables are replaced by the value from the `/etc/os-release` file:
+     - `$os_release_name`       => `NAME`
+     - `$os_release_id`         => `ID`
+     - `$os_release_version`    => `VERSION`
+     - `$os_release_version_id` => `VERSION_ID`
 
 The first suitable URL will be used. There are two exceptions:
 

--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu Dec  9 15:56:25 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
+
+- Improve the self-update process, do not read the products from
+  the installation medium (bsc#1193536)
+- Adde more /etc/os-release replacements in the self-update URL
+- 4.4.27
+
+-------------------------------------------------------------------
 Fri Dec  3 06:53:52 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Display the product's license when only 1 product is available

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation
-Version:        4.4.26
+Version:        4.4.27
 Release:        0
 Summary:        YaST2 - Installation Parts
 License:        GPL-2.0-only

--- a/src/lib/installation/update_repositories_finder.rb
+++ b/src/lib/installation/update_repositories_finder.rb
@@ -151,7 +151,11 @@ module Installation
     # Converts the string into an URI if it's valid
     #
     # Substituting $arch pattern with the architecture of the current system.
-    # Substituting $os_release_version pattern with the release of the current system.
+    # Substituting these variables with the /etc/os-release content:
+    #   $os_release_name       => NAME
+    #   $os_release_id         => ID
+    #   $os_release_version    => VERSION
+    #   $os_release_version_id => VERSION_ID
     #
     # @return [URI,nil] The string converted into a URL; nil if it's
     #                   not a valid URL.
@@ -160,6 +164,12 @@ module Installation
     def get_url_from(url)
       return nil unless url.is_a?(::String)
       real_url = url.gsub(/\$arch\b/, Yast::Pkg.GetArchitecture)
+      real_url = real_url.gsub(/\$os_release_name\b/,
+        Yast::OSRelease.ReleaseName)
+      real_url = real_url.gsub(/\$os_release_id\b/,
+        Yast::OSRelease.id)
+      real_url = real_url.gsub(/\$os_release_version_id\b/,
+        Yast::OSRelease.ReleaseVersion)
       real_url = real_url.gsub(/\$os_release_version\b/,
         Yast::OSRelease.ReleaseVersionHumanReadable)
       URI.regexp.match(real_url) ? URI(real_url) : nil

--- a/src/lib/installation/update_repositories_finder.rb
+++ b/src/lib/installation/update_repositories_finder.rb
@@ -86,7 +86,6 @@ module Installation
       return [] unless defined?(::Registration::UrlHelpers)
       # load the base product from the installation medium,
       # the registration server needs it for evaluating the self update URL
-      add_installation_repo
       urls = update_urls_from_connect
       urls ? urls.map { |u| UpdateRepository.new(u, :default) } : []
     end
@@ -164,23 +163,6 @@ module Installation
       real_url = real_url.gsub(/\$os_release_version\b/,
         Yast::OSRelease.ReleaseVersionHumanReadable)
       URI.regexp.match(real_url) ? URI(real_url) : nil
-    end
-
-    # Loads the base product from the installation medium
-    def add_installation_repo
-      base_url = Yast::InstURL.installInf2Url("")
-      initial_repository = Yast::Pkg.SourceCreateBase(base_url, "")
-
-      until initial_repository
-        log.error "Adding the installation repository failed"
-        # ask user to retry
-        base_url = Packages.UpdateSourceURL(base_url)
-
-        # aborted by user
-        return false if base_url == ""
-
-        initial_repository = Yast::Pkg.SourceCreateBase(base_url, "")
-      end
     end
 
     # Return the URL of the preferred registration server


### PR DESCRIPTION
- https://bugzilla.suse.com/show_bug.cgi?id=1193536
- Do not scan the installation repository for the self update products, it takes very long time on the SLE Full medium
- Updated documentation
- See more details in https://github.com/yast/yast-registration/pull/552