### PR TITLE
Do not propose Linux Security Module default config when declared as not configurable

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Jan  5 09:45:20 UTC 2022 - Knut Anderssen <kanderssen@suse.com>
+
+- Do not propose Linux Security Module default configuration when
+  it is declared as not configurable in the control file or in the
+  AutoYaST profile (related to jsc#SLE-22069).
+- 4.4.32
+
+-------------------------------------------------------------------
 Mon Dec 27 07:22:50 UTC 2021 - Knut Alejandro Anderssen González <kanderssen@suse.com>
 
 - Add support for selecting and configuring the desired Linux

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation
-Version:        4.4.31
+Version:        4.4.32
 Release:        0
 Summary:        YaST2 - Installation Parts
 License:        GPL-2.0-only

--- a/src/lib/installation/security_settings.rb
+++ b/src/lib/installation/security_settings.rb
@@ -70,8 +70,8 @@ module Installation
     # When Linux Security Module is declared as configurable and there is no Module selected yet
     # it will select the desired LSM and the needed patterns for it accordingly
     def propose_lsm_config
-      return false unless lsm_config.configurable?
-      return false if lsm_config.selected
+      return unless lsm_config.configurable?
+      return if lsm_config.selected
 
       lsm_config.propose_default
       # It will be set even if the proposal is not shown (e.g. configurable but not selectable)

--- a/src/lib/installation/security_settings.rb
+++ b/src/lib/installation/security_settings.rb
@@ -53,7 +53,7 @@ module Installation
       enable_sshd! if wanted_enable_sshd?
       open_ssh! if wanted_open_ssh?
       open_vnc! if wanted_open_vnc?
-      lsm_config.propose_default unless lsm_config.selected
+      propose_lsm_config
       # FIXME: obtain from Y2Firewall::Firewalld, control file or allow to
       # chose a different one in the proposal
       @default_zone = "public"
@@ -65,6 +65,17 @@ module Installation
       load_feature(:firewall_enable_ssh, :open_ssh)
       load_feature(:enable_sshd, :enable_sshd)
       load_feature(:polkit_default_privs, :polkit_default_privileges)
+    end
+
+    # When Linux Security Module is declared as configurable and there is no Module selected yet
+    # it will select the desired LSM and the needed patterns for it accordingly
+    def propose_lsm_config
+      return false unless lsm_config.configurable?
+      return false if lsm_config.selected
+
+      lsm_config.propose_default
+      # It will be set even if the proposal is not shown (e.g. configurable but not selectable)
+      Yast::PackagesProposal.SetResolvables("LSM", :pattern, lsm_config.needed_patterns)
     end
 
     # Services

--- a/test/lib/clients/security_proposal_test.rb
+++ b/test/lib/clients/security_proposal_test.rb
@@ -102,12 +102,12 @@ describe Installation::Clients::SecurityProposal do
 
   describe "#make_proposal" do
     let(:firewall_enabled) { false }
+    let(:lsm_configurable) { false }
 
     before do
       allow(proposal_settings).to receive("enable_firewall").and_return(firewall_enabled)
-
-      allow(proposal_settings.lsm_config).to receive(:configurable?)
-        .and_return(false)
+      allow(proposal_settings.lsm_config).to receive(:configurable?).and_return(lsm_configurable)
+      allow(proposal_settings.lsm_config).to receive(:propose_default)
     end
 
     it "returns a hash with 'preformatted_proposal', 'links', 'warning_level' and 'warning'" do
@@ -137,10 +137,11 @@ describe Installation::Clients::SecurityProposal do
     end
 
     context "when LSM is configurable" do
+      let(:lsm_configurable) { true }
+
       it "contains the LSM configuration" do
-        allow(proposal_settings.lsm_config).to receive(:configurable?)
-          .and_return(true)
         allow(Yast::Bootloader).to receive(:kernel_param).and_return(:missing)
+        proposal_settings.lsm_config.select(:selinux)
 
         proposal = client.make_proposal({})
 

--- a/test/lib/security_settings_test.rb
+++ b/test/lib/security_settings_test.rb
@@ -135,10 +135,6 @@ describe Installation::SecuritySettings do
         expect(lsm_config).to_not receive(:propose_default)
         subject.propose_lsm_config
       end
-
-      it "returns false" do
-        expect(subject.propose_lsm_config).to eql(false)
-      end
     end
 
     context "when Linux Security Module is declared as configurable" do
@@ -157,10 +153,6 @@ describe Installation::SecuritySettings do
         it "does not propose any module" do
           expect(lsm_config).to_not receive(:propose_default)
           subject.propose_lsm_config
-        end
-
-        it "returns false" do
-          expect(subject.propose_lsm_config).to eql(false)
         end
       end
 

--- a/test/lib/security_settings_test.rb
+++ b/test/lib/security_settings_test.rb
@@ -161,6 +161,7 @@ describe Installation::SecuritySettings do
           # The initialization already calls propose default so we force a initialization but
           # resetting the lsm_config
           subject.lsm_config.reset
+          lsm_config.configurable = true
           allow(lsm_config).to receive(:needed_patterns).and_return(["selinux"])
         end
 

--- a/test/lib/security_settings_test.rb
+++ b/test/lib/security_settings_test.rb
@@ -120,6 +120,72 @@ describe Installation::SecuritySettings do
     end
   end
 
+  describe "#propose_lsm_config" do
+    let(:lsm_config) { Y2Security::LSM::Config.instance }
+    before do
+      lsm_config.reset
+    end
+
+    context "when Linux Security Module is declared as not configurable" do
+      before do
+        lsm_config.configurable = false
+      end
+
+      it "does not propose any module" do
+        expect(lsm_config).to_not receive(:propose_default)
+        subject.propose_lsm_config
+      end
+
+      it "returns false" do
+        expect(subject.propose_lsm_config).to eql(false)
+      end
+    end
+
+    context "when Linux Security Module is declared as configurable" do
+      before do
+        lsm_config.configurable = true
+        allow(Yast::PackagesProposal).to receive("SetResolvables")
+          .with("LSM", :pattern, anything)
+        allow(subject).to receive(:propose_default)
+      end
+
+      context "but there is already a module selected" do
+        before do
+          lsm_config.select(:apparmor)
+        end
+
+        it "does not propose any module" do
+          expect(lsm_config).to_not receive(:propose_default)
+          subject.propose_lsm_config
+        end
+
+        it "returns false" do
+          expect(subject.propose_lsm_config).to eql(false)
+        end
+      end
+
+      context "and there is no module selected" do
+        before do
+          # The initialization already calls propose default so we force a initialization but
+          # resetting the lsm_config
+          subject.lsm_config.reset
+          allow(lsm_config).to receive(:needed_patterns).and_return(["selinux"])
+        end
+
+        it "selects the module declared as the default one to be selected" do
+          expect(lsm_config).to receive(:propose_default)
+          subject.propose_lsm_config
+        end
+
+        it "sets the needed patterns for the selected module" do
+          expect(Yast::PackagesProposal).to receive("SetResolvables")
+            .with("LSM", :pattern, ["selinux"])
+          subject.propose_lsm_config
+        end
+      end
+    end
+  end
+
   describe "#enable_firewall!" do
     it "sets firewalld service to be enabled" do
       allow(Yast::PackagesProposal).to receive("AddResolvables")


### PR DESCRIPTION
Do not propose **Linux Security Module** default configuration when it is declared as **not configurable** avoiding the write of the **kernel boot parameters** when are not needed / wanted. For more details see https://github.com/yast/yast-security/pull/117