### PR TITLE
Memsample: redirect the STDERR output (bsc#1195116)

### DIFF
--- a/bin/memsample
+++ b/bin/memsample
@@ -39,6 +39,7 @@ while true; do
   I=$((I + 1))
   I_TIME=$(printf %04d $I)-$(date -Iseconds)
 
+  # redirect STDERR to not break the YaST UI (bsc#1195116)
   {
       echo "### df-$I_TIME"
       df -k /
@@ -48,7 +49,7 @@ while true; do
 
       echo "### ps-$I_TIME"
       memsample_ps
-  } | gzip -c >> "$ARCHIVE"
+  } 2>&1 | gzip -c >> "$ARCHIVE"
 
   sleep "$SLEEP"
 done

--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Feb  1 07:52:48 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
+
+- Redirect the STDERR output in the memsample script to not
+  break the YaST UI (bsc#1195116)
+- 4.4.38
+
+-------------------------------------------------------------------
 Thu Jan 27 07:50:21 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
 
 - Handle service name collision during upgrade (bsc#1194453),

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation
-Version:        4.4.37
+Version:        4.4.38
 Release:        0
 Summary:        YaST2 - Installation Parts
 License:        GPL-2.0-only


### PR DESCRIPTION
### The Problem

![screenshot](https://user-images.githubusercontent.com/907998/151936555-1f511114-5230-446e-a67a-a97bb4433cd3.png)


- Redirect the STDERR output in the memsample script to not break the YaST UI
- See https://bugzilla.suse.com/show_bug.cgi?id=1195116#c8
- 4.4.38