### PR TITLE
Add Before=xvnc.socket dependency to Firstboot and Second Stage services (bsc#1197265)

### DIFF
--- a/package/YaST2-Firstboot.service
+++ b/package/YaST2-Firstboot.service
@@ -6,7 +6,7 @@ After=purge-kernels.service
 Conflicts=plymouth-start.service
 Before=getty@tty1.service serial-getty@ttyS0.service serial-getty@ttyS1.service serial-getty@ttyS2.service
 Before=serial-getty@hvc0.service serial-getty@ttyAMA0.service
-Before=display-manager.service
+Before=display-manager.service xvnc.socket
 ConditionPathExists=/var/lib/YaST2/reconfig_system
 OnFailure=shutdown.target
 

--- a/package/YaST2-Second-Stage.service
+++ b/package/YaST2-Second-Stage.service
@@ -10,8 +10,8 @@ Conflicts=plymouth-start.service
 Before=getty@tty1.service getty@tty2.service getty@tty3.service getty@tty4.service getty@tty5.service getty@tty6.service
 Before=serial-getty@ttyS0.service serial-getty@ttyS1.service serial-getty@ttyS2.service
 Before=serial-getty@hvc0.service serial-getty@ttyAMA0.service serial-getty@ttysclp0.service
-# Prevent too early user login (bsc#1196594)
-Before=display-manager.service
+# Prevent too early user login (bsc#1196594) and too early vnc connection (bsc#1197265)
+Before=display-manager.service xvnc.socket
 ConditionPathExists=/var/lib/YaST2/runme_at_boot
 
 [Service]

--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Fri Mar 18 11:20:47 UTC 2022 - Knut Anderssen <kanderssen@suse.com>
+
+- Do not stop xvnc.socket but run the YaST2-Second-Stage and
+  YaST2-Firsboot services before it in order to prevent early
+  vnc connections (bsc#1197265)
+-4.3.50
+
+-------------------------------------------------------------------
 Thu Mar 17 12:46:16 UTC 2022 - Knut Anderssen <kanderssen@suse.com>
 
 - Run the YaST2-Second-Stage and YaST2-Firsboot services after 

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.3.49
+Version:        4.3.50
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/startup/Second-Stage/S09-cleanup
+++ b/startup/Second-Stage/S09-cleanup
@@ -15,7 +15,6 @@ if [ ! -z "$VNC" ] && [ "$VNC" -eq 1 ] ; then
 	log "\tkill all VNC sessions..."
 	killall Xvnc >/dev/null 2>&1
 	rm -fv /root/.vnc/passwd.yast
-	restore_xvnc
 fi
 # 13.3) stop network and sshd
 if [ "$Y2_NETWORK_ACTIVE" -ne 0 ] ; then

--- a/startup/YaST2.call
+++ b/startup/YaST2.call
@@ -172,7 +172,6 @@ function prepare_for_vnc () {
 	if [ $VNCPASS_EXCEPTION = 0 ];then
 		disable_splash
 		displayVNCMessage
-		stop_xvnc
 		startVNCServer
 		wait_for_x11
 		if [ "$server_running" = 1 ];then

--- a/startup/common/misc.sh
+++ b/startup/common/misc.sh
@@ -187,36 +187,6 @@ function disable_splash () {
 	[ -f /proc/splash ] && echo "verbose" > /proc/splash
 }
 
-#----[ stop_xvnc]-----#
-function stop_xvnc () {
-#--------------------------------------------------
-# stop xvnc since its default configuration collides
-# with the Xvnc server used for VNC installation
-# ---
-	systemctl stop xvnc.socket >/dev/null 2>&1
-# stop also running instances of xvnc to allow start our own
-        systemctl stop xvnc@* >/dev/null 2>&1
-}
-
-#----[ is_xvnc_enabled ]-----#
-function is_xvnc_enabled () {
-# return 0 if xvnc is enabled
-# ---
-	systemctl --quiet is-enabled xvnc.socket >/dev/null 2>&1
-	return $?
-}
-
-#----[ restore_xvnc ]-----#
-function restore_xvnc () {
-#--------------------------------------------------
-# start xvnc again if it is enabled, once the Xvnc
-# server already owns its port
-# ---
-	if is_xvnc_enabled; then
-		systemctl start xvnc.socket
-	fi
-}
-
 #----[ have_pid ]----#
 function have_pid () {
 #------------------------------------------------------


### PR DESCRIPTION
## Problem

- During the Second Stage of an installation, the **xvnc.socket** can starts before the **YaST2-Second-Stage** service runs its own Xvnc server. That could produce a black screen vnc connection as reported by openQA.

- In the past (see [yast/yast-installation: Pull Request 316](https://github.com/yast/yast-installation/pull/316)) we used to have a **systemd dependency** to be run before **xinetd** service and we removed that because some cycle dependency but once we removed **xinetd** it looks safer to add a before **xvnc.socket** dependency instead of stop the service and run it again which looks strange.

- https://bugzilla.suse.com/show_bug.cgi?id=1197265 (https://trello.com/c/cl2XRuwf/)

## Solution

Add **Before=xvnc.socket** to **YaST2-Second-Stage** and **YaST2-Firstboot** services. This will also prevent agetty to get the 5901 port (related to https://bugzilla.suse.com/show_bug.cgi?id=1196614).