### PR TITLE
[master] Refresh repositories with changed URL and reload them again

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Oct 31 12:40:00 UTC 2023 - Ladislav Slezák <lslezak@suse.com>
+
+- Refresh repositories with changed URL and reload them again
+  to activate the changes (related to bsc#1215884)
+- 5.0.2
+
+-------------------------------------------------------------------
 Tue Sep  5 09:41:29 UTC 2023 - Josef Reidinger <jreidinger@suse.com>
 
 - Adapt code for changes in yast2-bootloader done for systemd-boot

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -27,8 +27,8 @@ Source1:        YaST2-Second-Stage.service
 Source2:        YaST2-Firstboot.service
 
 BuildRequires:  update-desktop-files
-# Y2Packager::NewRepositorySetup
-BuildRequires:  yast2 >= 4.4.42
+# Y2Packager::Repository.refresh
+BuildRequires:  yast2 >= 5.0.3
 # new name for CPUMitigation widget
 BuildRequires:  yast2-bootloader >= 5.0.1
 # storage-ng based version
@@ -73,8 +73,8 @@ Requires:       pciutils
 Requires:       tar
 # /usr/lib/YaST2/bin/xftdpi, install only when the GUI is installed
 Requires:       (yast2-x11 >= 4.5.1 if libyui-qt)
-# Y2Packager::NewRepositorySetup
-Requires:       yast2 >= 4.4.42
+# Y2Packager::Repository.refresh
+Requires:       yast2 >= 5.0.3
 Requires:       yast2-bootloader >= 5.0.1
 Requires:       yast2-country >= 3.3.1
 # Language::GetLanguageItems and other API

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        5.0.1
+Version:        5.0.2
 Release:        0
 Summary:        YaST2 - Installation Parts
 License:        GPL-2.0-only

--- a/src/lib/installation/clients/inst_upgrade_urls.rb
+++ b/src/lib/installation/clients/inst_upgrade_urls.rb
@@ -19,6 +19,7 @@
 
 require "yast"
 require "installation/upgrade_repo_manager"
+require "y2packager/medium_type"
 require "y2packager/repository"
 
 Yast.import "GetInstArgs"
@@ -296,6 +297,9 @@ module Yast
     def save_pkg_mgr
       # do not save the changes in the test mode
       Pkg.SourceSaveAll unless test?
+
+      # reload repositories only when using the openSUSE Leap media
+      Pkg.SourceLoad if Y2Packager::MediumType.standard?
 
       # clear the old repositories
       Y2Packager::OriginalRepositorySetup.instance.repositories.clear

--- a/src/lib/installation/upgrade_repo_manager.rb
+++ b/src/lib/installation/upgrade_repo_manager.rb
@@ -125,6 +125,12 @@ module Installation
       update_urls
       process_repos
       remove_services
+
+      # reload the package manager to activate the changes
+      Yast::Pkg.SourceSaveAll
+      Yast::Pkg.SourceFinishAll
+      Yast::Pkg.SourceRestore
+      Yast::Pkg.SourceLoad
     end
 
   private
@@ -167,6 +173,9 @@ module Installation
     def update_urls
       new_urls.each do |repo, url|
         repo.url = url
+
+        # if the repository will be enabled refresh the content
+        Yast::Pkg.SourceForceRefreshNow(repo.repo_id) if status_map[repo] == :enabled
       end
     end
 

--- a/src/lib/installation/upgrade_repo_manager.rb
+++ b/src/lib/installation/upgrade_repo_manager.rb
@@ -175,7 +175,7 @@ module Installation
         repo.url = url
 
         # if the repository will be enabled refresh the content
-        Yast::Pkg.SourceForceRefreshNow(repo.repo_id) if status_map[repo] == :enabled
+        repo.refresh(force: true) if status_map[repo] == :enabled
       end
     end
 

--- a/test/lib/clients/inst_upgrade_urls_test.rb
+++ b/test/lib/clients/inst_upgrade_urls_test.rb
@@ -36,6 +36,8 @@ describe Yast::InstUpgradeUrlsClient do
     allow(Yast::UI).to receive(:QueryWidget)
     allow(Yast::UI).to receive(:ChangeWidget)
     allow(Yast::Pkg).to receive(:SourceSaveAll)
+    allow(Y2Packager::MediumType).to receive(:standard?).and_return(true)
+    allow(Yast::Pkg).to receive(:SourceLoad)
   end
 
   describe "#main" do

--- a/test/lib/upgrade_repo_manager_test.rb
+++ b/test/lib/upgrade_repo_manager_test.rb
@@ -97,6 +97,10 @@ describe Installation::UpgradeRepoManager do
       allow(repo1).to receive(:disable!)
       allow(repo1).to receive(:delete!)
       allow(Yast::Pkg).to receive(:ServiceDelete)
+      allow(Yast::Pkg).to receive(:SourceSaveAll)
+      allow(Yast::Pkg).to receive(:SourceFinishAll)
+      allow(Yast::Pkg).to receive(:SourceRestore)
+      allow(Yast::Pkg).to receive(:SourceLoad)
     end
 
     it "removes the selected repositories" do


### PR DESCRIPTION

- Just merging PR #1098  to master
- There is a small improvement, it uses the new `Repository.refresh` method
- See https://github.com/yast/yast-yast2/pull/1296