### PR TITLE
Fixed crash when starting the expert console (bsc#1196724)

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Mar  3 17:58:27 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
+
+- Fixed crash when starting the expert console (bsc#1196724)
+- 4.4.46
+
+-------------------------------------------------------------------
 Mon Feb 28 14:35:31 UTC 2022 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Fixed the start of the VNC server during installation. Done by

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.4.45
+Version:        4.4.46
 Release:        0
 Summary:        YaST2 - Installation Parts
 License:        GPL-2.0-only

--- a/src/lib/installation/console/commands.rb
+++ b/src/lib/installation/console/commands.rb
@@ -81,9 +81,9 @@ module Installation
         commands
       end
 
-      def respond_to_missing?(_method_name)
+      def respond_to_missing?(_method_name, _include_private = false)
         # method missing is not used for fancy meta programming,
-        # but to provide different behavior. No not respond to anything missing.
+        # but to provide different behavior. Not to respond to anything missing.
         false
       end
 


### PR DESCRIPTION
- The `respond_to_missing?` method actually accepts *two* arguments!
- See an [example](https://ruby-doc.org/core-3.1.1/BasicObject.html) in the documentation
- That is valid for both [Ruby 2.5](https://ruby-doc.org/core-2.5.9/Object.html#method-i-respond_to_missing-3F) (SLE15) and [Ruby 3.1](https://ruby-doc.org/core-3.1.1/Object.html#method-i-respond_to_missing-3F) (Tumbleweed)

## Testing

Tested manually

| Original Code | Fixed |
|----|----|
| ![expert_console_crash](https://user-images.githubusercontent.com/907998/156632022-0ab3c9e4-f9b9-4538-9fc7-64039101e04c.png) | ![expert_console_fixed](https://user-images.githubusercontent.com/907998/156632039-b37ec04e-aed8-4802-912d-938760335852.png) |

