### PR TITLE
In zVM || KVM write the cio_kernel_parameter only if given

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Jan 26 12:26:06 UTC 2024 - Knut Anderssen <kanderssen@suse.com>
+
+- In zVM or KVM installations the cio_ignore kernel argument will 
+  be written only if given (bsc#1210525).
+- 5.0.5
+
+-------------------------------------------------------------------
 Thu Jan 25 10:09:51 UTC 2024 - Knut Anderssen <kanderssen@suse.com>
 
 - Keep cio_ignore kernel argument when present in the parmfile or

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -27,8 +27,8 @@ Source1:        YaST2-Second-Stage.service
 Source2:        YaST2-Firstboot.service
 
 BuildRequires:  update-desktop-files
-# Kernel: Read kernel arguments from cmdline if install.inf does not exist (bsc#1216408).
-BuildRequires:  yast2 >= 5.0.4
+# Kernel: Use is_zvm from Yast::Arch
+BuildRequires:  yast2 >= 5.0.5
 # Whitelist cio_ignore s390 parameter
 BuildRequires:  yast2-bootloader >= 5.0.4
 # storage-ng based version

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        5.0.4
+Version:        5.0.5
 Release:        0
 Summary:        YaST2 - Installation Parts
 License:        GPL-2.0-only

--- a/src/lib/installation/cio_ignore.rb
+++ b/src/lib/installation/cio_ignore.rb
@@ -24,16 +24,6 @@ module Installation
 
   private
 
-    def kvm?
-      File.exist?("/proc/sysinfo") &&
-        File.readlines("/proc/sysinfo").grep(/Control Program: KVM\/Linux/).any?
-    end
-
-    def zvm?
-      File.exist?("/proc/sysinfo") &&
-        File.readlines("/proc/sysinfo").grep(/Control Program: z\/VM/).any?
-    end
-
     # Get current I/O device autoconf setting (rd.zdev kernel option)
     #
     # @return [Boolean]
@@ -53,11 +43,12 @@ module Installation
       if Yast::Mode.autoinst
         Yast::AutoinstConfig.cio_ignore
       else
+        Yast.import "Arch"
         # In case of given as a kernel parameter we should respect it,
         # if not it will depend on the installation environment (bsc#1210525)
         # cio_ignore does not make sense for KVM or z/VM (fate#317861)
         # but for other cases return true as requested FATE#315586
-        cio_ignore_given? || !(kvm? || zvm?)
+        cio_ignore_given? || !(Yast::Arch.is_zkvm || Yast::Arch.is_zvm)
       end
     end
 

--- a/src/lib/installation/cio_ignore.rb
+++ b/src/lib/installation/cio_ignore.rb
@@ -24,6 +24,16 @@ module Installation
 
   private
 
+    def kvm?
+      File.exist?("/proc/sysinfo") &&
+        File.readlines("/proc/sysinfo").grep(/Control Program: KVM\/Linux/).any?
+    end
+
+    def zvm?
+      File.exist?("/proc/sysinfo") &&
+        File.readlines("/proc/sysinfo").grep(/Control Program: z\/VM/).any?
+    end
+
     # Get current I/O device autoconf setting (rd.zdev kernel option)
     #
     # @return [Boolean]
@@ -36,11 +46,26 @@ module Installation
       rd_zdev != "no-auto"
     end
 
-    # Get current device blacklist setting (cio_ignore kernel option)
+    # Get current device blacklist setting (cio_ignore kernel option).
     #
     # @return [Boolean]
     def cio_setting
-      Yast::Mode.autoinst ? Yast::AutoinstConfig.cio_ignore : true
+      if Yast::Mode.autoinst
+        Yast::AutoinstConfig.cio_ignore
+      else
+        # In case of given as a kernel parameter we should respect it,
+        # if not it will depend on the installation environment (bsc#1210525)
+        # cio_ignore does not make sense for KVM or z/VM (fate#317861)
+        # but for other cases return true as requested FATE#315586
+        cio_ignore_given? || !(kvm? || zvm?)
+      end
+    end
+
+    # Whether the cio_ignore kernel parameter was given or not
+    #
+    # @return [Boolean]
+    def cio_ignore_given?
+      Yast::Bootloader.kernel_param(:common, "cio_ignore") != :missing
     end
   end
 

--- a/test/cio_ignore_test.rb
+++ b/test/cio_ignore_test.rb
@@ -9,6 +9,7 @@ Yast.import "Bootloader"
 describe ::Installation::CIOIgnore do
   before do
     allow(Yast::Bootloader).to receive(:kernel_param).with(:common, "rd.zdev")
+    allow(Yast::Bootloader).to receive(:kernel_param).with(:common, "cio_ignore")
   end
 
   describe "cio_ignore enable/disable" do
@@ -43,6 +44,7 @@ describe ::Installation::CIOIgnoreProposal do
 
   before(:each) do
     allow(Yast::Bootloader).to receive(:kernel_param).with(:common, "rd.zdev")
+    allow(Yast::Bootloader).to receive(:kernel_param).with(:common, "cio_ignore")
     ::Installation::CIOIgnore.instance.reset
   end
 

--- a/test/cio_ignore_test.rb
+++ b/test/cio_ignore_test.rb
@@ -13,10 +13,10 @@ describe ::Installation::CIOIgnore do
   let(:auto) { false }
 
   before do
+    arch_mock = double("Yast::Arch", s390: false, is_zkvm: kvm, is_zvm: zvm)
+    stub_const("Yast::Arch", arch_mock)
     allow(Yast::Bootloader).to receive(:kernel_param).with(:common, "rd.zdev")
     allow(Yast::Bootloader).to receive(:kernel_param).with(:common, "cio_ignore").and_return(param)
-    allow_any_instance_of(described_class).to receive(:kvm?).and_return(kvm)
-    allow_any_instance_of(described_class).to receive(:zvm?).and_return(zvm)
     allow(Yast::Mode).to receive(:autoinst).and_return(auto)
   end
 


### PR DESCRIPTION
Change #1104 implementation writing the **cio_ignore kernel parameter** only if given according to the bug request. It depends on https://github.com/yast/yast-yast2/pull/1300