### PR TITLE
Connect only nbft

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Jan 25 19:56:12 UTC 2023 - Knut Anderssen <kanderssen@suse.com>
+
+- Connect only NBFT when linuxrc sets UseNBFT (jsc#PED-967)
+- 4.5.15
+
+-------------------------------------------------------------------
 Wed Jan 25 15:25:50 UTC 2023 - Knut Anderssen <kanderssen@suse.com>
 
 - Discover and connect to all NVMe-over-Fabrics subsystems in case

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.5.14
+Version:        4.5.15
 Release:        0
 Summary:        YaST2 - Installation Parts
 License:        GPL-2.0-only

--- a/src/include/installation/inst_inc_all.rb
+++ b/src/include/installation/inst_inc_all.rb
@@ -255,7 +255,7 @@ module Yast
     def connect_nbft
       require "yast2/execute"
 
-      Yast::Execute.locally!("nvme", "connect-all")
+      Yast::Execute.locally!("nvme", "connect-nbft")
     rescue Cheetah::ExecutionFailed
       Builtins.y2error("Error connecting NBFT")
     end


### PR DESCRIPTION
## Problem

It was requested to use `nvme connect-nbft` when **UseNBFT** was set by **linuxrc** but we call  `nvme connect-all`.

- https://trello.com/c/eFJXEeep/3274-3-urgent-top-priority-connect-to-nbft-disks
- https://jira.suse.com/browse/PED-3138
- https://build.suse.de/request/show/288814

## Solution 

Implement the call as requested (it depends on https://build.suse.de/request/show/288814)