### PR TITLE
Fix Second Stage timeout when using ssh (bsc#1195059)

### DIFF
--- a/package/YaST2-Second-Stage.service
+++ b/package/YaST2-Second-Stage.service
@@ -1,10 +1,8 @@
 [Unit]
 Description=YaST2 Second Stage
-After=apparmor.service local-fs.target plymouth-start.service
+After=apparmor.service local-fs.target plymouth-start.service systemd-user-sessions.service
 Conflicts=plymouth-start.service
-Before=getty@tty1.service serial-getty@ttyS0.service serial-getty@ttyS1.service serial-getty@ttyS2.service
-Before=serial-getty@hvc0.service serial-getty@ttyAMA0.service
-Before=display-manager.service
+Before=getty-pre.target display-manager.service
 ConditionPathExists=/var/lib/YaST2/runme_at_boot
 
 [Service]
@@ -15,6 +13,7 @@ Type=oneshot
 # and envvar extensions are still loaded, /etc/sysconfig/proxy values are still
 # used correctly (see bnc#866692 and bnc#866692 for details).
 Environment=TERM=linux PX_MODULE_PATH=""
+ExecStartPre=-/usr/bin/touch /run/nologin
 ExecStartPre=-/usr/bin/plymouth quit
 ExecStart=/usr/lib/YaST2/startup/YaST2.Second-Stage
 RemainAfterExit=yes
@@ -22,6 +21,7 @@ TimeoutSec=0
 # Initialize tty1 in order to remove old YaST output and to show the cursor
 # again (bnc#1018037)
 ExecStartPost=/bin/sh -c '/usr/bin/printf "\033c" > /dev/tty1'
+ExecStartPost=/usr/bin/rm -f /run/nologin
 ExecStartPost=/usr/bin/rm -f /var/lib/YaST2/runme_at_boot
 ExecStartPost=/usr/bin/systemctl restart systemd-vconsole-setup.service
 StandardInput=tty

--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Feb 21 14:59:55 UTC 2022 - Knut Anderssen <kanderssen@suse.com>
+
+- Modified Second Stage service dependencies fixing a root login
+  systemd timeout when installing with ssh (bsc#1195059)
+- 4.3.46
+
+-------------------------------------------------------------------
 Fri Feb 18 06:38:05 UTC 2022 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Do not create a Btrfs snapshot at the end of the installation

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.3.45
+Version:        4.3.46
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only


### PR DESCRIPTION
## Problem

**AutoYaST init-scripts** are run before **systemd-user-sessions.service** which prevent users including privileged ones to login the system which in case of **ssh** installation does not allow the user to connect until pam_systemd gives a timeout.

- https://bugzilla.suse.com/show_bug.cgi?id=1195059

## Solution

Adapted the service file as suggested being run just after systemd-user-sessions.service.