### PR TITLE
Directly Calculate the Qt Scale Factor, don't rely on the Xft.dpi X Resource

### DIFF
--- a/startup/YaST2.call
+++ b/startup/YaST2.call
@@ -75,13 +75,31 @@ function calculate_x11_dpi () {
 #------------------------------------------------------
 # Calculate the monitor's dpi from xrandr's output
 # ---
-	local MON_SIZE=`xrandr |grep mm |head -n 1`
-	local MON_WIDTH_MM=`echo $MON_SIZE | sed -e "s/.* \([0-9]\+\)mm x \([0-9]\+\)mm.*/\1/"`
+        local MON_SIZE=`xrandr |grep mm |head -n 1`
 	local MON_WIDTH_PX=`echo $MON_SIZE | sed -e "s/.* \([0-9]\+\)x[0-9]\++.*/\1/"`
-	local DPI=`ruby -e "puts (($MON_WIDTH_PX/($MON_WIDTH_MM*0.0393701)/48).round)*48"`
+	local MON_WIDTH_MM=`echo $MON_SIZE | sed -e "s/.* \([0-9]\+\)mm x \([0-9]\+\)mm.*/\1/"`
+
 	log "Monitor size: $MON_SIZE"
-	log "Monitor width mm: $MON_WIDTH_MM"
 	log "Monitor width px: $MON_WIDTH_PX"
+	log "Monitor width mm: $MON_WIDTH_MM"
+
+        if [ ${MON_WIDTH_MM:-0} -le 0 ]; then
+                log "Monitor width in mm unknown, using 96 dpi as default"
+                DPI=96
+        else
+                local DPI=`ruby -e "puts (($MON_WIDTH_PX/($MON_WIDTH_MM*0.0393701)/48).round)*48"`
+        fi
+
+        if [ ${DPI:-96} -gt 288 ]; then
+                log "Monitor dpi is suspiciously high (${DPI}), using 288 dpi"
+                DPI=288
+                # Not sure if capping this at 288 dpi is really appropriate;
+                # 13" 4k laptops easily get up to 336 dpi.
+                # The original intent was to protect against bogus EDID values.
+                #
+                # 2022-09-12 shundhammer
+        fi
+
 	log "Monitor dpi: $DPI"
 	echo "$DPI"
 }
@@ -92,6 +110,37 @@ function set_xft_dpi () {
 # Set Xft.dpi resource using a helper tool
 # ---
 	/usr/lib/YaST2/bin/xftdpi "$1" && log "Xft.dpi set to: $1"
+        # If the Xft.dpi X resource is set, it overrides the value
+        # that Qt otherwise calculates.
+}
+
+
+function set_qt_scale_factor () {
+#------------------------------------------------------
+# Set Qt environment variables for the scale factor, i.e. the factor by which
+# to increase the size of the UI in HiDPI cases.
+#
+# We assume the UI is designed for 96 dpi and calculate the scale factor based
+# on that. We use multiples of 0.5 here (1.0, 1.5, 2.0, 2.5, 3.0) which is
+# already guaranteed by enforcing a DPI value that is a multiple of 48
+# (see function calculate_x11_dpi()).
+# ---
+        local DPI=${1:-96}
+
+        if [ $DPI -le 96 ]; then
+                export QT_SCALE_FACTOR=1
+                # Also in non-HiDPI cases to avoid surprises if Qt
+                # should decide to do its own scaling
+        else
+                export QT_SCALE_FACTOR=`ruby -e "puts $DPI/96.0"`
+        fi
+
+        # Override the Qt default of rounding to the next integer.
+        # https://doc-snapshots.qt.io/qt5-5.15/highdpi.html
+        export QT_SCALE_FACTOR_ROUNDING_POLICY="PassThrough"
+
+        log "QT_SCALE_FACTOR: $QT_SCALE_FACTOR"
+        log "QT_SCALE_FACTOR_ROUNDING_POLICY: $QT_SCALE_FACTOR_ROUNDING_POLICY"
 }
 
 
@@ -115,17 +164,8 @@ function prepare_for_x11 () {
 			log "\tX-Server is ready: $xserver_pid"
 
 			local DPI=`calculate_x11_dpi`
-			if [ "$DPI" -ge 144 -a "$DPI" -le 288 ]; then
-				set_xft_dpi $DPI
-			elif [ "$DPI" -gt 288 ]; then
-				# This is a workaround against monitors
-				# that provide bad edid values
-				log "WARNING: Detected monitor DPI is too high ($DPI), using value 288"
-				set_xft_dpi 288
-			else
-				log "WARNING: Detected monitor DPI is too low ($DPI), using value 96"
-				set_xft_dpi 96
-			fi
+			# set_xft_dpi $DPI
+                        set_qt_scale_factor $DPI
 		fi
 	fi
 
@@ -506,6 +546,13 @@ function start_yast_again () {
 	fi
 }
 
+
+
+#----------------------------------------------------------------------
+# MAIN
+#----------------------------------------------------------------------
+
+
 #=============================================
 # Start the Magic :-)
 #=============================================
@@ -514,6 +561,7 @@ function start_yast_again () {
 . /usr/lib/YaST2/startup/common/functions.sh
 . /usr/lib/YaST2/startup/common/network.sh
 . /usr/lib/YaST2/startup/requires
+
 
 #=============================================
 # 1.1) set splash progress bar to 90%

--- a/startup/YaST2.call
+++ b/startup/YaST2.call
@@ -563,6 +563,18 @@ function start_yast_again () {
 . /usr/lib/YaST2/startup/requires
 
 
+# Debugging helper: Only calculate and show the DPI, then exit.
+if [ -n "$DEBUG_YAST_DPI" ]; then
+        echo "*** DPI Debug mode ***"
+        DPI=`calculate_x11_dpi`
+        echo "DPI: $DPI"
+        set_qt_scale_factor $DPI
+        env | grep "^QT_SCALE"
+        echo "Done."
+        exit 1
+fi
+
+
 #=============================================
 # 1.1) set splash progress bar to 90%
 #---------------------------------------------

--- a/startup/YaST2.call
+++ b/startup/YaST2.call
@@ -21,16 +21,15 @@
 #               : - Via serial line ttyS0/115200 baud, 8N1, RTS/CTS
 #               :   which is the same as the NCURSES mode
 #               : - VNC Installation via browser
-#               :
-# STATUS        : $Id$
 #----------------
 #
 #set -x
 
 #=============================================
-# Functions...
-#---------------------------------------------
-#----[ wait_for_x11 ]----#
+# Functions
+#=============================================
+
+
 function wait_for_x11() {
 #------------------------------------------------------
 # after a X-Server has been started you can wait until
@@ -71,7 +70,7 @@ function wait_for_x11() {
 	done
 }
 
-#----[ calculate_x11_dpi ]----#
+
 function calculate_x11_dpi () {
 #------------------------------------------------------
 # Calculate the monitor's dpi from xrandr's output
@@ -87,7 +86,7 @@ function calculate_x11_dpi () {
 	echo "$DPI"
 }
 
-#----[ set_xft_dpi ]----#
+
 function set_xft_dpi () {
 #------------------------------------------------------
 # Set Xft.dpi resource using a helper tool
@@ -95,7 +94,7 @@ function set_xft_dpi () {
 	/usr/lib/YaST2/bin/xftdpi "$1" && log "Xft.dpi set to: $1"
 }
 
-#----[ prepare_for_x11 ]----#
+
 function prepare_for_x11 () {
 #------------------------------------------------------
 # prepare X11 installation
@@ -139,14 +138,13 @@ function prepare_for_x11 () {
 }
 
 
-#----[ prepare_for_qt ]----#
+
 function prepare_for_qt () {
     set_inst_qt_env
     prepare_for_x11
 }
 
 
-#----[ prepare_for_ncurses ]----#
 function prepare_for_ncurses () {
 #------------------------------------------------------
 # prepare NCURSES installation
@@ -184,7 +182,7 @@ function prepare_for_ncurses () {
 	fi
 }
 
-#----[ prepare_for_ssh ]----#
+
 function prepare_for_ssh () {
 #------------------------------------------------------
 # prepare SSH installation
@@ -193,7 +191,7 @@ function prepare_for_ssh () {
 	set_inst_qt_env
 }
 
-#----[ prepare_for_vnc ]----#
+
 function prepare_for_vnc () {
 #------------------------------------------------------
 # prepare VNC installation
@@ -230,7 +228,7 @@ function prepare_for_vnc () {
 	set_inst_qt_env
 }
 
-#----[ kill_xserver ]----#
+
 function kill_xserver () {
   if [ -n "$xserver_pid" ];then
     sleep 1 && kill $xserver_pid
@@ -241,7 +239,7 @@ function kill_xserver () {
   fi
 }
 
-#----[ check_x11 ]----#
+
 function check_x11 () {
 #------------------------------------------------------
 # check if the prepared medium X11 (Qt) is valid
@@ -269,7 +267,7 @@ function check_x11 () {
 	fi
 }
 
-#----[ check_network ]----#
+
 function check_network () {
 #------------------------------------------------------
 # check if the prepared medium SSH is valid. It is valid
@@ -294,7 +292,7 @@ function check_network () {
 	fi
 }
 
-#----[ check_vnc ]----#
+
 function check_vnc () {
 #------------------------------------------------------
 # check if the prepared medium VNC is valid
@@ -334,7 +332,7 @@ function ssh_reboot_message()
 	fi
 }
 
-#---[ validate_backup ]---#
+
 function validate_backup () {
   # Check that the ID and VERSION_ID in the backup os-release file
   # matches with the values in the /etc/os-release to considered it
@@ -359,7 +357,7 @@ function validate_backup () {
   fi
 }
 
-#----[ restore_backup ]----#
+
 function restore_backup () {
   # restores backup if it is available
   if [ -d /mnt/var/adm/backup/system-upgrade ]; then
@@ -377,7 +375,7 @@ function restore_backup () {
   fi
 }
 
-#----[ start_yast ]----#
+
 function start_yast () {
 #------------------------------------------------------
 # Start YaST2 refering to the contents of the Y2_*
@@ -477,7 +475,7 @@ function start_yast () {
 	fi
 }
 
-#----[ start_yast_and_reboot ]----#
+
 function start_yast_and_reboot () {
 #------------------------------------------------------
 # This function will reboot the system and start yast
@@ -495,7 +493,7 @@ function start_yast_and_reboot () {
 	fi
 }
 
-#----[ start_yast_again ]----#
+
 function start_yast_again () {
 #------------------------------------------------------
 # This function will restart yast again with the same


### PR DESCRIPTION
## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1199020


## Trello

https://trello.com/c/ST2Xm5iz/


## Problem

Qt has a life of its own when it comes to determining the scaling of YaST's geometry and what font sizes to use during installation in HiDPI cases. Sometimes the fonts are too large, sometimes they are too small.


## Cause

While we used to check the DPI based on EDID and the `xrandr` output and set the `Xft.dpi` X resource accordingly (making sure to always use values that can be divided by 48, at least 96 dpi, at most 288 dpi), Qt rounded the resulting values to an integer number, based on a new "scale factor rounding policy".

We found that rounding and the resulting integer scaling factors are too coarse; factors like 1.5 or 2.5 work just fine (even 1.25, 1.75, 2.25, 2.75 would work just fine) as the major desktops prove who use those factors for magnifying GUIs all the time.


## Fix

Don't rely on setting the DPI to the `Xft.dp` X resource and hope for the best that Qt will do the right thing; we are now explicitly setting the scale factor with two environment variables:

- `QT_SCALE_FACTOR`
- `QT_SCALE_FACTOR_ROUNDING_POLICY="PassThrough"` (to avoid rounding)

Since we already make sure that the DPI value we use is rounded so it can always be divided by 48, and we limit to min 96 and max 288, we will always get one of those scale factors:

- 1
- 1.5
- 2
- 2.5
- 3

## To Discuss

In a previous PR, @antlarr introduced a maximum of 288 dpi to guard against bogus EDID values. But modern 13" laptops with a 4k display already have 336 dpi; should we use a higher maximum?


## Related Gist

https://gist.github.com/shundhammer/79d534b8452554b16fb2f667f58290f9