### PR TITLE
Avoid login

### DIFF
--- a/package/YaST2-Second-Stage.service
+++ b/package/YaST2-Second-Stage.service
@@ -2,7 +2,9 @@
 Description=YaST2 Second Stage
 After=apparmor.service local-fs.target plymouth-start.service systemd-user-sessions.service
 Conflicts=plymouth-start.service
-Before=getty-pre.target display-manager.service
+Before=getty@tty1.service serial-getty@ttyS0.service serial-getty@ttyS1.service serial-getty@ttyS2.service
+Before=serial-getty@hvc0.service serial-getty@ttyAMA0.service
+Before=display-manager.service
 ConditionPathExists=/var/lib/YaST2/runme_at_boot
 
 [Service]

--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Mar  1 13:32:31 UTC 2022 - José Iván López González <jlopez@suse.com>
+
+- Avoid terminal login prompt when running Second Stage service
+  (bsc#1196594 and related to bsc#1195059).
+- 4.3.47
+
+-------------------------------------------------------------------
 Mon Feb 21 14:59:55 UTC 2022 - Knut Anderssen <kanderssen@suse.com>
 
 - Modified Second Stage service dependencies fixing a root login

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.3.46
+Version:        4.3.47
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only


### PR DESCRIPTION
## Problem

When running *YaST2-Second-Stage.service*, if you switch to a virtual console (e.g., ctrl + alt + F1), then getty prompt is shown. Before changes introduced by https://github.com/yast/yast-installation/pull/1024, *systemd-user-sessions.service* was forced to run after the second stage (actually, after the *autoyast-initscripts.service*). This prevented getty prompt while switching to a virtual console. Now, *systemd-user-sessions.service* runs before the second stage. So, [*systemd-getty-generator*](https://www.freedesktop.org/software/systemd/man/systemd-getty-generator.html) is able to instanciate a getty service when switching to a virtual console.

Note that *YaST2-Second-Stage.service* set `Before=getty-pre.target`, but this is not enough to avoid *systemd-getty-generator* instanciates getty services on demand.

* Related to https://bugzilla.suse.com/show_bug.cgi?id=1195059
* See also https://bugzilla.suse.com/show_bug.cgi?id=1195910#c45

## Solution

Explicitly prevent getty services while running second stage. Note that only getty1 is prevented, so 2-6 are still available (for example, to collect logs). 

See also https://github.com/yast/yast-autoinstallation/pull/829.

## Testing

Manually tested.