### PR TITLE
yupdate - allow patching the D-Installer

### DIFF
--- a/bin/yupdate
+++ b/bin/yupdate
@@ -482,7 +482,10 @@ module YUpdate
 
       src_dir = File.dirname(rakefile)
       Dir.chdir(src_dir) do
-        `rake install DESTDIR=#{target.shellescape} 2> /dev/null`
+        redir = ENV["VERBOSE"] == "1" ? "" : " > /dev/null 2>&1"
+        unless system("rake install DESTDIR=#{target.shellescape} #{redir}")
+          raise "rake install failed"
+        end
       end
     end
 

--- a/bin/yupdate
+++ b/bin/yupdate
@@ -109,10 +109,16 @@ module YUpdate
   # a simple /etc/install.inf parser/writer,
   # we need to disable the YaST self-update feature to avoid conflicts
   class InstallInf
+    PATH = "/etc/install.inf".freeze
+
     attr_reader :path
 
+    def self.exist?(path = PATH)
+      File.exist?(path)
+    end
+
     # read the file
-    def initialize(path = "/etc/install.inf")
+    def initialize(path = PATH)
       @path = path
       @values = File.read(path).lines.map(&:chomp)
     end
@@ -566,8 +572,8 @@ module YUpdate
     end
   end
 
-  # inst-sys test
-  class InstSys
+  # inst-sys or live medium test
+  class System
     # check if the script is running in the inst-sys,
     # the script might not work as expected in an installed system
     # and using OverlayFS is potentially dangerous
@@ -575,8 +581,11 @@ module YUpdate
       # the inst-sys contains the /.packages.initrd file with a list of packages
       return if File.exist?("/.packages.initrd")
 
+      # live medium uses overlay FS for the root
+      return if `mount`.match?(/^\w+ on \/ type overlay/)
+
       # exit immediately if running in an installed system
-      warn "ERROR: This script can only work in the installation system (inst-sys)!"
+      warn "ERROR: This script can only work in the installation system (inst-sys) or Live medium!"
       exit 1
     end
   end
@@ -590,10 +599,10 @@ module YUpdate
       when "version"
         VersionCommand.new
       when "overlay"
-        InstSys.check!
+        System.check!
         OverlayCommand.new(argv)
       when "patch"
-        InstSys.check!
+        System.check!
         PatchCommand.new(argv)
       when "servers"
         ServersCommand.new(argv)
@@ -700,10 +709,29 @@ module YUpdate
       g.install_required_gems
     end
 
+    def run_pre_script(download_dir)
+      script = File.join(download_dir, ".yupdate.pre")
+      run_script(script)
+    end
+
+    def run_post_script(download_dir)
+      script = File.join(download_dir, ".yupdate.post")
+      run_script(script)
+    end
+
+    def run_script(script)
+      return unless File.exist?(script)
+
+      puts "Running script #{File.basename(script)}..."
+      raise "Script #{File.basename(script)} failed" unless system(script)
+    end
+
     def install_tar(downloader)
       Dir.mktmpdir do |download_dir|
         downloader.extract_to(download_dir)
+        run_pre_script(download_dir)
         install_sources(download_dir)
+        run_post_script(download_dir)
       end
     end
 
@@ -712,6 +740,8 @@ module YUpdate
 
     # disable the self update in the install.inf file
     def disable_self_update
+      return unless InstallInf.exist?
+
       inf = InstallInf.new
       return if inf[SELF_UPDATE_KEY] == "0"
 

--- a/bin/yupdate
+++ b/bin/yupdate
@@ -34,8 +34,8 @@ module YUpdate
   # version of the script
   class Version
     MAJOR = 0
-    MINOR = 1
-    PATCH = 3
+    MINOR = 2
+    PATCH = 0
 
     STRING = "#{MAJOR}.#{MINOR}.#{PATCH}".freeze
   end

--- a/doc/yupdate.md
+++ b/doc/yupdate.md
@@ -223,6 +223,28 @@ state.
   AutoYaST second stage cannot be fixed by `yupdate`, you need to build
   a DUD, see below.
 
+## Hooks
+
+The source code might contain several callback scripts which are executed
+at specific points. The goal is to allow adjusting the target system before
+or after installing new files.
+
+- `.yupdate.pre` - This script is executed *before* installing the package (before
+  running `rake install`). It can prepare the system for installation, install
+  required packages.
+- `.yupdate.post` - This script is executed *after* installing the package (after
+  running `rake install`). It can activate the changes, restart services.
+
+When a hook script fails then yupdate aborts the update process immediately.
+
+## Environment Variables
+
+The yupdate script uses these environment variables:
+
+- `VERBOSE` - When set to `1` the output of the `rake install` command is
+  displayed in the terminal. By default it is hidden because the output is too
+  long and verbose. Use this option for debugging installation problems.
+
 ## Alternative
 
 1. For all repos, run `rake osc:build`

--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Jan  6 12:33:29 UTC 2023 - Ladislav Slezák <lslezak@suse.com>
+
+- yupdate - added suport for patching the D-Installer
+  (bsc#1206927)
+- 4.5.12
+
+-------------------------------------------------------------------
 Mon Dec  5 10:13:28 UTC 2022 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Use default depth for Xvnc, no longer enforce depth 16

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.5.11
+Version:        4.5.12
 Release:        0
 Summary:        YaST2 - Installation Parts
 License:        GPL-2.0-only

--- a/test/yupdate/inst_sys_test.rb
+++ b/test/yupdate/inst_sys_test.rb
@@ -3,8 +3,13 @@
 require_relative "../test_helper"
 require_yupdate
 
-describe YUpdate::InstSys do
+describe YUpdate::System do
   let(:file) { "/.packages.initrd" }
+
+  before do
+    allow(File).to receive(:exist?).with(file).and_return(false)
+    allow(described_class).to receive(:`).with("mount").and_return("")
+  end
 
   describe ".check!" do
     context "when running in an inst-sys" do
@@ -18,9 +23,20 @@ describe YUpdate::InstSys do
       end
     end
 
+    context "when running on a live medium" do
+      before do
+        expect(described_class).to receive(:`).with("mount")
+          .and_return("LiveOS_rootfs on / type overlay (rw,relatime)")
+      end
+
+      it "does not exit" do
+        expect(described_class).to_not receive(:exit)
+        described_class.check!
+      end
+    end
+
     context "when running in a normal system" do
       before do
-        expect(File).to receive(:exist?).with(file).and_return(false)
         allow(described_class).to receive(:exit).with(1)
       end
 


### PR DESCRIPTION
## Problem

The current `yupdate` script can be only used from inst-sys for patching the standard YaST modules. It would be nice to extend it so it could be used the same way with the D-Installer. This would make testing and development of new features easier.

## Solution

Adapt the script so it can work in a different environment (live medium).

- Check for the live medium environment (the root uses the `overlay` file system)
- Do not try to modify `/etc/install.inf` if it does not exist (it is not present on the live medium)
- Add pre and post hooks so some actions can be done before patching the system (installing some RPM packages) or after (restarting the DBus service). It runs the `.yupdate.pre` and `.yupdate.post` scripts when present in the source code.

## Testing

- Updated unit test
- Tested manually

