### PR TITLE
SSH installation theme fix

### DIFF
--- a/bin/memsample-archive-to-csv
+++ b/bin/memsample-archive-to-csv
@@ -108,6 +108,8 @@ class MemsampleCsv < MemsampleArchive
   end
 
   def handle_ps(_counter, datetime, data)
+    return if data.include?("Signal 23 (URG) caught by ps")
+
     processes = data.lines.map { |l| l.chomp.split(" ", 9) }
     headings = processes.shift
     processes.map! do |cols|

--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Feb 22 13:06:51 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
+
+- Use the default UI theme in SSH installation, the
+  "installation_slim" theme does not exist anymore (bsc#1196287)
+- memsample-archive-to-csv - handle "ps" errors in the data file
+- 4.4.44
+
+-------------------------------------------------------------------
 Mon Feb 21 14:59:55 UTC 2022 - Knut Anderssen <kanderssen@suse.com>
 
 - Modified Second Stage service dependencies fixing a root login

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.4.43
+Version:        4.4.44
 Release:        0
 Summary:        YaST2 - Installation Parts
 License:        GPL-2.0-only

--- a/startup/YaST2.call
+++ b/startup/YaST2.call
@@ -190,8 +190,6 @@ function prepare_for_ssh () {
 # prepare SSH installation
 # ---
 #
-	:
-        export Y2STYLE="installation_slim"
 	set_inst_qt_env
 }
 

--- a/startup/YaST2.ssh
+++ b/startup/YaST2.ssh
@@ -57,9 +57,6 @@ EOF
 # call YaST2 if flag file exists
 #----------------------------------------
 if [ -f /var/lib/YaST2/runme_at_boot ];then
-
-        export Y2STYLE="installation_slim" 
-
 	# running the second stage installation
 	/usr/lib/YaST2/startup/YaST2.call installation continue
 


### PR DESCRIPTION
- https://bugzilla.suse.com/show_bug.cgi?id=1196287
- The `installation_slim` theme does not exist anymore, after merging https://github.com/yast/yast-yast2/pull/1242 it is not changed to the default theme. If theme does not exist then the default (light) Qt theme is used.
- Additionally fixed crash is the `memsample-archive-to-csv` script, related to https://github.com/yast/yast-installation/pull/1017

## Testing

Tested manually, with the fix it uses the usual default installation style:

![ssh_installation_dark](https://user-images.githubusercontent.com/907998/155141354-19e9a00a-57bb-4821-a5ca-dffa0dcaa02c.png)
