### PR TITLE
Adjusted Linux Security Module installation summary labels

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Feb 18 08:47:35 UTC 2022 - Knut Anderssen <kanderssen@suse.com>
+
+- LSM: Adjusted installation summary labels (bsc#1196013).
+- 4.4.41
+
+-------------------------------------------------------------------
 Wed Feb  9 15:05:32 UTC 2022 - Antonio Larrosa <alarrosa@suse.com>
 
 - Set the Xft.dpi resource after running the X server,

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation
-Version:        4.4.40
+Version:        4.4.41
 Release:        0
 Summary:        YaST2 - Installation Parts
 License:        GPL-2.0-only

--- a/src/lib/installation/clients/security_proposal.rb
+++ b/src/lib/installation/clients/security_proposal.rb
@@ -257,16 +257,12 @@ module Installation
           # after the installation will be SELinux running in the selected mode which could be
           # 'enforcing', 'permissive' or 'disabled'
           format(_(
-                   "Major Linux Security Module: Activate %{module} in '%{mode}' mode"
+                   "Major Linux Security Module: %{module} in '%{mode}' mode"
                  ), module: selected.label, mode: selected.mode.to_human_string)
-        when :apparmor
+        when :apparmor, :none
           # TRANSLATORS: Proposal's text describing that the active Linux Security Major Module
           # after the installation will be AppArmor
-          format(_("Major Linux Security Module: Activate %{module}"), module: selected.label)
-        when :none
-          # TRANSLATORS: Proposal's text describing that no Linux Security Major Module will be
-          # activated after the installation
-          _("Major Linux Security Module: No major module will be activated")
+          format(_("Major Linux Security Module: %{module}"), module: selected.label)
         end
       end
     end


### PR DESCRIPTION
## Problem

YaST should not add verbs to the installation summary. In the case of **AppArmor**, just show that without the activate, and only show **None** when nothing will be applied/set.

- https://bugzilla.suse.com/show_bug.cgi?id=1196013

## Screenshots
![Screenshot_opensusetumbleweed_2022-02-18_10:04:15](https://user-images.githubusercontent.com/7056681/154661313-fc0f953f-33d7-485b-b887-f0bcc586bc08.png)
![Screenshot_opensusetumbleweed_2022-02-18_10:03:55](https://user-images.githubusercontent.com/7056681/154661319-53f36135-494e-48d8-b419-a73e85975361.png)
![Screenshot_opensusetumbleweed_2022-02-18_10:03:34](https://user-images.githubusercontent.com/7056681/154661323-9d49612c-c47f-4e5e-98be-4db22873e97d.png)

