### PR TITLE
Expert console: fixed crash in Ruby 3.1 (bsc#1195422)

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Feb  2 11:46:42 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
+
+- Fixed crash in Ruby 3.1 after pressing the hamburger menu icon
+  in the welcome screen (bsc#1195422)
+- 4.4.39
+
+-------------------------------------------------------------------
 Tue Feb  1 07:52:48 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
 
 - Redirect the STDERR output in the memsample script to not

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation
-Version:        4.4.38
+Version:        4.4.39
 Release:        0
 Summary:        YaST2 - Installation Parts
 License:        GPL-2.0-only

--- a/src/lib/installation/console.rb
+++ b/src/lib/installation/console.rb
@@ -37,6 +37,7 @@ module IrbLogger
 end
 
 # inject the code
+require "irb"
 require "irb/workspace"
 module IRB # :nodoc:
   class WorkSpace
@@ -67,9 +68,7 @@ module Installation
       # configure IRB and start an interactive session
       # @param context [Object] context in which the IRB session runs
       def irb(context)
-        # lazy loading
-        require "irb"
-        # enable TAB completion
+        # lazy loading, enable TAB completion
         require "irb/completion"
 
         # see the Binding::irb method in irb.rb in the Ruby stdlib


### PR DESCRIPTION
- Fixed crash after pressing the hamburger menu icon in the welcome screen
- Regression in Ruby 3.1
- https://bugzilla.suse.com/show_bug.cgi?id=1195422

![hamburger_crash](https://user-images.githubusercontent.com/907998/152151026-36141475-9bf9-4910-a65c-df24bb4921fb.png)


## Fix

Just run the `require "irb"` command earlier.

## Test

Tested manually in the latest TW installer, the expert console dialog it now correctly displayed.

![hamburger_fixed](https://user-images.githubusercontent.com/907998/152151080-8d285c2e-a666-4add-84f6-840d337ae360.png)
