### PR TITLE
Backports fix for bsc#1180142 to SLE 12

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Dec 10 11:50:58 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Do not crash when it is not possible to create a snapshot after
+  installing or upgrading the system (bsc#1180142).
+- 3.2.57.1
+
+-------------------------------------------------------------------
 Wed Aug  1 16:43:45 CEST 2018 - schubi@suse.de
 
 - Disable display of status messages on the console (bsc#1099505).

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation
-Version:        3.2.57
+Version:        3.2.57.1
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -41,14 +41,14 @@ BuildRequires:  yast2-xml
 BuildRequires:  rubygem(rspec)
 BuildRequires:  rubygem(yast-rake)
 
-# CWM::RadioButtons#vspacing
-BuildRequires: yast2 >= 3.2.20
+# Yast2::FsSnapshotStore::IOError
+BuildRequires:  yast2 >= 3.2.46.2
 
 # AutoinstSoftware.SavePackageSelection()
 Requires:       autoyast2-installation >= 3.1.105
 
-# PackageDownloader and PackageExtractor
-Requires:       yast2 >= 3.2.19
+# Yast2::FsSnapshotStore::IOError
+Requires:       yast2 >= 3.2.46.2
 
 # Language::GetLanguageItems and other API
 # Language::Set (handles downloading the translation extensions)

--- a/src/lib/installation/snapshots_finish.rb
+++ b/src/lib/installation/snapshots_finish.rb
@@ -13,6 +13,7 @@ module Installation
       Yast.import "Mode"
       Yast.import "StorageSnapper"
       Yast.import "InstFunctions"
+      Yast.import "Report"
       Yast.include self, "installation/misc.rb"
     end
 
@@ -49,12 +50,18 @@ module Installation
       Yast2::FsSnapshot.create_post(_("after update"), pre_number, cleanup: :number, important: true)
       Yast2::FsSnapshotStore.clean("update")
       true
+    rescue Yast2::SnapshotCreationFailed, Yast2::FsSnapshotsStore::IOError
+      Yast::Report.Error(_("Could not create a post-update snapshot."))
+      false
     end
 
     def create_single_snapshot
       # TRANSLATORS: label for filesystem snapshot taken after system installation
       Yast2::FsSnapshot.create_single(_("after installation"), cleanup: :number, important: true)
       true
+    rescue Yast2::SnapshotCreationFailed
+      Yast::Report.Error(_("Could not create a post-installation snapshot."))
+      false
     end
   end
 end

--- a/src/lib/installation/snapshots_finish.rb
+++ b/src/lib/installation/snapshots_finish.rb
@@ -50,7 +50,8 @@ module Installation
       Yast2::FsSnapshot.create_post(_("after update"), pre_number, cleanup: :number, important: true)
       Yast2::FsSnapshotStore.clean("update")
       true
-    rescue Yast2::SnapshotCreationFailed, Yast2::FsSnapshotsStore::IOError
+    rescue Yast2::SnapshotCreationFailed, Yast2::FsSnapshotsStore::IOError => error
+      log.error("Error creating a post-update snapshot: #{error}")
       Yast::Report.Error(_("Could not create a post-update snapshot."))
       false
     end
@@ -59,7 +60,8 @@ module Installation
       # TRANSLATORS: label for filesystem snapshot taken after system installation
       Yast2::FsSnapshot.create_single(_("after installation"), cleanup: :number, important: true)
       true
-    rescue Yast2::SnapshotCreationFailed
+    rescue Yast2::SnapshotCreationFailed => error
+      log.error("Error creating a post-installation snapshot: #{error}")
       Yast::Report.Error(_("Could not create a post-installation snapshot."))
       false
     end

--- a/src/lib/installation/snapshots_finish.rb
+++ b/src/lib/installation/snapshots_finish.rb
@@ -50,7 +50,7 @@ module Installation
       Yast2::FsSnapshot.create_post(_("after update"), pre_number, cleanup: :number, important: true)
       Yast2::FsSnapshotStore.clean("update")
       true
-    rescue Yast2::SnapshotCreationFailed, Yast2::FsSnapshotsStore::IOError => error
+    rescue Yast2::SnapshotCreationFailed, Yast2::FsSnapshotStore::IOError => error
       log.error("Error creating a post-update snapshot: #{error}")
       Yast::Report.Error(_("Could not create a post-update snapshot."))
       false

--- a/test/snapshots_finish_test.rb
+++ b/test/snapshots_finish_test.rb
@@ -47,13 +47,28 @@ describe ::Installation::SnapshotsFinish do
         context "when updating" do
           before do
             allow(Yast::Mode).to receive(:update).and_return(true)
+            allow(Yast2::FsSnapshotStore).to receive(:load).with("update").and_return(1)
+            allow(Yast2::FsSnapshotStore).to receive(:clean).with("update")
           end
 
           it "creates a snapshot of type 'post' with 'after update' as description and paired with 'pre' snapshot" do
-            expect(Yast2::FsSnapshotStore).to receive(:load).with("update").and_return(1)
-            expect(Yast2::FsSnapshotStore).to receive(:clean).with("update")
             expect(Yast2::FsSnapshot).to receive(:create_post).with("after update", 1, cleanup: :number, important: true).and_return(true)
             expect(subject.write).to eq(true)
+          end
+
+          context "and could not create the snapshot" do
+            before do
+              allow(Yast2::FsSnapshot).to receive(:create_post).and_raise(Yast2::SnapshotCreationFailed)
+            end
+
+            it "returns false" do
+              expect(subject.write).to eq(false)
+            end
+
+            it "reports the problem to the user" do
+              expect(Yast::Report).to receive(:Error).with(/snapshot/)
+              subject.write
+            end
           end
         end
 
@@ -65,6 +80,21 @@ describe ::Installation::SnapshotsFinish do
           it "creates a snapshot of type 'single' with 'after installation' as description" do
             expect(Yast2::FsSnapshot).to receive(:create_single).with("after installation", cleanup: :number, important: true).and_return(true)
             expect(subject.write).to eq(true)
+          end
+
+          context "and could not create the snapshot" do
+            before do
+              allow(Yast2::FsSnapshot).to receive(:create_single).and_raise(Yast2::SnapshotCreationFailed)
+            end
+
+            it "returns false" do
+              expect(subject.write).to eq(false)
+            end
+
+            it "reports the problem to the user" do
+              expect(Yast::Report).to receive(:Error).with(/snapshot/)
+              subject.write
+            end
           end
         end
       end


### PR DESCRIPTION
Backport fix for [bsc#1180142](https://bugzilla.suse.com/show_bug.cgi?id=1180142) to SLE 12 SP3. Please, check #901 for details about the original fix.

Related to:

* https://github.com/yast/yast-yast2/pull/1211
* https://github.com/yast/yast-update/pull/176