### PR TITLE
SLE#25560: do not create a snapshot after install/upgrade if root filesystem is RO

### DIFF
--- a/doc/snapshots.md
+++ b/doc/snapshots.md
@@ -1,0 +1,78 @@
+# Installation and upgrade snapshots
+
+This document tries to clarify how YaST, as an installer, creates snapshots during installation and
+offline upgrade when Snapper is enabled. In a nutshell, YaST creates these snapshots:
+
+* A *single* snapshot at the end of the installation (except for transactional systems, like
+  MicroOS).
+* A *pre* snapshot at the beginning of the upgrade and a *post* snapshot at the end.
+
+However, things are not that simple, so let's try to draw a full picture of this feature.
+
+## Non-transactional systems
+
+Let's start considering non transactional systems, like SUSE Linux Enterprise, openSUSE Leap or
+openSUSE Tumbleweed. Remember that you can use openSUSE Tumbleweed as a transactional system if
+you select the *Transactional Server* role during installation.
+
+### Installation
+
+YaST creates a snapshot after *finishing* the normal installation. If you are using AutoYaST, it
+takes the snapshot at the end of the 2nd stage *unless it is disabled*. If the 2nd stage is
+disabled, YaST takes the snapshot at the end of the 1st stage, just like a normal installation.
+
+If you run `snapper list` in your just installed system, you should see something like this:
+
+```
+# snapper list
+ # | Type   | Pre # | Date                     | User | Used Space | Cleanup | Description           | Userdata     
+---+--------+-------+--------------------------+------+------------+---------+-----------------------+--------------
+0  | single |       |                          | root |            |         | current               |              
+1* | single |       | Fri Feb 18 06:06:17 2022 | root |  13.22 MiB |         | first root filesystem |              
+2  | single |       | Fri Feb 18 06:12:22 2022 | root |   3.01 MiB | number  | after installation    | important=yes
+```
+
+Which is the role of each "snapshot"?
+
+* Snapshot 0: it is created by Snapper during the initialization.
+* Snapshot 1: it is the *current snapshot*. It is mounted as read/write and it is where your system
+  lives.
+* Snapshot 2: YaST created this snapshot at the end of the installation.
+
+Your system runs on *snapshot 1*, and *snapshot 2* is just a way to travel back in time to the end
+of the installation. We usually think about snapshots as *pictures* of the system on a given time,
+but that is not an accurate definition.
+
+### Offline Upgrade
+
+During offline upgrade, YaST takes two different snapshots: one at the beginning of the installation
+and another one at the end. Both snapshots are related as you can see in the table below:
+
+```
+# snapper list
+ # | Type   | Pre # | Date                     | User | Used Space | Cleanup | Description           | Userdata     
+---+--------+-------+--------------------------+------+------------+---------+-----------------------+--------------
+0  | single |       |                          | root |            |         | current               |              
+1* | single |       | Fri Feb 18 06:06:17 2022 | root |  13.22 MiB |         | first root filesystem |              
+2  | single |       | Fri Feb 18 06:12:22 2022 | root |   3.01 MiB | number  | after installation    | important=yes
+3  | pre    |       | Fri Feb 18 10:40:05 2022 | root |  36.63 MiB | number  | zypp(zypper)          | important=yes
+4  | post   |     3 | Fri Feb 18 10:55:11 2022 | root |  16.11 MiB | number  |                       | important=yes
+5  | pre    |       | Fri Feb 18 13:36:49 2022 | root |  14.91 MiB | number  | before update         | important=yes
+6  | post   |     5 | Fri Feb 18 14:01:59 2022 | root |   2.45 MiB | number  | after update          | important=yes
+```
+
+According to the table above, YaST created snapshot 5 (*pre*) before starting the upgrade process
+and snapshot 6 (*post*) at the end. However, snapshot 1 is still the root file system.
+
+## Transactional systems
+
+Transactional systems, like MicroOS or the *Transactional Server* role of openSUSE Tumbleweed, take
+care of their own snapshots. In those cases, YaST does not perform any snapshot at the end of the
+installation. About the offline upgrade, using YaST to upgrade those systems is not supported.
+
+Starting in yast2-installation 4.3.45, YaST detects if it is installing a transactional system by
+checking whether the root filesystem is mounted as read-only.
+
+## Related features
+
+[FATE#317932](https://w3.suse.de/~lpechacek/fate-archive/317973.html) and SLE-22560.

--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Fri Feb 18 06:38:05 UTC 2022 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Do not create a Btrfs snapshot at the end of the installation
+  or upgrade when the root filesystem is mounted as read-only
+  (SLE-22560).
+- 4.3.45
+
+-------------------------------------------------------------------
 Mon Nov  1 12:48:19 UTC 2021 - Martin Vidner <mvidner@suse.com>
 
 - Filter the installation proposals (in the Installation Settings

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.3.44
+Version:        4.3.45
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/src/lib/installation/snapshots_finish.rb
+++ b/src/lib/installation/snapshots_finish.rb
@@ -28,16 +28,16 @@ module Installation
     def write
       snapper_config
 
-      if !InstFunctions.second_stage_required? && Yast2::FsSnapshot.configured?
-        log.info("Creating root filesystem snapshot")
-        if Mode.update
-          create_post_snapshot
-        else
-          create_single_snapshot
-        end
-      else
+      if InstFunctions.second_stage_required? || !Yast2::FsSnapshot.configured?
         log.info("Skipping root filesystem snapshot creation")
-        false
+        return false
+      end
+
+      log.info("Creating root filesystem snapshot")
+      if Mode.update
+        create_post_snapshot
+      else
+        create_single_snapshot
       end
     end
 

--- a/src/lib/installation/snapshots_finish.rb
+++ b/src/lib/installation/snapshots_finish.rb
@@ -2,7 +2,7 @@ require "yast"
 require "yast2/fs_snapshot"
 require "yast2/fs_snapshot_store"
 require "installation/finish_client"
-require "y2storage/storage_manager"
+require "y2storage"
 
 module Installation
   class SnapshotsFinish < ::Installation::FinishClient
@@ -85,7 +85,7 @@ module Installation
     #   mounted as read-only or if it is not found
     def ro_root_fs?
       staging = Y2Storage::StorageManager.instance.staging
-      root_fs = staging.filesystems.find { |f| f.mount_path == "/" }
+      root_fs = Y2Storage::MountPoint.find_by_path(staging, "/")
       return false unless root_fs
 
       root_fs.mount_options.include?("ro")

--- a/src/lib/installation/snapshots_finish.rb
+++ b/src/lib/installation/snapshots_finish.rb
@@ -85,7 +85,7 @@ module Installation
     #   mounted as read-only or if it is not found
     def ro_root_fs?
       staging = Y2Storage::StorageManager.instance.staging
-      root_fs = Y2Storage::MountPoint.find_by_path(staging, "/")
+      root_fs = Y2Storage::MountPoint.find_by_path(staging, "/").first
       return false unless root_fs
 
       root_fs.mount_options.include?("ro")

--- a/test/snapshots_finish_test.rb
+++ b/test/snapshots_finish_test.rb
@@ -16,12 +16,31 @@ describe ::Installation::SnapshotsFinish do
       allow(Yast2::FsSnapshot).to receive(:configured?).and_return(snapper_configured)
       allow(Yast::Mode).to receive(:installation).and_return(mode == :installation)
       allow(Yast2::FsSnapshot).to receive(:configure_on_install?).and_return configure
+      allow(Y2Storage::StorageManager).to receive(:instance).and_return(storage_manager)
     end
 
     let(:second_stage_required) { false }
     let(:snapper_configured) { false }
     let(:mode) { :normal }
     let(:configure) { false }
+    let(:staging) do
+      instance_double(Y2Storage::Devicegraph, filesystems: [root_fs, home_fs])
+    end
+    let(:storage_manager) { instance_double(Y2Storage::StorageManager, staging: staging) }
+
+    let(:root_fs_options) { [] }
+
+    let(:root_fs) do
+      instance_double(
+        Y2Storage::Filesystems::BlkFilesystem, mount_path: "/", mount_options: root_fs_options
+      )
+    end
+
+    let(:home_fs) do
+      instance_double(
+        Y2Storage::Filesystems::BlkFilesystem, mount_path: "/home", mount_options: []
+      )
+    end
 
     context "during a fresh installation" do
       let(:mode) { :installation }
@@ -107,6 +126,15 @@ describe ::Installation::SnapshotsFinish do
             expect(subject.write).to eq(true)
           end
 
+          context "and root filesystem is read-only" do
+            let(:root_fs_options) { ["ro"] }
+
+            it "does not create any snapshot" do
+              expect(Yast2::FsSnapshot).to_not receive(:create_post)
+              expect(subject.write).to eq(false)
+            end
+          end
+
           context "and could not create the snapshot" do
             before do
               allow(Yast2::FsSnapshot).to receive(:create_post).and_raise(Yast2::SnapshotCreationFailed)
@@ -132,6 +160,15 @@ describe ::Installation::SnapshotsFinish do
           it "creates a snapshot of type 'single' with 'after installation' as description" do
             expect(Yast2::FsSnapshot).to receive(:create_single).with("after installation", cleanup: :number, important: true).and_return(true)
             expect(subject.write).to eq(true)
+          end
+
+          context "and root filesystem is read-only" do
+            let(:root_fs_options) { ["ro"] }
+
+            it "does not create any snapshot" do
+              expect(Yast2::FsSnapshot).to_not receive(:create_single)
+              expect(subject.write).to eq(false)
+            end
           end
 
           context "and could not create the snapshot" do

--- a/test/snapshots_finish_test.rb
+++ b/test/snapshots_finish_test.rb
@@ -17,28 +17,21 @@ describe ::Installation::SnapshotsFinish do
       allow(Yast::Mode).to receive(:installation).and_return(mode == :installation)
       allow(Yast2::FsSnapshot).to receive(:configure_on_install?).and_return configure
       allow(Y2Storage::StorageManager).to receive(:instance).and_return(storage_manager)
+      allow(Y2Storage::MountPoint).to receive(:find_by_path).with(staging, "/")
+        .and_return(root_fs)
     end
 
     let(:second_stage_required) { false }
     let(:snapper_configured) { false }
     let(:mode) { :normal }
     let(:configure) { false }
-    let(:staging) do
-      instance_double(Y2Storage::Devicegraph, filesystems: [root_fs, home_fs])
-    end
+    let(:staging) { instance_double(Y2Storage::Devicegraph) }
     let(:storage_manager) { instance_double(Y2Storage::StorageManager, staging: staging) }
-
     let(:root_fs_options) { [] }
 
     let(:root_fs) do
       instance_double(
         Y2Storage::Filesystems::BlkFilesystem, mount_path: "/", mount_options: root_fs_options
-      )
-    end
-
-    let(:home_fs) do
-      instance_double(
-        Y2Storage::Filesystems::BlkFilesystem, mount_path: "/home", mount_options: []
       )
     end
 

--- a/test/snapshots_finish_test.rb
+++ b/test/snapshots_finish_test.rb
@@ -18,7 +18,7 @@ describe ::Installation::SnapshotsFinish do
       allow(Yast2::FsSnapshot).to receive(:configure_on_install?).and_return configure
       allow(Y2Storage::StorageManager).to receive(:instance).and_return(storage_manager)
       allow(Y2Storage::MountPoint).to receive(:find_by_path).with(staging, "/")
-        .and_return(root_fs)
+        .and_return([root_fs])
     end
 
     let(:second_stage_required) { false }


### PR DESCRIPTION
Feature [SLE#25560](https://jira.suse.com/browse/SLE-22560).
Trello: https://trello.com/c/RovP5dk3/

On systems using the transactional-update mechanism, the filesystem is supposed to be mounted as read-only at the end of the installation. In those cases, we should not create a snapshot.

In this attempt, we check the mount options in the storage staging devicegraph.

## Tests

- [x] SLE 15 SP3
- [x] MicroOS (Snapshot20220215)
- [x] SLE 15 SP3 with AutoYaST, as the snapshots_finish client is executed during the 2nd stage too.
- [x] SLE 15 SP3 upgrade
- [x] SLE 15 SP3 upgrade with AutoYaST

![microos-snapshots](https://user-images.githubusercontent.com/15836/154721156-3ceb1395-98a8-4f48-80ba-d719ff3cd2f1.png)