### PR TITLE
ignore cpu_mitigations for bootloaders which do not support cpu mitig…

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,7 +1,7 @@
 -------------------------------------------------------------------
 Tue Sep  5 09:41:29 UTC 2023 - Josef Reidinger <jreidinger@suse.com>
 
-- Adapt code for changes in bootlaoder done for systemd-boot
+- Adapt code for changes in yast2-bootloader done for systemd-boot
   experimental support (jsc#PED-1906)
 - 5.0.1
 

--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Sep  5 09:41:29 UTC 2023 - Josef Reidinger <jreidinger@suse.com>
+
+- Adapt code for changes in bootlaoder done for systemd-boot
+  experimental support (jsc#PED-1906)
+- 5.0.1
+
+-------------------------------------------------------------------
 Wed Aug 30 20:16:10 UTC 2023 - Josef Reidinger <jreidinger@suse.cz>
 
 - 5.0.0 (#bsc1185510)

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -29,8 +29,8 @@ Source2:        YaST2-Firstboot.service
 BuildRequires:  update-desktop-files
 # Y2Packager::NewRepositorySetup
 BuildRequires:  yast2 >= 4.4.42
-# CIOIgnore
-BuildRequires:  yast2-bootloader
+# new name for CPUMitigation widget
+BuildRequires:  yast2-bootloader >= 5.0.1
 # storage-ng based version
 BuildRequires:  yast2-country >= 3.3.1
 BuildRequires:  yast2-devtools >= 3.1.10
@@ -75,8 +75,7 @@ Requires:       tar
 Requires:       (yast2-x11 >= 4.5.1 if libyui-qt)
 # Y2Packager::NewRepositorySetup
 Requires:       yast2 >= 4.4.42
-# CIOIgnore
-Requires:       yast2-bootloader
+Requires:       yast2-bootloader >= 5.0.1
 Requires:       yast2-country >= 3.3.1
 # Language::GetLanguageItems and other API
 # Language::Set (handles downloading the translation extensions)

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        5.0.0
+Version:        5.0.1
 Release:        0
 Summary:        YaST2 - Installation Parts
 License:        GPL-2.0-only

--- a/src/lib/installation/clients/security_proposal.rb
+++ b/src/lib/installation/clients/security_proposal.rb
@@ -140,7 +140,7 @@ module Installation
       def cpu_mitigations_proposal
         require "bootloader/bootloader_factory"
         bl = ::Bootloader::BootloaderFactory.current
-        return nil if bl.name == "none"
+        return nil unless bl.respond_to?(:cpu_mitigations)
 
         mitigations = bl.cpu_mitigations
 

--- a/src/lib/installation/dialogs/security.rb
+++ b/src/lib/installation/dialogs/security.rb
@@ -121,7 +121,7 @@ module Installation
       def cpu_frame
         frame(
           _("CPU"),
-          ::Bootloader::CpuMitigationsWidget.new
+          ::Bootloader::Grub2Widget::CpuMitigationsWidget.new
         )
       end
 


### PR DESCRIPTION
…ations e.g. none/systemd-boot


## Problem

systemd-boot bootloader currently does not support cpu mitigation. So no proposal should be shown for this 
setting like "none" bootloader is already doing it. So this is more a generic solution for it.

- https://github.com/yast/yast-bootloader/pull/686
- https://jira.suse.com/browse/PED-1906


## Solution

Checking if the corresponding bootloader has a cpu_mitigations call.


## Testing
- Tested manually


