### PR TITLE
Before sclp0

### DIFF
--- a/package/YaST2-Second-Stage.service
+++ b/package/YaST2-Second-Stage.service
@@ -6,10 +6,11 @@ After=systemd-user-sessions.service
 # Run after kernels are purged to prevent a zypper lock (bsc#1196431)
 After=purge-kernels.service
 Conflicts=plymouth-start.service
-# Prevent getty auto-generation (bsc#1196614, bsc#1196594)
+# Prevent getty auto-generation (bsc#1196614, bsc#1196594, bsc#1199746)
 Before=getty@tty1.service getty@tty2.service getty@tty3.service getty@tty4.service getty@tty5.service getty@tty6.service
 Before=serial-getty@ttyS0.service serial-getty@ttyS1.service serial-getty@ttyS2.service
 Before=serial-getty@hvc0.service serial-getty@ttyAMA0.service serial-getty@ttysclp0.service
+Before=serial-getty@sclp_line0.service
 # Prevent too early user login (bsc#1196594)
 Before=display-manager.service
 ConditionPathExists=/var/lib/YaST2/runme_at_boot

--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon May 23 15:42:10 UTC 2022 - Knut Anderssen <kanderssen@suse.com>
+
+- AutoYaST Second Stage: Added a missing dependency to the service
+  to prevent getty-autogeneration listen on 5901 port (bsc#1199746)
+- 4.3.53
+
+-------------------------------------------------------------------
 Mon Apr 25 23:10:17 UTC 2022 - Knut Anderssen <kanderssen@suse.com>
 
 - Revert changes introduced in v4.3.50 as it produces some ordering

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.3.52
+Version:        4.3.53
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only


### PR DESCRIPTION
## Problem

It extends https://github.com/yast/yast-installation/pull/1033 which missed the **serial-getty@sclp_line0.service** before dependency according to the bug.

- https://bugzilla.suse.com/show_bug.cgi?id=1199746#c39

## Solution

Added the before dependency to prevent the spawned **agetty** process to listen in the 5901 causing **AutoYaST-SecondStage.service** to not be able to start its own instance of the XVnc server.

