### PR TITLE
Use default Depth for Xvnc

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Dec  5 10:13:28 UTC 2022 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Use default depth for Xvnc, no longer enforce depth 16
+  (bsc#1205585)
+- 4.5.11
+
+-------------------------------------------------------------------
 Thu Nov 24 09:24:34 UTC 2022 - Martin Vidner <mvidner@suse.com>
 
 - Fix hash vs keyword arguments in RSpec expectations (bsc#1204871)

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.5.10
+Version:        4.5.11
 Release:        0
 Summary:        YaST2 - Installation Parts
 License:        GPL-2.0-only

--- a/startup/common/vnc.sh
+++ b/startup/common/vnc.sh
@@ -83,12 +83,12 @@ startVNCServer () {
 	[ -z "$VNCSize" ] && VNCSize=1024x768
 
 	# For -noreset see BNC #351338
+        # No longer using -depth 16 (bsc#1205585)
 	/usr/bin/Xvnc :0 \
 		-noreset \
 		-rfbauth /root/.vnc/passwd.yast \
 		-desktop "Installation" \
 		-geometry "$VNCSize" \
-		-depth 16 \
                 -dpi 96 \
 		-rfbport 5901 \
 		-fp /usr/share/fonts/misc/,/usr/share/fonts/uni/,/usr/share/fonts/truetype/ \


### PR DESCRIPTION
## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1205585


## Problem

On installations using Xvnc, sometimes the font rendering is broken in the Qt UI to the point of making some fonts illegible.

![wizard-welcome](https://user-images.githubusercontent.com/11538225/205612589-322cd904-9f52-488c-b000-843a2d0e3412.png)

_See the wizard steps on the left side._

## Underlying Cause

@Vogtinator found out that there is a bug in the Qt libs:

https://bugreports.qt.io/browse/QTBUG-109169

> It's a bad conversion between QRgb and QRgba64 types in a gamma correct blending function. 


## Workaround

@Vogtinator also suggested to drop using the `-depth 16` option when starting `Xvnc` to avoid getting into that special case. That's what this PR does.