### PR TITLE
Use a larger Font for xterm during Installation via X Resources

### DIFF
--- a/startup/YaST2.call
+++ b/startup/YaST2.call
@@ -179,6 +179,50 @@ function set_qt_scale_factor () {
 }
 
 
+function calculate_xterm_font_size() {
+#------------------------------------------------------
+# Calculate an appropriate font size for xterm based on the DPI
+# ($1) and set XTERM_FONT_SIZE accordingly.
+# ---
+
+	local DPI=${1:-96}
+
+	if [ ${DPI:-0} -le 96 ]; then
+	    XTERM_FONT_SIZE=10
+	elif [ $DPI -le 192 ]; then
+	    XTERM_FONT_SIZE=12
+	else
+	    XTERM_FONT_SIZE=14
+	fi
+
+	export XTERM_FONT_SIZE
+	log "\tXTERM_FONT_SIZE: $XTERM_FONT_SIZE for $DPI dpi"
+}
+
+
+function add_x11_resources() {
+#------------------------------------------------------
+# Add some X resources for xterm to /root/.Xdefaults
+#
+# Notice that this file is only used if nothing has been
+# loaded into the X server with 'xrdb' yet.
+# ---
+
+	local RESOURCE_FILE=/root/.Xdefaults
+	XTERM_FONT_SIZE=${XTERM_FONT_SIZE:-12}
+	log "\tAdding X resources for xterm to $RESOURCE_FILE"
+
+	cat >>$RESOURCE_FILE <<EOF
+
+! Fonts for xterm during a YaST Qt UI installation
+! (You can start an xterm with Ctrl-Shift-Alt X)
+XTerm*faceName:	 DejaVu Sans Mono
+XTerm*faceSize:	 $XTERM_FONT_SIZE
+
+EOF
+}
+
+
 function prepare_for_x11 () {
 #------------------------------------------------------
 # prepare X11 installation
@@ -201,6 +245,8 @@ function prepare_for_x11 () {
 			local DPI=`calculate_x11_dpi`
 			# set_xft_dpi $DPI
                         set_qt_scale_factor $DPI
+                        calculate_xterm_font_size $DPI
+                        add_x11_resources
 		fi
 	fi
 
@@ -618,7 +664,9 @@ if [ -n "$FAKE_MON_WIDTH_MM" ]; then
         DPI=`calculate_x11_dpi`
         echo "DPI: $DPI"
         set_qt_scale_factor $DPI
-        env | grep "^QT_SCALE"
+        calculate_xterm_font_size $DPI
+        env | grep -E "^(QT_SCALE|XTERM)"
+        # add_x11_resources
         echo "Done."
         exit 1
 fi


### PR DESCRIPTION
## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1211267


## Problem

For debugging, you can start an _xterm_ during a YaST Qt installation with the `Ctrl`-`Shift`-`Alt` key combination. But since the X11 environment in the inst-sys is minimalistic, and _xterm_ is a very old (almost 40 years) X application, it falls back to built-in very small pixel fonts.

That makes that _xterm_ really hard to use even on normal-sized modern displays; on HiDPI displays, it's too tiny to be usable.


## Fix

This adds an old-fashioned `~/.Xdefaults` file to set the font size for _xterm_ via X resources:

```
! Fonts for xterm during a YaST Qt UI installation
! (You can start an xterm with Ctrl-Shift-Alt X)
XTerm*faceName:  DejaVu Sans Mono
XTerm*faceSize:  12
```

_Notice that the comment character in X resource files is '!', not '#' as in most file types._

Even though _xterm_ is one of the oldest X11 applications ever, it received support for modern scalable fonts; see `man xterm` for the resource names.
