### PR TITLE
Before user sessions

### DIFF
--- a/package/YaST2-Second-Stage.service
+++ b/package/YaST2-Second-Stage.service
@@ -1,8 +1,6 @@
 [Unit]
 Description=YaST2 Second Stage
 After=apparmor.service local-fs.target plymouth-start.service
-# systemd-user-sessions is needed to allow ssh connection (bsc#1195059)
-After=systemd-user-sessions.service
 # Run after kernels are purged to prevent a zypper lock (bsc#1196431)
 After=purge-kernels.service
 Conflicts=plymouth-start.service
@@ -24,7 +22,6 @@ Type=oneshot
 # used correctly (see bnc#866692 and bnc#866692 for details).
 Environment=TERM=linux PX_MODULE_PATH=""
 # Block non-privileged user login (bsc#1195059)
-ExecStartPre=-/usr/bin/touch /run/nologin
 ExecStartPre=-/usr/bin/plymouth quit
 ExecStart=/usr/lib/YaST2/startup/YaST2.Second-Stage
 RemainAfterExit=yes
@@ -32,7 +29,6 @@ TimeoutSec=0
 # Initialize tty1 in order to remove old YaST output and to show the cursor
 # again (bnc#1018037)
 ExecStartPost=/bin/sh -c '/usr/bin/printf "\033c" > /dev/tty1'
-ExecStartPost=/usr/bin/rm -f /run/nologin
 ExecStartPost=/usr/bin/rm -f /var/lib/YaST2/runme_at_boot
 ExecStartPost=/usr/bin/systemctl restart systemd-vconsole-setup.service
 StandardInput=tty

--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,9 +1,17 @@
 -------------------------------------------------------------------
+Fri Jul 22 11:35:42 UTC 2022 - Knut Anderssen <kanderssen@suse.com>
+
+- AutoYaST SecondStage: Revert changes introduced in 4.3.46 running
+  the initscript service before systemd-user-sessions again once
+  systemd patched logind (bsc#1195059, bsc#1200780)
+- 4.3.55
+
+-------------------------------------------------------------------
 Wed Jun 15 11:28:30 UTC 2022 - Knut Anderssen <kanderssen@suse.com>
 
 - Do not restart services when updating the package (bsc#1199480,
   bsc#1200274)
--4.3.54
+- 4.3.54
 
 -------------------------------------------------------------------
 Mon May 23 15:42:10 UTC 2022 - Knut Anderssen <kanderssen@suse.com>

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.3.54
+Version:        4.3.55
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only


### PR DESCRIPTION
## Problem

In order to prevent a ssh timeout produced because of systemd logind we [added](https://github.com/yast/yast-network/pull/1024) a condition to run the **SecondStage.service** after  **systemd-user-sessions** but once syste systemd logind has been patched (see https://github.com/systemd/systemd/pull/23936 & https://build.suse.de/request/show/276157) our fix can be reverted removing 
 the Before condition.

- https://bugzilla.suse.com/show_bug.cgi?id=1200780 & https://bugzilla.suse.com/show_bug.cgi?id=1195059

## Solution

Remove the **After=systemd-user-sessions** condition from the YaST2-SecondStage.service once systemd logind has been patched to prevent the ssh timeout.
