### PR TITLE
Avoid Recreating all openQA Needles

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Sep 15 14:04:42 UTC 2022 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Don't set QT_SCALE_FACTOR unless > 1 (bsc#1199020)
+  to avoid forcing QA to recreate all needles for all standard cases
+- 4.5.7
+
+-------------------------------------------------------------------
 Tue Sep 13 12:13:19 UTC 2022 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Directly calculate the Qt scale factor, no longer rely on the

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.5.6
+Version:        4.5.7
 Release:        0
 Summary:        YaST2 - Installation Parts
 License:        GPL-2.0-only

--- a/startup/YaST2.call
+++ b/startup/YaST2.call
@@ -154,11 +154,13 @@ function set_qt_scale_factor () {
         local DPI=${1:-96}
         # Reference DPI as a base for scaling
         local REF_DPI=144
+        log "\tReference DPI: $REF_DPI"
 
         if [ $DPI -le 96 ]; then
-                export QT_SCALE_FACTOR=1
-                # Also setting the environment variable in non-HiDPI cases to
-                # avoid surprises if Qt should decide to do its own scaling.
+                # Don't set QT_SCALE_FACTOR unless really needed,
+                # otherwise all openQA needles need to be changed.
+
+                log "\tNo Qt scaling needed."
         else
                 # Calculate a scale factor based on the reference DPI, but no
                 # smaller than 1.0; and round to multiples of 0.25 (1.25, 1.5,
@@ -166,15 +168,14 @@ function set_qt_scale_factor () {
                 # fractions.
 
                 export QT_SCALE_FACTOR=`ruby -e "puts [(($DPI/(1.0*$REF_DPI)/0.25).round * 0.25), 1.0].max"`
+
+                # Override the Qt default of rounding to the next integer.
+                # https://doc-snapshots.qt.io/qt5-5.15/highdpi.html
+                export QT_SCALE_FACTOR_ROUNDING_POLICY="PassThrough"
+
+                log "\tQT_SCALE_FACTOR: $QT_SCALE_FACTOR"
+                log "\tQT_SCALE_FACTOR_ROUNDING_POLICY: $QT_SCALE_FACTOR_ROUNDING_POLICY"
         fi
-
-        # Override the Qt default of rounding to the next integer.
-        # https://doc-snapshots.qt.io/qt5-5.15/highdpi.html
-        export QT_SCALE_FACTOR_ROUNDING_POLICY="PassThrough"
-
-        log "\tReference DPI: $REF_DPI"
-        log "\tQT_SCALE_FACTOR: $QT_SCALE_FACTOR"
-        log "\tQT_SCALE_FACTOR_ROUNDING_POLICY: $QT_SCALE_FACTOR_ROUNDING_POLICY"
 }
 
 
@@ -607,7 +608,7 @@ function start_yast_again () {
 # Debugging helper: Only calculate and show the DPI, then exit.
 # Start with
 #
-#   FAKE_MON_WIDTH_MM=200 ./Yast2.call
+#   FAKE_MON_WIDTH_MM=200 ./YaST2.call
 #
 # and watch stdout and /var/log/YaST2/y2start.log
 


### PR DESCRIPTION
## Problem

The last PR https://github.com/yast/yast-installation/pull/1057 changed the font size even in non-HiDPI cases ever so slightly, so the existing openQA needles don't fit anymore.

![190419184-e43e5ec2-c564-4817-bad5-4b44a152ece7](https://user-images.githubusercontent.com/11538225/190425660-0bacb6dd-aa79-4f17-bcda-9081974cee87.png)


## Cause

The two environment variables were always set, even for a scale factor of 1:

```
QT_SCALE_FACTOR=1
QT_SCALE_FACTOR_ROUNDING_POLICY="PassThrough"
```

which obviously does make a difference.


## Fix

Only set them if > 1.
