### PR TITLE
Do not restart services when the package is updated

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Jun 15 11:28:30 UTC 2022 - Knut Anderssen <kanderssen@suse.com>
+
+- Do not restart services when updating the package (bsc#1199480,
+  bsc#1200274)
+-4.3.54
+
+-------------------------------------------------------------------
 Mon May 23 15:42:10 UTC 2022 - Knut Anderssen <kanderssen@suse.com>
 
 - AutoYaST Second Stage: Added a missing dependency to the service

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.3.53
+Version:        4.3.54
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only
@@ -191,7 +191,7 @@ systemctl enable YaST2-Firstboot.service
 %service_del_preun YaST2-Second-Stage.service YaST2-Firstboot.service
 
 %postun
-%service_del_postun YaST2-Second-Stage.service YaST2-Firstboot.service
+%service_del_postun_without_restart YaST2-Second-Stage.service YaST2-Firstboot.service
 
 #suse_version
 %endif


### PR DESCRIPTION
## Problem

The system hangs when it is updated by the initscripts service and it contains an updated version of this package.

- https://bugzilla.suse.com/show_bug.cgi?id=1199480
- https://bugzilla.suse.com/show_bug.cgi?id=1200274


## Solution

Do not restart yast2-installation services when the package is updated. 

**Note:** It will not help if the system is updated with previous versions of the package but will help with future ones.

## Tests

Tested manually