### PR TITLE
Revert "AY: Do not stop xvnc.socket but rely on systemd"

### DIFF
--- a/package/YaST2-Firstboot.service
+++ b/package/YaST2-Firstboot.service
@@ -6,7 +6,7 @@ After=purge-kernels.service
 Conflicts=plymouth-start.service
 Before=getty@tty1.service serial-getty@ttyS0.service serial-getty@ttyS1.service serial-getty@ttyS2.service
 Before=serial-getty@hvc0.service serial-getty@ttyAMA0.service
-Before=display-manager.service xvnc.socket
+Before=display-manager.service
 ConditionPathExists=/var/lib/YaST2/reconfig_system
 OnFailure=shutdown.target
 

--- a/package/YaST2-Second-Stage.service
+++ b/package/YaST2-Second-Stage.service
@@ -10,8 +10,8 @@ Conflicts=plymouth-start.service
 Before=getty@tty1.service getty@tty2.service getty@tty3.service getty@tty4.service getty@tty5.service getty@tty6.service
 Before=serial-getty@ttyS0.service serial-getty@ttyS1.service serial-getty@ttyS2.service
 Before=serial-getty@hvc0.service serial-getty@ttyAMA0.service serial-getty@ttysclp0.service
-# Prevent too early user login (bsc#1196594) and too early vnc connection (bsc#1197265)
-Before=display-manager.service xvnc.socket
+# Prevent too early user login (bsc#1196594)
+Before=display-manager.service
 ConditionPathExists=/var/lib/YaST2/runme_at_boot
 
 [Service]

--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Apr 25 23:10:17 UTC 2022 - Knut Anderssen <kanderssen@suse.com>
+
+- Revert changes introduced in v4.3.50 as it produces some ordering
+  cycle issues (bsc#1198294)
+- 4.3.52
+
+-------------------------------------------------------------------
 Tue Mar 29 09:25:58 UTC 2022 - Martin Vidner <mvidner@suse.com>
 
 - AutoYaST: move custom file creation past user creation so that

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.3.51
+Version:        4.3.52
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/startup/Second-Stage/S09-cleanup
+++ b/startup/Second-Stage/S09-cleanup
@@ -15,6 +15,7 @@ if [ ! -z "$VNC" ] && [ "$VNC" -eq 1 ] ; then
 	log "\tkill all VNC sessions..."
 	killall Xvnc >/dev/null 2>&1
 	rm -fv /root/.vnc/passwd.yast
+	restore_xvnc
 fi
 # 13.3) stop network and sshd
 if [ "$Y2_NETWORK_ACTIVE" -ne 0 ] ; then

--- a/startup/YaST2.call
+++ b/startup/YaST2.call
@@ -172,6 +172,7 @@ function prepare_for_vnc () {
 	if [ $VNCPASS_EXCEPTION = 0 ];then
 		disable_splash
 		displayVNCMessage
+		stop_xvnc
 		startVNCServer
 		wait_for_x11
 		if [ "$server_running" = 1 ];then

--- a/startup/common/misc.sh
+++ b/startup/common/misc.sh
@@ -187,6 +187,36 @@ function disable_splash () {
 	[ -f /proc/splash ] && echo "verbose" > /proc/splash
 }
 
+#----[ stop_xvnc]-----#
+function stop_xvnc () {
+#--------------------------------------------------
+# stop xvnc since its default configuration collides
+# with the Xvnc server used for VNC installation
+# ---
+	systemctl stop xvnc.socket >/dev/null 2>&1
+# stop also running instances of xvnc to allow start our own
+        systemctl stop xvnc@* >/dev/null 2>&1
+}
+
+#----[ is_xvnc_enabled ]-----#
+function is_xvnc_enabled () {
+# return 0 if xvnc is enabled
+# ---
+	systemctl --quiet is-enabled xvnc.socket >/dev/null 2>&1
+	return $?
+}
+
+#----[ restore_xvnc ]-----#
+function restore_xvnc () {
+#--------------------------------------------------
+# start xvnc again if it is enabled, once the Xvnc
+# server already owns its port
+# ---
+	if is_xvnc_enabled; then
+		systemctl start xvnc.socket
+	fi
+}
+
 #----[ have_pid ]----#
 function have_pid () {
 #------------------------------------------------------


### PR DESCRIPTION
This reverts commit 0f3456341afa58b6265fe9217a0ccfcce975ecf9.


## Problem

Our recent changes in the services (start after **systemd-user-sessiones** #1024 and after **purge-kernels** #1036) probably introduced a bigger window time to connect to the **xvnc.socket** instance getting a black screen... specially the change about starting after the purge of old kernels will delay the start of our services. 

We tried to fix that (see https://bugzilla.suse.com/show_bug.cgi?id=1197265) adding a **Before=xvnc.socket** dependency which is the behavior we would like to have but as **Frank Bui** explained **YaST2-Second-Stage** and **YaST2-Firstboot.service** can't have **DefaultDependencies=yes** (implicit setting, which implies **After=basic.target**) and in the meantime has **Before=xvnc.socket** (which is ordered before basic.target). 

In the bug reported, the ordering cycle problem deletes the **systemd-user-sessions.service/start** job so it is not run and not privileged users are not able to login the system.

Modifying **YaST2-Firstboot**  and **YaST2-Second-Stage** to have **DefaultDependencies=no** introduce other systemd ordering cycle issues so it does not looks like a valid fix.

![orderyng cycle](https://user-images.githubusercontent.com/7056681/165077019-a49cdd14-1ed6-4963-a40e-625d2ff74de8.png)

- https://bugzilla.suse.com/show_bug.cgi?id=1198294 (related to https://bugzilla.suse.com/show_bug.cgi?id=1197265)

## Solution

By now we have decided to revert changes introduced in #1038 not starting **YaST2-Second-Stage** and **YaST2-Firsboot** services before **xvnc.socket** due to ordering cycle issues. For future releases we could improve the behavior controlling the xvnc.socket enablement during the **First Stage** of the installation not enabling it until the **YaST2-Second-Stage** or the **YaST2-Firstboot** of the installation has finished.

## Tests

Tested manually and verified that the same behavior is in previous versions too but the period of time where the xvnc.socket service is up before we start our own Xvnc socket is so small that it is hard to face it.
