### PR TITLE
Handle service name collision during upgrade (bsc#1194453)

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Jan 26 20:19:41 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
+
+- Handle service name collision during upgrade (bsc#1194453),
+  do not delete the new services which have the same name
+  as an old service
+- 4.4.36
+
+-------------------------------------------------------------------
 Thu Jan 20 08:52:18 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
 
 - Enable RSpec verifying doubles in unit tests to ensue that

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation
-Version:        4.4.35
+Version:        4.4.36
 Release:        0
 Summary:        YaST2 - Installation Parts
 License:        GPL-2.0-only
@@ -28,8 +28,8 @@ Source1:        YaST2-Second-Stage.service
 Source2:        YaST2-Firstboot.service
 
 BuildRequires:  update-desktop-files
-# Y2Packager::Resolvable.none? (bsc#1194387)
-BuildRequires:  yast2 >= 4.4.33
+# Y2Packager::NewRepositorySetup
+BuildRequires:  yast2 >= 4.4.42
 # CIOIgnore
 BuildRequires:  yast2-bootloader
 # storage-ng based version
@@ -70,8 +70,8 @@ Requires:       iproute2
 Requires:       pciutils
 # tar-gzip some system files and untar-ungzip them after the installation (FATE #300421, #120103)
 Requires:       tar
-# Y2Packager::Resolvable.none? (bsc#1194387)
-Requires:       yast2 >= 4.4.33
+# Y2Packager::NewRepositorySetup
+Requires:       yast2 >= 4.4.42
 # CIOIgnore
 Requires:       yast2-bootloader
 Requires:       yast2-country >= 3.3.1

--- a/src/lib/installation/upgrade_repo_manager.rb
+++ b/src/lib/installation/upgrade_repo_manager.rb
@@ -13,6 +13,7 @@
 
 require "yast"
 
+require "y2packager/new_repository_setup"
 require "y2packager/original_repository_setup"
 require "y2packager/repository"
 require "y2packager/service"
@@ -53,6 +54,8 @@ module Installation
       current_repos = Y2Packager::Repository.all
       stored_repos = Y2Packager::OriginalRepositorySetup.instance.repositories
       stored_repo_aliases = stored_repos.map(&:repo_alias)
+      # exclude the newly added repositories with the same alias
+      stored_repo_aliases -= Y2Packager::NewRepositorySetup.instance.repositories
       reg_urls = registration_urls
 
       old_repos = current_repos.select do |r|
@@ -63,6 +66,8 @@ module Installation
       current_services = Y2Packager::Service.all
       stored_services = Y2Packager::OriginalRepositorySetup.instance.services
       stored_service_aliases = stored_services.map(&:alias)
+      # exclude the newly added services with the same name
+      stored_service_aliases -= Y2Packager::NewRepositorySetup.instance.services
       old_services = current_services.select { |s| stored_service_aliases.include?(s.alias) }
 
       # sort the repositories by name

--- a/test/lib/upgrade_repo_manager_test.rb
+++ b/test/lib/upgrade_repo_manager_test.rb
@@ -157,7 +157,8 @@ describe Installation::UpgradeRepoManager do
     end
 
     it "does not remove the new services with same name as an old service" do
-      expect(Y2Packager::NewRepositorySetup.instance).to receive(:services).and_return([service1.name])
+      expect(Y2Packager::NewRepositorySetup.instance).to receive(:services)
+        .and_return([service1.name])
       expect(Y2Packager::OriginalRepositorySetup.instance).to receive(:services)
         .and_return([service1])
 

--- a/test/lib/upgrade_repo_manager_test.rb
+++ b/test/lib/upgrade_repo_manager_test.rb
@@ -134,9 +134,14 @@ describe Installation::UpgradeRepoManager do
   describe ".create_from_old_repositories" do
     before do
       allow(Y2Packager::Repository).to receive(:all).and_return([repo1, repo2])
-      expect(Y2Packager::OriginalRepositorySetup.instance).to receive(:repositories)
+      allow(Y2Packager::Service).to receive(:all).and_return([])
+      allow(Y2Packager::OriginalRepositorySetup.instance).to receive(:repositories)
         .and_return([repo1, repo2])
+      allow(Y2Packager::OriginalRepositorySetup.instance).to receive(:services)
+        .and_return([])
       allow(Registration::Registration).to receive(:is_registered?).and_return(false)
+      allow(Y2Packager::NewRepositorySetup.instance).to receive(:services).and_return([])
+      allow(Y2Packager::NewRepositorySetup.instance).to receive(:repositories).and_return([])
     end
 
     it "initializes the UpgradeRepoManager from the stored old repositories" do
@@ -149,6 +154,18 @@ describe Installation::UpgradeRepoManager do
       allow(Y2Packager::Repository).to receive(:all).and_return([repo1])
       old_repo_manager = Installation::UpgradeRepoManager.create_from_old_repositories
       expect(old_repo_manager.repositories).to eq([repo1])
+    end
+
+    it "does not remove the new services with same name as an old service" do
+      expect(Y2Packager::NewRepositorySetup.instance).to receive(:services).and_return([service1.name])
+      expect(Y2Packager::OriginalRepositorySetup.instance).to receive(:services)
+        .and_return([service1])
+
+      upgrade_repo_manager = Installation::UpgradeRepoManager.create_from_old_repositories
+
+      # empty result as the old service has the same name as the new service
+      # so it is not deleted
+      expect(upgrade_repo_manager.services).to eq([])
     end
   end
 end


### PR DESCRIPTION
- https://bugzilla.suse.com/show_bug.cgi?id=1194453
- Do not delete the new services which have the same name as an old service
- Related to https://github.com/yast/yast-yast2/pull/1239 and https://github.com/yast/yast-registration/pull/562