### PR TITLE
Prevent getty auto-generation

### DIFF
--- a/package/YaST2-Second-Stage.service
+++ b/package/YaST2-Second-Stage.service
@@ -1,9 +1,14 @@
 [Unit]
 Description=YaST2 Second Stage
-After=apparmor.service local-fs.target plymouth-start.service systemd-user-sessions.service
+After=apparmor.service local-fs.target plymouth-start.service
+# systemd-user-sessions is needed to allow ssh connection (bsc#1195059)
+After=systemd-user-sessions.service
 Conflicts=plymouth-start.service
-Before=getty@tty1.service serial-getty@ttyS0.service serial-getty@ttyS1.service serial-getty@ttyS2.service
-Before=serial-getty@hvc0.service serial-getty@ttyAMA0.service
+# Prevent getty auto-generation (bsc#1196614, bsc#1196594)
+Before=getty@tty1.service getty@tty2.service getty@tty3.service getty@tty4.service getty@tty5.service getty@tty6.service
+Before=serial-getty@ttyS0.service serial-getty@ttyS1.service serial-getty@ttyS2.service
+Before=serial-getty@hvc0.service serial-getty@ttyAMA0.service serial-getty@ttysclp0.service
+# Prevent too early user login (bsc#1196594)
 Before=display-manager.service
 ConditionPathExists=/var/lib/YaST2/runme_at_boot
 
@@ -15,6 +20,7 @@ Type=oneshot
 # and envvar extensions are still loaded, /etc/sysconfig/proxy values are still
 # used correctly (see bnc#866692 and bnc#866692 for details).
 Environment=TERM=linux PX_MODULE_PATH=""
+# Block non-privileged user login (bsc#1195059)
 ExecStartPre=-/usr/bin/touch /run/nologin
 ExecStartPre=-/usr/bin/plymouth quit
 ExecStart=/usr/lib/YaST2/startup/YaST2.Second-Stage

--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Mar  8 19:25:42 UTC 2022 - José Iván López González <jlopez@suse.com>
+
+- Prevent getty auto-generation because it makes xvnc to fail when
+  it is started in YaST second stage (bsc#1196614).
+- 4.3.48
+
+-------------------------------------------------------------------
 Tue Mar  1 13:32:31 UTC 2022 - José Iván López González <jlopez@suse.com>
 
 - Avoid terminal login prompt when running Second Stage service

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.3.47
+Version:        4.3.48
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only


### PR DESCRIPTION
- [bsc#1196614](https://bugzilla.suse.com/show_bug.cgi?id=1196614)
- https://trello.com/c/yLz1DrJp

## Problem

Dependencies in *YaST2-Second-Stage.service* have been adjusted. First, it was necessary to force the second stage service to run after *systemd-user-sessions.service* in order to avoid issues when connecting with ssh, see https://github.com/yast/yast-installation/pull/1024. Then, that patch was improved to avoid display manager and getty prompt to appear too early, see https://github.com/yast/yast-installation/pull/1030.

With the latest changes, it is still possible to switch to another virtual console (ctrl+alt+f2-6), making *systemd-getty-generator* to instantiate a getty service on demand. Note that getty auto-generation is prevented if *systemd-user-sessions.service* runs after YaST second stage, as it was done before the lastest changes in the service dependencies.

And, for some reason, if a getty is instantiate on demand before *YaST2-Second-Stage.service* is started, then xvnc fails to start. Note that switching to a virtual console before second stage usually does not happen, but openQA tests could do it to execute something.

## Solution

*YaST2-Second-Stage.service* was already preventing *getty@tty1.service* to be instantiate before finishing the second stage. This was avoiding an early prompt login in tty1. Now, *getty@tty2-6.service* are also explicitly prevented, so *systemd-getty-generator* will not generate getty sessions on demand. For openQA tests in s390, the service *serial-getty@ttysclp0.service* needs to be prevented, too. 

## Testing

Manually tested with both ssh and vnc installations.
 