### PR TITLE
Replace SecurityPolicies::Manager#write_config with #write

### DIFF
--- a/src/lib/installation/clients/security_finish.rb
+++ b/src/lib/installation/clients/security_finish.rb
@@ -191,7 +191,8 @@ module Installation
         # write security policies config only during a fresh install
         return if Yast::Mode.update
 
-        Y2Security::SecurityPolicies::Manager.instance.write_config
+        manager = Y2Security::SecurityPolicies::Manager.instance
+        manager.write
       end
     end
   end

--- a/test/lib/clients/security_finish_test.rb
+++ b/test/lib/clients/security_finish_test.rb
@@ -9,7 +9,7 @@ Yast.import "Service"
 describe Installation::Clients::SecurityFinish do
   before do
     allow_any_instance_of(Y2Firewall::Firewalld::Api).to receive(:running?).and_return(false)
-    allow(Y2Security::SecurityPolicies::Manager.instance).to receive(:write_config)
+    allow(Y2Security::SecurityPolicies::Manager.instance).to receive(:write)
   end
 
   let(:proposal_settings) { Installation::SecuritySettings.create_instance }
@@ -49,7 +49,7 @@ describe Installation::Clients::SecurityFinish do
     end
 
     it "writes the security policies config" do
-      expect(Y2Security::SecurityPolicies::Manager.instance).to receive(:write_config)
+      expect(Y2Security::SecurityPolicies::Manager.instance).to receive(:write)
 
       subject.write
     end
@@ -129,7 +129,7 @@ describe Installation::Clients::SecurityFinish do
       end
 
       it "skips writting the security policies config" do
-        expect(Y2Security::SecurityPolicies::Manager.instance).to_not receive(:write_config)
+        expect(Y2Security::SecurityPolicies::Manager.instance).to_not receive(:write)
 
         subject.write
       end


### PR DESCRIPTION
Replace `#write_config` with `#write` to conform to the changes in https://github.com/yast/yast-security/pull/142.