### PR TITLE
Status toggling in the "Previously Used Repositories" dialog didn't work well

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Fri Aug  4 07:09:13 UTC 2023 - Michal Filka <mfilka@suse.com>
+
+- bsc#1213959
+  - Change status label properly when toggling status in the
+    "Previousy used repositories" dialog.
+- 4.6.6 
+
+-------------------------------------------------------------------
 Tue Jul 11 07:20:29 UTC 2023 - Ladislav Slezák <lslezak@suse.com>
 
 - Fixed yupdate script to properly run pre/post scripts

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.6.5
+Version:        4.6.6
 Release:        0
 Summary:        YaST2 - Installation Parts
 License:        GPL-2.0-only

--- a/src/lib/installation/clients/inst_upgrade_urls.rb
+++ b/src/lib/installation/clients/inst_upgrade_urls.rb
@@ -150,10 +150,10 @@ module Yast
       when :removed
         # TRANSLATORS: The action to perform with a repository
         _("Remove")
-      when :disable
+      when :disabled
         # TRANSLATORS: The action to perform with a repository
         _("Disable")
-      when :enable
+      when :enabled
         # TRANSLATORS: The action to perform with a repository
         _("Enable")
       else


### PR DESCRIPTION
## Problem

From the bug description:
What happened prior to Leap 15.3 was the Toggle Status button cycled through three options: Delete, Keep, and Disable. For Leap 15.4 and 15.5, The displayed options are only Delete and Keep. However, there are still three states, as repeatedly pressing Toggle Status will show you. First press of Toggle Status changes the display to Keep; second press the display stays Keep; third press the display returns to Delete.

- [bsc1213959](https://bugzilla.suse.com/show_bug.cgi?id=1213959)
- Most probably introduced in this commit 661f8f5d6e450aff5727f4b4c3b5cac9dd874624

## Solution

Fixed symbols used for referencing to particular labels

Opensuse 15.4 and 15.5 affected. However impact is small so I propose it for tumbleweed only

## Testing

- *Tested manually*


## Screenshots

*If the fix affects the UI attach some screenshots here.*

