### PR TITLE
yupdate - improved Live ISO detection, added "--force" option

### DIFF
--- a/bin/yupdate
+++ b/bin/yupdate
@@ -584,14 +584,20 @@ module YUpdate
       # the inst-sys contains the /.packages.initrd file with a list of packages
       return if File.exist?("/.packages.initrd")
 
-      # live medium uses overlay FS for the root
-      return if `mount`.match?(/^\w+ on \/ type overlay/)
+      mount_out = `mount`
+      # live medium uses overlay FS or device mapper for the root
+      if mount_out.match?(/^\w+ on \/ type overlay/) ||
+          mount_out.match?(/^\/dev\/mapper\/live-rw on \/ /)
+
+        return
+      end
 
       return if in_container?
 
       # exit immediately if running in an installed system
       warn "ERROR: This script can only work in the installation system (inst-sys), " \
            "live medium or in a container!"
+      warn "If you are sure it is OK to use the script add the --force option."
       exit 1
     end
 
@@ -620,16 +626,23 @@ module YUpdate
   # parse the command line options
   class Options
     def self.parse(argv)
+      force = argv.include?("--force")
+      if force
+        argv.delete("--force")
+        # pass the force option to the executed scripts
+        ENV["YUPDATE_FORCE"] = "1"
+      end
+
       command = argv.shift
 
       case command
       when "version"
         VersionCommand.new
       when "overlay"
-        System.check!
+        System.check! unless force
         OverlayCommand.new(argv)
       when "patch"
-        System.check!
+        System.check! unless force
         PatchCommand.new(argv)
       when "servers"
         ServersCommand.new(argv)

--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Apr  3 12:04:23 UTC 2023 - Ladislav Slezák <lslezak@suse.com>
+
+- yupdate - improved Live ISO detection, added "--force" option
+  (related to bsc#1206927)
+- 4.6.2
+
+-------------------------------------------------------------------
 Mon Mar 13 08:49:20 UTC 2023 - Ladislav Slezák <lslezak@suse.com>
 
 - Removed unnecessary executable flag from file security_proposal.rb

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.6.1
+Version:        4.6.2
 Release:        0
 Summary:        YaST2 - Installation Parts
 License:        GPL-2.0-only


### PR DESCRIPTION
- The latest Agama Live ISO uses different Kiwi options and the Live ISO now uses disk mapper instead of the Overlay FS to make the root writable
- As the Live ISO implementation can change in the future again let's add the `--force` option which can skip the system detection 
- Tested manually