### PR TITLE
Restore the selected products (bsc#1218391)

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Feb  6 15:14:27 UTC 2024 - Ladislav Slezák <lslezak@suse.com>
+
+- Restore the selected products after reloading the package
+  manager, properly install all products for new modules and
+  extensions when upgrading from SLE12 (bsc#1218391)
+- 4.6.10
+
+-------------------------------------------------------------------
 Wed Nov 29 16:27:50 UTC 2023 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Enclose IPv6 addresses within square brackets when calling

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.6.9
+Version:        4.6.10
 Release:        0
 Summary:        YaST2 - Installation Parts
 License:        GPL-2.0-only

--- a/src/lib/installation/upgrade_repo_manager.rb
+++ b/src/lib/installation/upgrade_repo_manager.rb
@@ -126,11 +126,17 @@ module Installation
       process_repos
       remove_services
 
-      # reload the package manager to activate the changes
+      # reload the package manager to activate the changes,
+      # remember the selected products/packages (ignore the dependencies selected by solver)
+      selected = Y2Packager::Resolvable.find(status: :selected, transact_by: :appl_high)
+
       Yast::Pkg.SourceSaveAll
       Yast::Pkg.SourceFinishAll
       Yast::Pkg.SourceRestore
       Yast::Pkg.SourceLoad
+
+      # restore the selection
+      selected.each { |s| Yast::Pkg.ResolvableInstall(s.name, s.kind) }
     end
 
   private

--- a/test/lib/upgrade_repo_manager_test.rb
+++ b/test/lib/upgrade_repo_manager_test.rb
@@ -101,6 +101,7 @@ describe Installation::UpgradeRepoManager do
       allow(Yast::Pkg).to receive(:SourceFinishAll)
       allow(Yast::Pkg).to receive(:SourceRestore)
       allow(Yast::Pkg).to receive(:SourceLoad)
+      allow(Y2Packager::Resolvable).to receive(:find).and_return([])
     end
 
     it "removes the selected repositories" do
@@ -131,6 +132,15 @@ describe Installation::UpgradeRepoManager do
 
     it "removes the old services" do
       expect(Yast::Pkg).to receive(:ServiceDelete).with(service1.alias)
+      subject.activate_changes
+    end
+
+    it "restores the selected products" do
+      product = double(name: "SLES", kind: :product)
+      expect(Y2Packager::Resolvable).to receive(:find)
+        .with(status: :selected, transact_by: :appl_high).and_return([product])
+      expect(Yast::Pkg).to receive(:ResolvableInstall)
+        .with(product.name, product.kind).and_return(true)
       subject.activate_changes
     end
   end


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1218391
- The upgrade summary from SLE12 does not list several modules and extensions
- From the y2log it turned out that the products were properly selected to install but later the package manager was restarted and the selected products were not restored back.

## Solution

- Restore the selected products after reloading the package manager, properly install all products for new modules and extensions.

## Testing

- Added a new unit test
- Tested manually

## Notes

The `upgrade_repo_manager.rb` file has not been changed since SP5 where the problem does not happen. But it was not called at all there, so the bug was triggered by some other change. Anyway restoring the previous selection after reloading the package manager it always a good idea.

## Screenshots

The original buggy behavior, for example the "Python 3" module was not displayed in the "Update Options" section although the repository service from SCC was added into the system:

![sp6_upgrade_summary](https://github.com/yast/yast-installation/assets/907998/31a1e807-b4e1-4fe0-b549-27e503afe28a)


With the fix the "Pyhon 3" module and some more are correctly listed:

![sp6_upgrade_summary_fixed](https://github.com/yast/yast-installation/assets/907998/1bd176cb-c22b-4ddb-b89a-77337f89aa21)


