### PR TITLE
bsc#1217637: retrieve an AutoYaST profile on a NFS+IPv6 setup (SLE-15-SP6)

### DIFF
--- a/doc/SELF_UPDATE.md
+++ b/doc/SELF_UPDATE.md
@@ -66,7 +66,7 @@ and select the language from the list. Or use the `language` boot option, e.g.
 `language=de_DE`.
 
 If you want to use a different keyboard layout for the console then use the
-[`keytable`](https://en.opensuse.org/SDB:Linuxrc#p_keytable) boot option.
+[keytable](https://en.opensuse.org/SDB:Linuxrc#p_keytable) boot option.
 
 ## Network Setup
 

--- a/doc/installation_overview.md
+++ b/doc/installation_overview.md
@@ -16,7 +16,7 @@ to learn more about that. This document is mainly about `installation` and
 
 Although _YaST_ sits at the central point of the installation process, it is
 not the only software involved.
-[_Linuxrc_](https://en.opensuse.org/SDB:Linuxrc), which will be started just
+[Linuxrc](https://en.opensuse.org/SDB:Linuxrc), which will be started just
 before _YaST_, is another key player.
 
 _Linuxrc_ sets up the hardware and initializes the installation process. It can
@@ -108,7 +108,7 @@ at `/usr/lib/YaST2/startup/First-Stage`.
 For _YaST_, the installation is now in the `initial`
 [stage](https://github.com/yast/yast-yast2/blob/master/library/general/src/modules/Stage.rb).
 At this point, the `installation` client relies on
-[`inst_worker_initial`](src/clients/inst_worker_initial.rb). You could take a
+[inst_worker_initial](src/clients/inst_worker_initial.rb). You could take a
 look at the documentation about [installation
 clients](doc/installation_clients.md) to learn more.
 
@@ -166,7 +166,7 @@ The scripts which perform these steps live in
 #### inst_worker_continue
 
 The client which drives the second stage is
-[`inst_worker_continue`](src/clients/inst_worker_continue.rb). Of course, it
+[inst_worker_continue](src/clients/inst_worker_continue.rb). Of course, it
 relies on `ProductControl` as `inst_worker_initial` does.
 
 ### YaST2.call

--- a/doc/memory-profile-valgrind-massif.md
+++ b/doc/memory-profile-valgrind-massif.md
@@ -36,7 +36,7 @@ But to see names inside libraries Massif needs debuginfo files.
 
 tl;dr: Boot with `extend=gdb MASSIF=1`.
 
-1. Install Massif. It is part of the [**gdb** extension][gdb-ext], so use
+1. Install Massif. It is part of the [gdb extension][gdb-ext], so use
    `extend=gdb` at the boot prompt, or run `extend gdb` in an inst-sys shell.
 
 2. Install Debuginfo. For Tumbleweed an automatic downloader is in place

--- a/doc/url.md
+++ b/doc/url.md
@@ -1,6 +1,6 @@
 # URL handling in the installer
 
-*For a general description of URL formats see [RFC 3986](https://www.rfc-editor.org/rfc/rfc3986#section-3).*
+For a general description of URL formats see [RFC 3986](https://www.rfc-editor.org/rfc/rfc3986#section-3).
 
 ## Absolute URLs
 
@@ -9,11 +9,11 @@ all can be traced to one of three backends:
 
 1. [Linuxrc](https://en.opensuse.org/SDB:Linuxrc#Parameter_Reference)
 2. [Zypp](https://doc.opensuse.org/projects/libzypp/HEAD/classzypp_1_1media_1_1MediaManager.html#MediaAccessUrl)
-3. [YaST/AutoYaST](https://doc.opensuse.org/projects/autoyast/#Commandline-ay) itself in [`Yast::Transfer::FileFromUrl.get_file_from_url`](https://github.com/yast/yast-installation/blob/b950b062729d98d11d98609cba829bbc39355143/src/lib/transfer/file_from_url.rb#L76-L92)
+3. [YaST/AutoYaST](https://doc.opensuse.org/projects/autoyast/#Commandline-ay) itself in [Yast::Transfer::FileFromUrl.get_file_from_url](https://github.com/yast/yast-installation/blob/b950b062729d98d11d98609cba829bbc39355143/src/lib/transfer/file_from_url.rb#L76-L92)
 
 > There was additionally a 4th one hidden in AutoYaST:
 > 
-> 4. [`Yast::ProfileLocationClass.Process`](https://github.com/yast/yast-autoinstallation/blob/SLE-15-SP4/src/modules/ProfileLocation.rb#L101-L116)
+> 4. [Yast::ProfileLocationClass.Process](https://github.com/yast/yast-autoinstallation/blob/SLE-15-SP4/src/modules/ProfileLocation.rb#L101-L116)
 >   took care of the `label` scheme in AutoYaST context. It's been added to `Yast::Transfer::FileFromUrl` now.
 
 ## Relative URLs
@@ -141,7 +141,7 @@ end
 There are often hidden assumptions in these regexps (e.g. that `relurl` starts with at least two slashes)
 that might break things at some point.
 
-But there is a perfectly fine [`URI`](https://docs.ruby-lang.org/en/master/URI.html) class
+But there is a perfectly fine [URI](https://docs.ruby-lang.org/en/master/URI.html) class
 in ruby that can do this better. For example:
 
 ```ruby
@@ -151,7 +151,7 @@ end
 ```
 
 And there is also the
-[`Yast::URLClass`](https://github.com/yast/yast-yast2/blob/master/library/types/src/modules/URL.rb)
+[Yast::URLClass](https://github.com/yast/yast-yast2/blob/master/library/types/src/modules/URL.rb)
 class for handling URLs. On the negative side this is old YCP code but on the
 positive side it deals with idiosyncrasies like varying number of slashes.
 
@@ -182,7 +182,7 @@ def resolve_location
 end
 ```
 
-There is a [`Yast2::RelURL`](https://github.com/yast/yast-yast2/blob/master/library/general/src/lib/yast2/rel_url.rb) class that can do exactly that.
+There is a [Yast2::RelURL](https://github.com/yast/yast-yast2/blob/master/library/general/src/lib/yast2/rel_url.rb) class that can do exactly that.
 
 ```ruby
 Yast2::RelURL.new("http://example.com", "relurl://foo/bar").absolute_url.to_s

--- a/doc/yupdate.md
+++ b/doc/yupdate.md
@@ -148,9 +148,9 @@ the start.
 By default this will use port 8000, if the server uses another port just add
 `:` followed by the port number.
 
-*Note: Make sure the server port is open in the firewall configuration,
+Note: Make sure the server port is open in the firewall configuration,
 see the [documentation](https://github.com/yast/yast-rake/#server) for
-more details.*
+more details.
 
 #### Patching Multiple Packages
 

--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Nov 29 16:27:50 UTC 2023 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Enclose IPv6 addresses within square brackets when calling
+  the mount command (bsc#1217637).
+- 5.0.3
+
+-------------------------------------------------------------------
 Tue Oct 31 12:40:00 UTC 2023 - Ladislav Slezák <lslezak@suse.com>
 
 - Refresh repositories with changed URL and reload them again

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        5.0.2
+Version:        5.0.3
 Release:        0
 Summary:        YaST2 - Installation Parts
 License:        GPL-2.0-only

--- a/src/lib/transfer/file_from_url.rb
+++ b/src/lib/transfer/file_from_url.rb
@@ -338,17 +338,18 @@ module Yast::Transfer
           ok = false
         end
       elsif _Scheme == "nfs" # NFS
+        nfs_host = find_nfs_host(_Host)
         if !Convert.to_boolean(
           SCR.Execute(
             path(".target.mount"),
-            [Ops.add(Ops.add(_Host, ":"), dirname(_Path)), mount_point],
+            [Ops.add(Ops.add(nfs_host, ":"), dirname(_Path)), mount_point],
             "-o noatime,nolock"
           )
         ) &&
             !Convert.to_boolean(
               SCR.Execute(
                 path(".target.mount"),
-                [Ops.add(Ops.add(_Host, ":"), dirname(_Path)), mount_point],
+                [Ops.add(Ops.add(nfs_host, ":"), dirname(_Path)), mount_point],
                 "-o noatime -t nfs4"
               )
             )
@@ -605,6 +606,18 @@ module Yast::Transfer
       tmp = toks.dup
       tmp["pass"] &&= "PASSWORD"
       tmp
+    end
+
+    # Determines the host to use when trying to mount an NFS volume.
+    #
+    # IPv6 addresses should be enclosed between square brackets.
+    #
+    # @param host [String] Hostname or IP address.
+    def find_nfs_host(host)
+      ip = IPAddr.new(host)
+      ip.ipv6? ? "[#{host}]" : host
+    rescue IPAddr::InvalidAddressError
+      host
     end
   end
 end


### PR DESCRIPTION
* Merge fix for [bsc#1217637](https://bugzilla.suse.com/show_bug.cgi?id=1217637) into `master` (see #1101).
* Adapt the documentation format according to https://github.com/lsegal/yard/issues/1422.