### PR TITLE
Fixed yupdate script (bsc#1213197)

### DIFF
--- a/bin/yupdate
+++ b/bin/yupdate
@@ -751,13 +751,13 @@ module YUpdate
       g.install_required_gems
     end
 
-    def run_pre_script(download_dir, subdir)
-      script = File.join(download_dir, subdir, ".yupdate.pre")
+    def run_pre_script(download_dir)
+      script = File.join(download_dir, ".yupdate.pre")
       run_script(script)
     end
 
-    def run_post_script(download_dir, subdir)
-      script = File.join(download_dir, subdir, ".yupdate.post")
+    def run_post_script(download_dir)
+      script = File.join(download_dir, ".yupdate.post")
       run_script(script)
     end
 
@@ -774,9 +774,9 @@ module YUpdate
     def install_tar(downloader, subdir = "")
       Dir.mktmpdir do |download_dir|
         downloader.extract_to(download_dir)
-        run_pre_script(download_dir, subdir)
+        run_pre_script(File.join(download_dir, subdir))
         install_sources(download_dir)
-        run_post_script(download_dir, subdir)
+        run_post_script(File.join(download_dir, subdir))
       end
     end
 

--- a/bin/yupdate
+++ b/bin/yupdate
@@ -717,7 +717,9 @@ module YUpdate
       # add the default "yast" GitHub organization if missing
       repo = "yast/#{repo}" unless repo.include?("/")
       downloader = GithubDownloader.new(repo, branch)
-      install_tar(downloader)
+      # the GitHub tarballs have all content in a "<repo>-<branch>" subdirectory
+      dir = repo.split("/", 2).last + "-" + branch
+      install_tar(downloader, dir)
     end
 
     def install_from_tar(url)
@@ -749,13 +751,13 @@ module YUpdate
       g.install_required_gems
     end
 
-    def run_pre_script(download_dir)
-      script = File.join(download_dir, ".yupdate.pre")
+    def run_pre_script(download_dir, subdir)
+      script = File.join(download_dir, subdir, ".yupdate.pre")
       run_script(script)
     end
 
-    def run_post_script(download_dir)
-      script = File.join(download_dir, ".yupdate.post")
+    def run_post_script(download_dir, subdir)
+      script = File.join(download_dir, subdir, ".yupdate.post")
       run_script(script)
     end
 
@@ -766,12 +768,15 @@ module YUpdate
       raise "Script #{File.basename(script)} failed" unless system(script)
     end
 
-    def install_tar(downloader)
+    # extract the tarball into a temporary directory and install it
+    # @param downloader the downloader to use
+    # @param subdir subdirectory in the source tarball
+    def install_tar(downloader, subdir = "")
       Dir.mktmpdir do |download_dir|
         downloader.extract_to(download_dir)
-        run_pre_script(download_dir)
+        run_pre_script(download_dir, subdir)
         install_sources(download_dir)
-        run_post_script(download_dir)
+        run_post_script(download_dir, subdir)
       end
     end
 

--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Jul 11 07:20:29 UTC 2023 - Ladislav Slezák <lslezak@suse.com>
+
+- Fixed yupdate script to properly run pre/post scripts
+  when patching from GitHub (bsc#1213197)
+- 4.6.5
+
+-------------------------------------------------------------------
 Thu Jun 15 15:01:13 UTC 2023 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Don't always enable sshd and open the ssh port (bsc#1211764)

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.6.4
+Version:        4.6.5
 Release:        0
 Summary:        YaST2 - Installation Parts
 License:        GPL-2.0-only


### PR DESCRIPTION
## Problem

- Patching the Agama installer does not work properly
- It fails because the pre/post scripts are not executed

## Solution

- It turned out that the GitHub tarballs have all content in a `<repo>-<branch>` subdirectory, e.g. `agama-master`
- When downloading from GitHub add this extra path so the files are correctly found

## Testing

- Tested manually
