### PR TITLE
Set the Xft.dpi resource to fix small fonts in hidpi screens

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Feb  9 15:05:32 UTC 2022 - Antonio Larrosa <alarrosa@suse.com>
+
+- Set the Xft.dpi resource after running the X server,
+  before running yast to fix hidpi issues with Qt 5.15
+  (boo#1173451)
+
+-------------------------------------------------------------------
 Wed Feb  2 11:46:42 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
 
 - Fixed crash in Ruby 3.1 after pressing the hamburger menu icon

--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -4,6 +4,7 @@ Wed Feb  9 15:05:32 UTC 2022 - Antonio Larrosa <alarrosa@suse.com>
 - Set the Xft.dpi resource after running the X server,
   before running yast to fix hidpi issues with Qt 5.15
   (boo#1173451)
+- 4.4.40
 
 -------------------------------------------------------------------
 Wed Feb  2 11:46:42 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation
-Version:        4.4.39
+Version:        4.4.40
 Release:        0
 Summary:        YaST2 - Installation Parts
 License:        GPL-2.0-only

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -1,7 +1,7 @@
 #
 # spec file for package yast2-installation
 #
-# Copyright (c) 2021 SUSE LLC
+# Copyright (c) 2022 SUSE LLC
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed
@@ -70,6 +70,8 @@ Requires:       iproute2
 Requires:       pciutils
 # tar-gzip some system files and untar-ungzip them after the installation (FATE #300421, #120103)
 Requires:       tar
+# xrdb is used to set Xft.dpi in YaST2.call
+Requires:       xrdb
 # Y2Packager::NewRepositorySetup
 Requires:       yast2 >= 4.4.42
 # CIOIgnore

--- a/startup/YaST2.call
+++ b/startup/YaST2.call
@@ -121,8 +121,10 @@ function prepare_for_x11 () {
 			elif [ "$DPI" -gt 288 ]; then
 				# This is a workaround against monitors
 				# that provide bad edid values
+				log "WARNING: Detected monitor DPI is too high ($DPI), using value 288"
 				set_xft_dpi 288
 			else
+				log "WARNING: Detected monitor DPI is too low ($DPI), using value 96"
 				set_xft_dpi 96
 			fi
 		fi

--- a/startup/YaST2.call
+++ b/startup/YaST2.call
@@ -71,6 +71,29 @@ function wait_for_x11() {
 	done
 }
 
+#----[ calculate_x11_dpi ]----#
+function calculate_x11_dpi () {
+#------------------------------------------------------
+# Calculate the monitor's dpi from xrandr's output
+# ---
+	local MON_SIZE=`xrandr |grep mm |head -n 1`
+	local MON_WIDTH_MM=`echo $MON_SIZE | sed -e "s/.* \([0-9]\+\)mm x \([0-9]\+\)mm.*/\1/"`
+	local MON_WIDTH_PX=`echo $MON_SIZE | sed -e "s/.* \([0-9]\+\)x[0-9]\++.*/\1/"`
+	local DPI=`ruby -e "puts (($MON_WIDTH_PX/($MON_WIDTH_MM*0.0393701)/48).round)*48"`
+	log "Monitor size: $MON_SIZE"
+	log "Monitor width mm: $MON_WIDTH_MM"
+	log "Monitor width px: $MON_WIDTH_PX"
+	log "Monitor dpi: $DPI"
+	echo "$DPI"
+}
+
+#----[ set_xft_dpi ]----#
+function set_xft_dpi () {
+#------------------------------------------------------
+# Set Xft.dpi resource using xrdb
+# ---
+	echo "Xft.dpi: $1" | xrdb -merge - && log "Xft.dpi set to: $1"
+}
 
 #----[ prepare_for_x11 ]----#
 function prepare_for_x11 () {
@@ -91,6 +114,17 @@ function prepare_for_x11 () {
 		wait_for_x11 15
 		if [ "$server_running" = 1 ];then
 			log "\tX-Server is ready: $xserver_pid"
+
+			local DPI=`calculate_x11_dpi`
+			if [ "$DPI" -ge 144 -a "$DPI" -le 288 ]; then
+				set_xft_dpi $DPI
+			elif [ "$DPI" -gt 288 ]; then
+				# This is a workaround against monitors
+				# that provide bad edid values
+				set_xft_dpi 288
+			else
+				set_xft_dpi 96
+			fi
 		fi
 	fi
 


### PR DESCRIPTION
Qt 5.15 (actually, 5.14) introduces a behavior change with respect to hidpi screens and it now needs Xft.dpi to be set in order to use it. This change uses xrandr to find out edid information and xrdb to set Xft.dpi accordingly when starting the X server in YaST2.call. It always sets dpi to multiples of 48 with a minimum of 96 and a maximum of 288 (being effectively the same as having zoom factors of 1x, 1.5x, 2x, 2.5x amd 3x). Higher (or lower) dpi values are not used in order to try to filter out monitors that return wrong edid values.