### PR TITLE
[SLE15-SP5] Removed unnecessary executable flag (bsc#1209094)

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Mar 13 08:35:59 UTC 2023 - Ladislav Slezák <lslezak@suse.com>
+
+- Removed unnecessary executable flag from file security_proposal.rb
+  (bsc#1209094)
+- 4.5.16
+
+-------------------------------------------------------------------
 Wed Jan 25 19:56:12 UTC 2023 - Knut Anderssen <kanderssen@suse.com>
 
 - Connect only NBFT when linuxrc sets UseNBFT (jsc#PED-967)

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.5.15
+Version:        4.5.16
 Release:        0
 Summary:        YaST2 - Installation Parts
 License:        GPL-2.0-only

--- a/src/lib/installation/clients/security_proposal.rb
+++ b/src/lib/installation/clients/security_proposal.rb
@@ -1,7 +1,3 @@
-#!/usr/bin/env ruby
-#
-# encoding: utf-8
-
 # Copyright (c) [2017] SUSE LLC
 #
 # All Rights Reserved.


### PR DESCRIPTION
- File `security_proposal.rb` had executable flag set, it is not needed there
- Also removed the shebang (not needed) and the UTF-8 mark (Ruby default anyway)
- See more details in related https://github.com/yast/yast-storage-ng/pull/1322
