### PR TITLE
Enable RSpec verifying doubles in unit tests (bsc#1194784)

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Thu Jan 20 08:52:18 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
+
+- Enable RSpec verifying doubles in unit tests to ensue that
+  the mocked methods really exist (bsc#1194784)
+- Fixed crash when importing an SSH configuration in AutoYaST
+  installation
+- 4.4.35
+
+-------------------------------------------------------------------
 Wed Jan 12 13:02:56 UTC 2022 - Josef Reidinger <jreidinger@suse.com>
 
 - Show release notes button in progress in Qt interface

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation
-Version:        4.4.34
+Version:        4.4.35
 Release:        0
 Summary:        YaST2 - Installation Parts
 License:        GPL-2.0-only
@@ -41,8 +41,8 @@ BuildRequires:  yast2-firewall
 BuildRequires:  yast2-network >= 4.4.12
 # ProductSpec API
 BuildRequires:  yast2-packager >= 4.4.13
-# for AbortException and handle direct abort
-BuildRequires:  yast2-ruby-bindings >= 4.0.6
+# yast/rspec/helpers.rb
+BuildRequires:  yast2-ruby-bindings >= 4.4.7
 # For LSM classes
 BuildRequires:  yast2-security
 # using /usr/bin/udevadm

--- a/src/lib/installation/clients/ssh_import_auto.rb
+++ b/src/lib/installation/clients/ssh_import_auto.rb
@@ -133,7 +133,7 @@ module Installation
         Popup.Notify _("It makes no sense to write these settings to system.")
         true
       else
-        ssh_importer.write(::Installation.destdir)
+        ssh_importer.write(Yast::Installation.destdir)
       end
     end
 

--- a/test/inst_update_installer_test.rb
+++ b/test/inst_update_installer_test.rb
@@ -56,7 +56,6 @@ describe Yast::InstUpdateInstaller do
     allow(subject).to receive(:fetch_profile).and_return(ay_profile)
     allow(subject).to receive(:process_profile)
     allow(subject).to receive(:valid_repositories?).and_return(true)
-    allow(finder).to receive(:add_installation_repo)
 
     # stub the Profile module to avoid dependency on autoyast2-installation
     stub_const("Yast::Profile", ay_profile)

--- a/test/lib/clients/inst_complex_welcome_test.rb
+++ b/test/lib/clients/inst_complex_welcome_test.rb
@@ -108,7 +108,6 @@ describe Yast::InstComplexWelcomeClient do
         allow(Yast::FileUtils).to receive(:Exists).with("/README.BETA")
           .and_return(true)
         allow(Yast::GetInstArgs).to receive(:going_back).and_return(false)
-        allow(subject).to receive(:event_loop)
         allow(Yast::ProductLicense).to receive(:AcceptanceNeeded).and_return(false)
       end
 

--- a/test/lib/clients/security_finish_test.rb
+++ b/test/lib/clients/security_finish_test.rb
@@ -108,7 +108,7 @@ describe Installation::Clients::SecurityFinish do
       end
 
       it "skips writting policy kit default privileges" do
-        allow(proposal_settings).to receive(:polkit_default_privs).and_return("easy")
+        allow(proposal_settings).to receive(:polkit_default_privileges).and_return("easy")
         expect(Yast::SCR).to_not receive(:Write).with(
           path(".sysconfig.security.POLKIT_DEFAULT_PRIVS"), anything
         )

--- a/test/lib/security_settings_test.rb
+++ b/test/lib/security_settings_test.rb
@@ -142,7 +142,7 @@ describe Installation::SecuritySettings do
         lsm_config.configurable = true
         allow(Yast::PackagesProposal).to receive("SetResolvables")
           .with("LSM", :pattern, anything)
-        allow(subject).to receive(:propose_default)
+        allow(lsm_config).to receive(:propose_default)
       end
 
       context "but there is already a module selected" do

--- a/test/lib/update_repositories_finder_test.rb
+++ b/test/lib/update_repositories_finder_test.rb
@@ -77,8 +77,6 @@ describe Installation::UpdateRepositoriesFinder do
         allow(Yast::ProductFeatures).to receive(:GetStringFeature)
           .with("globals", "self_update_url")
           .and_return(url_from_control)
-        # TODO: test don't mock!
-        allow(finder).to receive(:add_installation_repo)
         allow(Yast::Linuxrc).to receive(:InstallInf).with("regurl")
           .and_return(nil)
       end
@@ -113,7 +111,7 @@ describe Installation::UpdateRepositoriesFinder do
           )
         end
 
-        let(:regservice_selection) { Class.new }
+        let(:regservice_selection) { Class.new { def self.run(_arg); end } }
 
         let(:url_helpers) do
           double("url_helpers", registration_url: smt0.slp_url, slp_discovery: [])

--- a/test/lib/widgets/online_repos_test.rb
+++ b/test/lib/widgets/online_repos_test.rb
@@ -7,5 +7,9 @@ require "cwm/rspec"
 describe Installation::Widgets::OnlineRepos do
   subject { described_class.new }
 
+  before do
+    allow(Yast::WFM).to receive(:CallFunction)
+  end
+
   include_examples "CWM::PushButton"
 end

--- a/test/lib/widgets/system_role_reader_test.rb
+++ b/test/lib/widgets/system_role_reader_test.rb
@@ -8,6 +8,8 @@ describe ::Installation::Widgets::SystemRoleReader do
   class DummySystemRoleReader
     include Yast::Logger
     include ::Installation::Widgets::SystemRoleReader
+
+    attr_accessor :value
   end
 
   subject { DummySystemRoleReader.new }

--- a/test/proposal_runner_test.rb
+++ b/test/proposal_runner_test.rb
@@ -159,17 +159,19 @@ describe ::Installation::ProposalRunner do
       end
 
       context "and it enables soft r/o proposal in case of error" do
-        PROPERTIES = {
-          "enable_skip"      => "no",
-          "label"            => "Installation Settings",
-          "mode"             => "autoinstallation",
-          "name"             => "initial",
-          "stage"            => "initial",
-          "unique_id"        => "auto_inst_proposal",
-          "proposal_modules" => [
-            { "name" => "software", "presentation_order" => "15", "read_only" => "soft" }
-          ]
-        }.freeze
+        let(:properties) do
+          {
+            "enable_skip"      => "no",
+            "label"            => "Installation Settings",
+            "mode"             => "autoinstallation",
+            "name"             => "initial",
+            "stage"            => "initial",
+            "unique_id"        => "auto_inst_proposal",
+            "proposal_modules" => [
+              { "name" => "software", "presentation_order" => "15", "read_only" => "soft" }
+            ]
+          }
+        end
         let(:proposals) { [["software_proposal", 15]] }
 
         it "makes a proposal" do

--- a/test/ssh_import_auto_test.rb
+++ b/test/ssh_import_auto_test.rb
@@ -128,7 +128,7 @@ describe ::Installation::SSHImportAutoClient do
 
       before do
         importer.add_config(fixtures_dir("root1"), "dev")
-        allow(::Installation).to receive(:destdir).and_return("/")
+        allow(Yast::Installation).to receive(:destdir).and_return("/")
       end
 
       it "writes the keys/configuration to the installation directory" do


### PR DESCRIPTION
- Fixed crash when importing an SSH configuration in AutoYaST installation
- 4.4.35