### PR TITLE
[SLE15-SP5] Refresh repositories with changed URL and reload them again

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Oct 27 14:13:14 UTC 2023 - Ladislav Slezák <lslezak@suse.com>
+
+- Refresh repositories with changed URL and reload them again
+  to activate the changes (related to bsc#1215884)
+- 4.5.18
+
 -------------------------------------------------------------------
 Thu Jun 15 15:01:13 UTC 2023 - Stefan Hundhammer <shundhammer@suse.com>
 

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.5.17
+Version:        4.5.18
 Release:        0
 Summary:        YaST2 - Installation Parts
 License:        GPL-2.0-only

--- a/src/lib/installation/clients/inst_upgrade_urls.rb
+++ b/src/lib/installation/clients/inst_upgrade_urls.rb
@@ -19,6 +19,7 @@
 
 require "yast"
 require "installation/upgrade_repo_manager"
+require "y2packager/medium_type"
 require "y2packager/repository"
 
 Yast.import "GetInstArgs"
@@ -296,6 +297,9 @@ module Yast
     def save_pkg_mgr
       # do not save the changes in the test mode
       Pkg.SourceSaveAll unless test?
+
+      # reload repositories only when using the openSUSE Leap media
+      Pkg.SourceLoad if Y2Packager::MediumType.standard?
 
       # clear the old repositories
       Y2Packager::OriginalRepositorySetup.instance.repositories.clear

--- a/src/lib/installation/upgrade_repo_manager.rb
+++ b/src/lib/installation/upgrade_repo_manager.rb
@@ -125,6 +125,12 @@ module Installation
       update_urls
       process_repos
       remove_services
+
+      # reload the package manager to activate the changes
+      Yast::Pkg.SourceSaveAll
+      Yast::Pkg.SourceFinishAll
+      Yast::Pkg.SourceRestore
+      Yast::Pkg.SourceLoad
     end
 
   private
@@ -167,6 +173,9 @@ module Installation
     def update_urls
       new_urls.each do |repo, url|
         repo.url = url
+
+        # if the repository will be enabled refresh the content
+        Yast::Pkg.SourceForceRefreshNow(repo.repo_id) if status_map[repo] == :enabled
       end
     end
 

--- a/test/lib/clients/inst_upgrade_urls_test.rb
+++ b/test/lib/clients/inst_upgrade_urls_test.rb
@@ -36,6 +36,8 @@ describe Yast::InstUpgradeUrlsClient do
     allow(Yast::UI).to receive(:QueryWidget)
     allow(Yast::UI).to receive(:ChangeWidget)
     allow(Yast::Pkg).to receive(:SourceSaveAll)
+    allow(Y2Packager::MediumType).to receive(:standard?).and_return(true)
+    allow(Yast::Pkg).to receive(:SourceLoad)
   end
 
   describe "#main" do

--- a/test/lib/upgrade_repo_manager_test.rb
+++ b/test/lib/upgrade_repo_manager_test.rb
@@ -97,6 +97,10 @@ describe Installation::UpgradeRepoManager do
       allow(repo1).to receive(:disable!)
       allow(repo1).to receive(:delete!)
       allow(Yast::Pkg).to receive(:ServiceDelete)
+      allow(Yast::Pkg).to receive(:SourceSaveAll)
+      allow(Yast::Pkg).to receive(:SourceFinishAll)
+      allow(Yast::Pkg).to receive(:SourceRestore)
+      allow(Yast::Pkg).to receive(:SourceLoad)
     end
 
     it "removes the selected repositories" do


### PR DESCRIPTION
- Related to https://github.com/yast/yast-update/pull/191
- This fixes using the old repositories in openSUSE
- In SLE it works fine but the explicit refresh is better. Libzypp/pkg-bindings run autorefresh automatically using a timestamp, but on some systems without RTC (some Arm boards) it might be better to not rely on the correct current time and force the refresh