### PR TITLE
Run YaST2-Second-Stage after purge-kernels service

### DIFF
--- a/package/YaST2-Firstboot.service
+++ b/package/YaST2-Firstboot.service
@@ -1,6 +1,8 @@
 [Unit]
 Description=YaST2 Firstboot
 After=apparmor.service local-fs.target plymouth-start.service YaST2-Second-Stage.service
+# Run after kernels are purged to prevent a zypper lock (bsc#1196431)
+After=purge-kernels.service
 Conflicts=plymouth-start.service
 Before=getty@tty1.service serial-getty@ttyS0.service serial-getty@ttyS1.service serial-getty@ttyS2.service
 Before=serial-getty@hvc0.service serial-getty@ttyAMA0.service

--- a/package/YaST2-Second-Stage.service
+++ b/package/YaST2-Second-Stage.service
@@ -3,6 +3,8 @@ Description=YaST2 Second Stage
 After=apparmor.service local-fs.target plymouth-start.service
 # systemd-user-sessions is needed to allow ssh connection (bsc#1195059)
 After=systemd-user-sessions.service
+# Run after kernels are purged to prevent a zypper block (bsc#1196431) 
+After=purge-kernels.service
 Conflicts=plymouth-start.service
 # Prevent getty auto-generation (bsc#1196614, bsc#1196594)
 Before=getty@tty1.service getty@tty2.service getty@tty3.service getty@tty4.service getty@tty5.service getty@tty6.service

--- a/package/YaST2-Second-Stage.service
+++ b/package/YaST2-Second-Stage.service
@@ -3,7 +3,7 @@ Description=YaST2 Second Stage
 After=apparmor.service local-fs.target plymouth-start.service
 # systemd-user-sessions is needed to allow ssh connection (bsc#1195059)
 After=systemd-user-sessions.service
-# Run after kernels are purged to prevent a zypper block (bsc#1196431) 
+# Run after kernels are purged to prevent a zypper lock (bsc#1196431)
 After=purge-kernels.service
 Conflicts=plymouth-start.service
 # Prevent getty auto-generation (bsc#1196614, bsc#1196594)

--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,8 +1,9 @@
 -------------------------------------------------------------------
 Thu Mar 17 12:46:16 UTC 2022 - Knut Anderssen <kanderssen@suse.com>
 
-- Run YaST2-Second-Stage.service after the purge-kernels.service
-  to prevent a zypper lock error message (bsc#1196431).
+- Run the YaST2-Second-Stage and YaST2-Firsboot services after 
+  purge-kernels to prevent a zypper lock error message 
+  (bsc#1196431).
 - 4.3.49
 
 -------------------------------------------------------------------

--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Mar 17 12:46:16 UTC 2022 - Knut Anderssen <kanderssen@suse.com>
+
+- Run YaST2-Second-Stage.service after the purge-kernels.service
+  to prevent a zypper lock error message (bsc#1196431).
+- 4.3.49
+
+-------------------------------------------------------------------
 Tue Mar  8 19:25:42 UTC 2022 - José Iván López González <jlopez@suse.com>
 
 - Prevent getty auto-generation because it makes xvnc to fail when

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.3.48
+Version:        4.3.49
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only


### PR DESCRIPTION
## Problem

If **purge-kernels** does not finish before **YaST2-Second-Stage** is run it locks **zypper** and a nasty message is shown. For preventing this situation YaST2-Second-Stage should be run after the **purge-kernels.service**.

- https://bugzilla.suse.com/show_bug.cgi?id=1196431 (https://trello.com/c/tl491wU2)

## Solution

Adapt **YaST2-Second-Stage.service** to be fun after **purge-kernels.service**