### PR TITLE
Security policy

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Sep 20 14:41:41 UTC 2022 - José Iván López González <jlopez@suse.com>
+
+- Write config for ssh-apply script according to the enabled
+  security policy (part of jsc#SLE-24764).
+- 4.4.57
+
+-------------------------------------------------------------------
 Tue Aug  2 14:56:52 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
 
 - Do not use "xrdb" for setting the "Xft.dpi" value, use a specific

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -42,8 +42,8 @@ BuildRequires:  yast2-network >= 4.4.12
 BuildRequires:  yast2-packager >= 4.4.13
 # yast/rspec/helpers.rb
 BuildRequires:  yast2-ruby-bindings >= 4.4.7
-# For LSM classes
-BuildRequires:  yast2-security
+# For security policies
+BuildRequires:  yast2-security >= 4.4.15
 # using /usr/bin/udevadm
 BuildRequires:  yast2-storage-ng >= 4.2.71
 # Y2Users

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.4.56
+Version:        4.4.57
 Release:        0
 Summary:        YaST2 - Installation Parts
 License:        GPL-2.0-only

--- a/src/lib/installation/clients/security_finish.rb
+++ b/src/lib/installation/clients/security_finish.rb
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-# Copyright (c) 2017 SUSE LLC
+# Copyright (c) [2017-2022] SUSE LLC
 #
 #
 # This program is free software; you can redistribute it and/or modify it under
@@ -21,6 +21,7 @@ require "yast"
 require "y2firewall/firewalld"
 require "installation/security_settings"
 require "installation/finish_client"
+require "y2security/security_policies/manager"
 
 Yast.import "Mode"
 Yast.import "SignatureCheckDialogs"
@@ -87,6 +88,8 @@ module Installation
 
         # Write down the Linux Security Module configuration
         settings.lsm_config.save
+
+        write_security_policies_config
 
         true
       end
@@ -181,6 +184,14 @@ module Installation
 
         Yast::Service.Enable("sshd") if @settings.enable_sshd
         configure_firewall if @firewalld.installed?
+      end
+
+      # Writes config for security policies
+      def write_security_policies_config
+        # write security policies config only during a fresh install
+        return if Yast::Mode.update
+
+        Y2Security::SecurityPolicies::Manager.instance.write_config
       end
     end
   end

--- a/test/lib/clients/security_finish_test.rb
+++ b/test/lib/clients/security_finish_test.rb
@@ -2,12 +2,14 @@
 
 require_relative "../../test_helper"
 require "installation/clients/security_finish"
+require "y2security/security_policies/manager"
 
 Yast.import "Service"
 
 describe Installation::Clients::SecurityFinish do
   before do
     allow_any_instance_of(Y2Firewall::Firewalld::Api).to receive(:running?).and_return(false)
+    allow(Y2Security::SecurityPolicies::Manager.instance).to receive(:write_config)
   end
 
   let(:proposal_settings) { Installation::SecuritySettings.create_instance }
@@ -42,6 +44,12 @@ describe Installation::Clients::SecurityFinish do
     it "enables the sshd service if enabled in the proposal" do
       allow(proposal_settings).to receive(:enable_sshd).and_return(true)
       expect(Yast::Service).to receive(:Enable).with("sshd")
+
+      subject.write
+    end
+
+    it "writes the security policies config" do
+      expect(Y2Security::SecurityPolicies::Manager.instance).to receive(:write_config)
 
       subject.write
     end
@@ -116,6 +124,12 @@ describe Installation::Clients::SecurityFinish do
 
       it "skips writting LSM config" do
         expect(proposal_settings.lsm_config).to_not receive(:save)
+
+        subject.write
+      end
+
+      it "skips writting the security policies config" do
+        expect(Y2Security::SecurityPolicies::Manager.instance).to_not receive(:write_config)
 
         subject.write
       end


### PR DESCRIPTION
## Problem

Security policies and rules can be enabled/disabled during the (auto-)installation. That info has to be transfered to the config file of the script provided by the ssg-apply package.  

For more info, see:

* https://github.com/yast/yast-security/pull/128
* https://github.com/yast/yast-security/pull/137


## Solution

Adapt *security_finish* client to also write the security policies config.


## Testing

* Added new unit tests
* Tested manually

