### PR TITLE
bsc#1192230: do not preselect during upgrade

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Dec 16 07:34:27 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Do not preselect any product during upgrade (related to
+  bsc#1192230).
+- 4.4.29
+
+-------------------------------------------------------------------
 Thu Dec  9 16:07:34 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
 
 - Improve the self-update process, do not read the products from

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation
-Version:        4.4.28
+Version:        4.4.29
 Release:        0
 Summary:        YaST2 - Installation Parts
 License:        GPL-2.0-only

--- a/src/lib/installation/clients/inst_complex_welcome.rb
+++ b/src/lib/installation/clients/inst_complex_welcome.rb
@@ -68,10 +68,7 @@ module Yast
 
       Yast::Wizard.EnableAbortButton
 
-      # Preselect the product if there is only one so the license can be shown.
-      # As selecting a product can have side effects (especially in the full
-      # medium), do not select it twice.
-      products.first.select if products.size == 1 && !products.first.selected?
+      preselect_product_if_needed
 
       loop do
         dialog_result = ::Installation::Dialogs::ComplexWelcome.run(
@@ -224,6 +221,21 @@ module Yast
       end
 
       true
+    end
+
+    # Preselects the product if required
+    #
+    # The product is preselected if:
+    #
+    # * There is only a single base product available.
+    # * The installer is not running on update mode. In this case, the product
+    #   is selected when the user choses which system to upgrade.
+    def preselect_product_if_needed
+      return if Mode.update || products.size != 1
+
+      # As selecting a product can have side effects (especially in the full
+      # medium), do not select it twice.
+      products.first.select unless products.first.selected?
     end
   end unless defined? Yast::InstComplexWelcomeClient
 end

--- a/test/lib/clients/inst_complex_welcome_test.rb
+++ b/test/lib/clients/inst_complex_welcome_test.rb
@@ -340,6 +340,11 @@ describe Yast::InstComplexWelcomeClient do
               .with(product_specs, anything)
             subject.main
           end
+
+          it "does not preselect the product" do
+            expect(product_spec).to_not receive(:select)
+            subject.main
+          end
         end
       end
     end


### PR DESCRIPTION
PR #999 introduced a change to preselect the product when just a single one is available. However, this behavior should be avoided during upgrades. See [comment 25 on bsc#1192230](https://bugzilla.suse.com/show_bug.cgi?id=1192230#c25).