### PR TITLE
Drop -rfbwait parameter on Xvnc

### DIFF
--- a/startup/common/vnc.sh
+++ b/startup/common/vnc.sh
@@ -90,7 +90,6 @@ startVNCServer () {
 		-geometry "$VNCSize" \
 		-depth 16 \
                 -dpi 96 \
-		-rfbwait 120000 \
 		-rfbport 5901 \
 		-fp /usr/share/fonts/misc/,/usr/share/fonts/uni/,/usr/share/fonts/truetype/ \
 	>/var/log/YaST2/vncserver.log 2>&1 &


### PR DESCRIPTION
With the update to tigervnc 1.12.0.
Xvnc no longer supports -rfbwait parameter.
This should fix bsc#1196201.

With older Xvnc versions, -rfbwait default value is 30 seconds. 
That shouldn't be a problem. 