### PR TITLE
[SP4] Do not use "xrdb" for setting the "Xft.dpi" value (bsc#1201966, bsc#1201532)

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,16 @@
 -------------------------------------------------------------------
+Tue Aug  2 14:56:52 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
+
+- Do not use "xrdb" for setting the "Xft.dpi" value, use a specific
+  YaST tool from the yast2-x11 package (bsc#1201532)
+  (xrdb depends on the C pre-processor increasing the dependencies
+   about of 22MB)
+- Install yast2-x11 only when GUI (libyui-qt) is installed,
+  avoid installing the dependent X libraries in minimal (text mode)
+  installation (bsc#1201966)
+- 4.4.56
+
+-------------------------------------------------------------------
 Fri Jul 22 11:35:42 UTC 2022 - Knut Anderssen <kanderssen@suse.com>
 
 - AutoYaST SecondStage: Revert changes introduced in 4.3.46 running

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.4.55
+Version:        4.4.56
 Release:        0
 Summary:        YaST2 - Installation Parts
 License:        GPL-2.0-only
@@ -69,8 +69,8 @@ Requires:       iproute2
 Requires:       pciutils
 # tar-gzip some system files and untar-ungzip them after the installation (FATE #300421, #120103)
 Requires:       tar
-# xrdb is used to set Xft.dpi in YaST2.call
-Requires:       xrdb
+# /usr/lib/YaST2/bin/xftdpi, install only when the GUI is installed
+Requires:       (yast2-x11 >= 4.4.2 if libyui-qt)
 # Y2Packager::NewRepositorySetup
 Requires:       yast2 >= 4.4.42
 # CIOIgnore

--- a/startup/YaST2.call
+++ b/startup/YaST2.call
@@ -90,9 +90,9 @@ function calculate_x11_dpi () {
 #----[ set_xft_dpi ]----#
 function set_xft_dpi () {
 #------------------------------------------------------
-# Set Xft.dpi resource using xrdb
+# Set Xft.dpi resource using a helper tool
 # ---
-	echo "Xft.dpi: $1" | xrdb -merge - && log "Xft.dpi set to: $1"
+	/usr/lib/YaST2/bin/xftdpi "$1" && log "Xft.dpi set to: $1"
 }
 
 #----[ prepare_for_x11 ]----#


### PR DESCRIPTION
- Backport #1052 to SP4
- https://bugzilla.suse.com/show_bug.cgi?id=1201966#c5