### PR TITLE
Do not use "xrdb" for setting the "Xft.dpi" value (bsc#1201532)

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,16 @@
 -------------------------------------------------------------------
+Mon Jul 18 16:05:26 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
+
+- Do not use "xrdb" for setting the "Xft.dpi" value, use a specific
+  YaST tool from the yast2-x11 package (bsc#1201532)
+  (xrdb depends on the C pre-processor increasing the dependencies
+   about of 22MB)
+- Install yast2-x11 only when GUI (libyui-qt) is installed,
+  avoid installing the dependent X libraries in minimal (text mode)
+  installation
+- 4.5.4
+
+-------------------------------------------------------------------
 Wed Jun 15 11:28:30 UTC 2022 - Knut Anderssen <kanderssen@suse.com>
 
 - Do not restart services when updating the package (bsc#1199480,

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.5.3
+Version:        4.5.4
 Release:        0
 Summary:        YaST2 - Installation Parts
 License:        GPL-2.0-only
@@ -69,8 +69,8 @@ Requires:       iproute2
 Requires:       pciutils
 # tar-gzip some system files and untar-ungzip them after the installation (FATE #300421, #120103)
 Requires:       tar
-# xrdb is used to set Xft.dpi in YaST2.call
-Requires:       xrdb
+# /usr/lib/YaST2/bin/xftdpi, install only when the GUI is installed
+Requires:       (yast2-x11 >= 4.5.1 if libyui-qt)
 # Y2Packager::NewRepositorySetup
 Requires:       yast2 >= 4.4.42
 # CIOIgnore

--- a/startup/YaST2.call
+++ b/startup/YaST2.call
@@ -90,9 +90,9 @@ function calculate_x11_dpi () {
 #----[ set_xft_dpi ]----#
 function set_xft_dpi () {
 #------------------------------------------------------
-# Set Xft.dpi resource using xrdb
+# Set Xft.dpi resource using a helper tool
 # ---
-	echo "Xft.dpi: $1" | xrdb -merge - && log "Xft.dpi set to: $1"
+	/usr/lib/YaST2/bin/xftdpi "$1" && log "Xft.dpi set to: $1"
 }
 
 #----[ prepare_for_x11 ]----#


### PR DESCRIPTION
## Problem

- `yast2-installation` depends on `xrdb`, that has two negative consequences
  - `xrdb` depends on some X libraries and because `yast2-installation` is included in the installed system then the X libraries are installed even in a minimal text mod installation
  - it also depends on the C pre-processor which has ~22MB (!)

## Solution

- Use an YaST specific tool instead of `xrdb` (see https://github.com/yast/yast-x11/pull/25), it does not depend on `cpp`
- Install the `yast2-x11` package only when `libyui-qt` is installed, otherwise it does not make sense

## Notes

The "new" expressions in RPM dependencies are supported since rpm 4.13. This is used in SUSE since 2017, SLE15-GA contains rpm 4.14.1 so this is supported even in the first SLE15 release. See more details in https://rpm-software-management.github.io/rpm/manual/boolean_dependencies.html

## TODO

- [ ] Check that installation-images is still correctly built
- [ ] Check the real saved space in the YaST containers
- [ ] Check if we could backport the fix to SP4 and how much space we would save in textmode installation