### PR TITLE
Fix hash vs keyword arguments in RSpec expectations (bsc#1204871)

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Nov 24 09:24:34 UTC 2022 - Martin Vidner <mvidner@suse.com>
+
+- Fix hash vs keyword arguments in RSpec expectations (bsc#1204871)
+- 4.5.10
+
+-------------------------------------------------------------------
 Tue Nov 15 13:43:41 UTC 2022 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Fixed the help in the installation summary to include the texts

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.5.9
+Version:        4.5.10
 Release:        0
 Summary:        YaST2 - Installation Parts
 License:        GPL-2.0-only

--- a/test/lib/clients/inst_download_release_notes_test.rb
+++ b/test/lib/clients/inst_download_release_notes_test.rb
@@ -58,10 +58,11 @@ describe Yast::InstDownloadReleaseNotesClient do
     end
 
     it "sets release notes content" do
-      expect(Yast::UI).to receive(:SetReleaseNotes).with(
+      relnotes_texts = {
         "SLES" => "SLES RN",
         "SDK"  => "SDK RN"
-      )
+      }
+      expect(Yast::UI).to receive(:SetReleaseNotes).with(relnotes_texts)
       client.main
     end
 

--- a/test/system_role_test.rb
+++ b/test/system_role_test.rb
@@ -145,8 +145,9 @@ describe Installation::SystemRole do
     end
 
     it "modifies the network proposal settings with defaults from the control file" do
+      defaults = { "ipv4_forward" => true, "ipv6_forward" => true }
       expect(settings).to receive(:modify_defaults)
-        .with("ipv4_forward" => true, "ipv6_forward" => true)
+        .with(defaults)
 
       role.adapt_network
     end
@@ -161,8 +162,9 @@ describe Installation::SystemRole do
     it "overlays the product features with the ones defined in the control file for this role" do
       role = described_class.find("role_one")
 
+      overlay = { "software" => { "desktop" => "knome" } }
       expect(Yast::ProductFeatures).to receive(:SetOverlay)
-        .with("software" => { "desktop" => "knome" })
+        .with(overlay)
 
       role.overlay_features
     end


### PR DESCRIPTION
- https://bugzilla.opensuse.org/show_bug.cgi?id=1204871 "- [Staging] rubygem-rspec-* 3.12 breaks various yast modules build"
- see https://github.com/yast/yast-yast2/pull/1279 for details

