### PR TITLE
Connect to all discovered NVMe-over-Fabrics subsystems in case of UseNBFT (jsc#PED-967)

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -2,7 +2,7 @@
 Wed Jan 25 15:25:50 UTC 2023 - Knut Anderssen <kanderssen@suse.com>
 
 - Discover and connect to all NVMe-over-Fabrics subsystems in case
-  that linuxrc sets UseNBFT (jsc#PED-3138).
+  that linuxrc sets UseNBFT (jsc#PED-967).
 - 4.5.14
 
 -------------------------------------------------------------------

--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Jan 25 15:25:50 UTC 2023 - Knut Anderssen <kanderssen@suse.com>
+
+- Discover and connect to all NVMe-over-Fabrics subsystems in case
+  that linuxrc sets UseNBFT (jsc#PED-3138).
+- 4.5.14
+
+-------------------------------------------------------------------
 Thu Jan 12 07:42:55 UTC 2023 - Ladislav Slezák <lslezak@suse.com>
 
 - yupdate - added suport for patching containers (bsc#1207069)

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.5.13
+Version:        4.5.14
 Release:        0
 Summary:        YaST2 - Installation Parts
 License:        GPL-2.0-only

--- a/src/include/installation/inst_inc_all.rb
+++ b/src/include/installation/inst_inc_all.rb
@@ -235,6 +235,8 @@ module Yast
     end
 
     def SetDiskActivationModule
+      # Connect all the discovered NVMe-over-Fabrics subsystems (jse#PED-318)
+      connect_nbft if Linuxrc.InstallInf("UseNBFT") == "1"
       # update the workflow according to current situation
       # disable disks activation if not needed
       iscsi = Linuxrc.InstallInf("WithiSCSI") == "1"
@@ -247,6 +249,15 @@ module Yast
       end
 
       nil
+    end
+
+    # Convenience method for discovering and connecting all NVMe over Fabrics subsystems
+    def connect_nbft
+      require "yast2/execute"
+
+      Yast::Execute.locally!("nvme", "connect-all")
+    rescue Cheetah::ExecutionFailed
+      Builtins.y2error("Error connecting NBFT")
     end
   end
 end


### PR DESCRIPTION
## Problem

When **linuxrc** (see https://github.com/openSUSE/linuxrc/pull/310) detects that there is some NBFT configured interface it will sets the **UseNBFT** variable and we should YaST should call `nvme connect-all` in order to discover and connect to all discovered **NVMe-over-Fabrics subsystems**

- https://trello.com/c/eFJXEeep/3274-3-urgent-top-priority-connect-to-nbft-disks
- https://jira.suse.com/browse/PED-967
- https://jira.suse.com/browse/PED-3118

## Solution

It was decided to add the call where we evaluate if the disks activation client should be disabled or not, currently we will just capture **Cheetah** exceptions and log that there were were some problem connecting **NVMe-oF subsystems** but as the **UI** is not completely initialized at that point we will not report any issue to the user.

In case of needed the code could be adapted to show also a feedback message like

```ruby
      require "yast2/feedback"
      Yast2::Feedback.show("Connecting to all discovered NVMe-oF subsystems") do
         Yast::Execute.locally!("nvme", "connect-all")
      end
```
moving the **SetDiskActivation** module just before the **ProductControl** is run

https://github.com/yast/yast-installation/blob/dc00a7f9f25380cbc4bdc46040363c428c6bed77/src/lib/installation/clients/inst_worker_initial.rb#L79 

## Testing

- *Added a new unit test*
- *Tested manually*


## Screenshots

*If the fix affects the UI attach some screenshots here.*

