### PR TITLE
Fix generation of help text in the installation summary

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,9 +1,15 @@
 -------------------------------------------------------------------
+Mon Oct  3 10:42:07 UTC 2022 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Fixed the help in the installation summary to include the texts
+  from the corresponding proposals (related to jsc#SLE-24764).
+- 4.4.57
+
+-------------------------------------------------------------------
 Tue Sep 20 14:41:41 UTC 2022 - José Iván López González <jlopez@suse.com>
 
-- Write config for ssh-apply script according to the enabled
+- Write config for ssg-apply script according to the enabled
   security policy (part of jsc#SLE-24764).
-- 4.4.57
 
 -------------------------------------------------------------------
 Tue Aug  2 14:56:52 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
@@ -30,7 +36,7 @@ Wed Jun 15 11:28:30 UTC 2022 - Knut Anderssen <kanderssen@suse.com>
 
 - Do not restart services when updating the package (bsc#1199480,
   bsc#1200274)
--4.4.54
+- 4.4.54
 
 -------------------------------------------------------------------
 Mon May 23 15:42:10 UTC 2022 - Knut Anderssen <kanderssen@suse.com>

--- a/src/lib/installation/proposal_store.rb
+++ b/src/lib/installation/proposal_store.rb
@@ -611,16 +611,16 @@ module Installation
     end
 
     def modules_help(current_tab)
-      modules_order = presentation_order
-      if tabs? && current_tab
-        modules_order = modules_order[current_tab]
-
-        modules_order.each_with_object("") do |client, text|
-          description = description_for(client)
-          text << description["help"] if description && description["help"]
+      modules_order =
+        if tabs? && current_tab
+          presentation_order[current_tab]
+        else
+          presentation_order
         end
-      else
-        ""
+
+      modules_order.each_with_object("") do |client, text|
+        description = description_for(client)
+        text << description["help"] if description && description["help"]
       end
     end
   end


### PR DESCRIPTION
## Problem

In theory, the different proposal clients displayed in the installation summary have the option to incorporate their own help texts to the general help of the summary screen.

That's documented in the [`Installation::ProposalClient`](https://github.com/yast/yast-yast2/blob/master/library/general/src/lib/installation/proposal_client.rb) class.

Unfortunately, the whole mechanism seems to be rather broken:

- The help texts of the clients are simply being ignored at least since the introduction of https://github.com/yast/yast-installation/pull/279 (at 2015!)
- The mentioned documentation at `ProposalClient` is also wrong. According to the current (broken) code, the help is fetched from the `description` hash, not from the `make_proposal` one (as documented).
- Nobody noticed it because there are exactly ZERO proposals with a help text at the moment of writing.

## Solution

Fix the broken code so the help texts from the proposal clients is added again to the general help text.

That will make again possible to specify per-client help texts, which we plan to use in the context of https://jira.suse.com/browse/PM-3526

## Testing

Tested manually

## Other pull requests

A pull request to `yast-yast2` should likely be created to fix the documentation of `ProposalClient`.

A pull request will be created in `yast-security` to introduce the desired help text in the corresponding proposal client.