### PR TITLE
yupdate - added suport for patching containers (bsc#1207069)

### DIFF
--- a/bin/yupdate
+++ b/bin/yupdate
@@ -35,7 +35,7 @@ module YUpdate
   class Version
     MAJOR = 0
     MINOR = 2
-    PATCH = 0
+    PATCH = 1
 
     STRING = "#{MAJOR}.#{MINOR}.#{PATCH}".freeze
   end
@@ -575,9 +575,9 @@ module YUpdate
     end
   end
 
-  # inst-sys or live medium test
+  # inst-sys, live medium or container test
   class System
-    # check if the script is running in the inst-sys,
+    # check if the script is running in the inst-sys, live medium or in a container
     # the script might not work as expected in an installed system
     # and using OverlayFS is potentially dangerous
     def self.check!
@@ -587,10 +587,34 @@ module YUpdate
       # live medium uses overlay FS for the root
       return if `mount`.match?(/^\w+ on \/ type overlay/)
 
+      return if in_container?
+
       # exit immediately if running in an installed system
-      warn "ERROR: This script can only work in the installation system (inst-sys) or Live medium!"
+      warn "ERROR: This script can only work in the installation system (inst-sys), " \
+           "live medium or in a container!"
       exit 1
     end
+
+    # Check whether running in a container.
+    # @return [Boolean] `true` if running inside a container, `false` otherwise
+    def self.in_container?
+      # use the systemd-detect-virt tool for container detection
+      detected = `systemd-detect-virt --container`.chomp
+
+      # the variable contains the detected system, like "docker" or "podman"
+      # see "man systemd-detect-virt" for details
+      !detected.empty? && detected != "none"
+    # systemd-detect-virt tool not present
+    rescue Errno::ENOENT
+      # fallback to detection by special files, this is less reliable
+      # (the files might be removed in the future) and does not
+      # support all container virtualizations
+
+      # docker or podman environment
+      File.exist?("/.dockerenv") || File.exist?("/run/.containerenv")
+    end
+
+    private_class_method :in_container?
   end
 
   # parse the command line options

--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jan 12 07:42:55 UTC 2023 - Ladislav Slezák <lslezak@suse.com>
+
+- yupdate - added suport for patching containers (bsc#1207069)
+- 4.5.13
+
+-------------------------------------------------------------------
 Fri Jan  6 12:33:29 UTC 2023 - Ladislav Slezák <lslezak@suse.com>
 
 - yupdate - added suport for patching the D-Installer

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.5.12
+Version:        4.5.13
 Release:        0
 Summary:        YaST2 - Installation Parts
 License:        GPL-2.0-only

--- a/test/yupdate/system_test.rb
+++ b/test/yupdate/system_test.rb
@@ -9,6 +9,7 @@ describe YUpdate::System do
   before do
     allow(File).to receive(:exist?).with(file).and_return(false)
     allow(described_class).to receive(:`).with("mount").and_return("")
+    allow(described_class).to receive(:`).with("systemd-detect-virt --container").and_return("")
   end
 
   describe ".check!" do
@@ -48,7 +49,7 @@ describe YUpdate::System do
 
       it "prints an error on STDERR" do
         _stdout, stderr = capture_stdio { described_class.check! }
-        expect(stderr).to match(/ERROR: .*inst-sys/)
+        expect(stderr).to start_with("ERROR: This script can only work")
       end
     end
   end


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1207069
- The yupdate script refuses to work in a container, that should be allowed.

## Solution

- Detect a container presence with `systemd-detect-virt --container`, fallback to testing some container specific files.
- If a container is detected then allow patching the system.

## Testing

- Tested manually

```
yast-container PC:/ # yupdate patch yast/yast-packager master
Downloading https://github.com/yast/yast-packager/archive/master.tar.gz
Preparing files...
Copying to system...
Updated: /usr/share/YaST2/include/checkmedia/ui.rb
Updated: /usr/share/applications/YaST2/org.opensuse.yast.CheckMedia.desktop
Updated: /usr/share/applications/YaST2/org.opensuse.yast.SWSingle.desktop
Updated: /usr/share/applications/YaST2/org.opensuse.yast.SWSource.desktop
Updated: /usr/share/applications/org.opensuse.yast.Packager.desktop
Number of modified files: 5
```
