### PR TITLE
add 'repo', 'cd', and 'hd' schemes to Yast::Transfer::FileFromUrl

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Oct 20 13:53:14 UTC 2022 - Steffen Winterfeldt <snwint@suse.com>
+
+- add 'repo', 'cd', 'dvd', 'hd', and 'label' schemes to
+  Yast::Transfer::FileFromUrl (jsc#SLE-22578, jsc#SLE-24584)
+- 4.5.8
+
+-------------------------------------------------------------------
 Thu Sep 15 14:04:42 UTC 2022 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Don't set QT_SCALE_FACTOR unless > 1 (bsc#1199020)

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.5.7
+Version:        4.5.8
 Release:        0
 Summary:        YaST2 - Installation Parts
 License:        GPL-2.0-only

--- a/src/lib/transfer/file_from_url.rb
+++ b/src/lib/transfer/file_from_url.rb
@@ -145,6 +145,12 @@ module Yast::Transfer
         end
       end
 
+      # convert 'label' scheme to 'device' scheme
+      if toks["scheme"] == "label"
+        toks["scheme"] = "device"
+        toks["host"] = "disk/by-label/#{toks["host"]}"
+      end
+
       _Scheme = toks["scheme"]
       _Host = toks["host"]
       _Path = toks["path"]

--- a/src/lib/transfer/file_from_url.rb
+++ b/src/lib/transfer/file_from_url.rb
@@ -116,7 +116,7 @@ module Yast::Transfer
         _Localfile
       )
 
-      log.info "toks initial: #{toks.inspect}"
+      log.info "toks initial: #{hide_password(toks).inspect}"
 
       if _Scheme == "repo"
         base_url = InstURL.installInf2Url("")
@@ -125,17 +125,17 @@ module Yast::Transfer
           return false
         end
 
-        log.info("installation path from install.inf: #{base_url}")
+        log.info("installation path from install.inf: #{URL.HidePassword(base_url)}")
 
         toks["scheme"] = "relurl"
         rel_url = URL.Build(toks)
         log.info("relative url: #{rel_url}")
 
         absolute_url = Yast2::RelURL.from_installation_repository(rel_url).absolute_url.to_s
-        log.info("absolute url: #{absolute_url}")
+        log.info("absolute url: #{URL.HidePassword(absolute_url)}")
 
         toks = URL.Parse(absolute_url)
-        log.info "toks absolute: #{toks.inspect}"
+        log.info "toks absolute: #{hide_password(toks).inspect}"
       end
 
       # convert 'cd', "dvd', and 'hd' Zypp schemes to 'device' schema
@@ -164,7 +164,7 @@ module Yast::Transfer
       end
       toks["path"] = _Path
 
-      log.info "toks final: #{toks.inspect}"
+      log.info "toks final: #{hide_password(toks).inspect}"
 
       # URL.Build does not reconstruct the URL in all cases; notably it has
       # some ideas about what the host part might look like - which conflicts
@@ -172,7 +172,7 @@ module Yast::Transfer
       #
       # It does not matter much as full_url is only used for ftp/http(s).
       full_url = URL.Build(toks)
-      log.info("full url (host part might be missing): #{full_url}")
+      log.info("full url (host part might be missing): #{URL.HidePassword(full_url)}")
 
       tmp_dir = Convert.to_string(WFM.Read(path(".local.tmpdir"), []))
       mount_point = Ops.add(tmp_dir, "/tmp_mount")
@@ -592,6 +592,19 @@ module Yast::Transfer
       ::FileUtils.cp(source, destination)
     rescue SystemCallError => e
       log.warn "Could not copy #{source} to #{destination}: #{e.inspect}"
+    end
+
+    # Replace password with 'PASSWORD', if one was set.
+    #
+    # This is used to keep logs clean.
+    #
+    # @param toks [Hash{String => String}]
+    #
+    # @return [Hash{String => String}]
+    def hide_password(toks)
+      tmp = toks.dup
+      tmp["pass"] &&= "PASSWORD"
+      tmp
     end
   end
 end

--- a/src/lib/transfer/file_from_url.rb
+++ b/src/lib/transfer/file_from_url.rb
@@ -77,7 +77,10 @@ module Yast::Transfer
     # The URL allows autoyast-specific schemes:
     # https://www.suse.com/documentation/sles-12/singlehtml/book_autoyast/book_autoyast.html#Commandline.ay
     #
-    # @param scheme    [String] cifs, nfs, device, usb, http, https, ...
+    # @note Some arguments are duplicated in the urltok hash. Where they
+    #   differ, the explicitly passed arguments replace their counterparts in urltok.
+    #
+    # @param scheme    [String] ftp, tftp, http, https, cifs, nfs, device, cd, hd, usb, file, label, repo
     # @param host      [String]
     # @param urlpath   [String]
     # @param localfile [String] destination filename

--- a/src/lib/transfer/file_from_url.rb
+++ b/src/lib/transfer/file_from_url.rb
@@ -80,7 +80,7 @@ module Yast::Transfer
     # @note Some arguments are duplicated in the urltok hash. Where they
     #   differ, the explicitly passed arguments replace their counterparts in urltok.
     #
-    # @param scheme    [String] ftp, tftp, http, https, cifs, nfs, device, cd, hd, usb, file, label, repo
+    # @param scheme    [String] ftp, tftp, http, https, cifs, nfs, device, cd, dvd, hd, usb, file, label, repo
     # @param host      [String]
     # @param urlpath   [String]
     # @param localfile [String] destination filename
@@ -138,8 +138,8 @@ module Yast::Transfer
         log.info "toks absolute: #{toks.inspect}"
       end
 
-      # convert 'cd' and 'hd' Zypp schemes to 'device' schema
-      if ["cd", "hd"].include?(toks["scheme"])
+      # convert 'cd', "dvd', and 'hd' Zypp schemes to 'device' schema
+      if ["cd", "dvd", "hd"].include?(toks["scheme"])
         dev_name = toks["query"].match(/devices?=\/dev\/(.*)/)
         if !dev_name.nil?
           toks["scheme"] = "device"


### PR DESCRIPTION
## Task

- https://trello.com/c/CAytlL3W
- https://jira.suse.com/browse/SLE-22578
- https://jira.suse.com/browse/SLE-24584

Add URI schema that works relative to the installation medium. Also, unify the URI schemes so that the Zypp/Addon syntax also works with AutoYaST.

Note that `relurl` cannot be used as it already has the meaning of 'relative to the AutoYaST profile' in AutoYaST context.

So, a new `repo` scheme is introduced.

## See also

- https://github.com/openSUSE/linuxrc/pull/299
- https://github.com/yast/yast-yast2/pull/1276
- https://github.com/yast/yast-autoinstallation/pull/852