### PR TITLE
Added GitHub Action for submitting the package to OBS Factory

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -1,0 +1,29 @@
+# See https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions
+
+name: OBS
+
+on:
+  # only when committing to master
+  push:
+    branches: master
+
+  # allow running manually from GitHub Web
+  workflow_dispatch:
+
+jobs:
+  submit:
+    # do not run in forks
+    if: github.repository_owner == 'yast'
+
+    runs-on: ubuntu-latest
+
+    # the default timeout is 6 hours, do not wait for that long if osc gets stucked
+    timeout-minutes: 30
+
+    steps:
+      - name: Submit the package
+        # see https://github.com/yast/actions/blob/master/submit/action.yml
+        uses: yast/actions/submit@master
+        with:
+          obs_user:     ${{ secrets.OBS_USER }}
+          obs_password: ${{ secrets.OBS_PASSWORD }}


### PR DESCRIPTION
## Problem

We need to maintain the Jenkins jobs for submitting the package to openSUSE Factory. And someone needs to maintain the Jenkins instance for that.

## Solution

- Let's try using the GitHub Actions to implement the same mechanism
- Move the common parts to a shared action
  - Easier maintenance, we will need to touch just one place, not all YaST repositories
  - The GitHub Action is then small and we can use the same definition everywhere

## Testing

I already tested that in my fork (https://github.com/lslezak/yast-devtools/blob/master/.github/workflows/submit.yml), let's test that with some real YaST package.

## Links

- See https://github.com/yast/actions/blob/master/submit/action.yml 

