### PR TITLE
Require awk for use in Startup Scripts

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Aug 15 08:42:50 UTC 2023 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Require awk for use in startup scripts (bsc#1214277)
+- 4.6.7
+
+-------------------------------------------------------------------
 Fri Aug  4 07:09:13 UTC 2023 - Michal Filka <mfilka@suse.com>
 
 - bsc#1213959

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.6.6
+Version:        4.6.7
 Release:        0
 Summary:        YaST2 - Installation Parts
 License:        GPL-2.0-only
@@ -58,6 +58,8 @@ Requires:       coreutils
 Requires:       gzip
 # use in startup scripts
 Requires:       initviocons
+# bsc#1214277; require awk, not gawk, to allow for lighterweight alternatives like busybox
+Requires:       awk
 # Needed call /sbin/ip in vnc.sh/network.sh
 Requires:       iproute2
 # for the first/second stage of installation


### PR DESCRIPTION
## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1214277


## Trello

https://trello.com/c/bgfX60e4/


## Problem

If `awk` is not installed, there are error messages on the console during a firstboot workflow.


## Fix

Require `awk` in the spec file.

Explicitly using `awk` and not `gawk` (the GNU version of `awk`) so lighterweight alternatives like _busybox_ can be used if they provide the `awk` symbol (which _busybox_ currently does not).


## What about other Common Linux Tools?

Many are part of the _coreutils_ package which we already require. Others are so common that a Linux system has little chance of working when they are missing, such as `grep` or `sed`: A lot of other packages depend on them.

See also the discussion in the bug.
