### PR TITLE
Fix call for connecting all discovered NVMe-over-Fabrics subsystems (bsc#1222246)

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Apr  3 13:39:37 UTC 2024 - Knut Anderssen <kanderssen@suse.com>
+
+- Adapted call for connecting all discovered NVMe-over-Fabrics 
+  subsystems (bsc#1222246).
+- 4.6.12
+
+-------------------------------------------------------------------
 Wed Mar 13 14:30:17 UTC 2024 - Ladislav Slezák <lslezak@suse.com>
 
 - Updated self-update URL in the documentation (jsc#PED-4839)

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.6.11
+Version:        4.6.12
 Release:        0
 Summary:        YaST2 - Installation Parts
 License:        GPL-2.0-only

--- a/src/include/installation/inst_inc_all.rb
+++ b/src/include/installation/inst_inc_all.rb
@@ -255,7 +255,8 @@ module Yast
     def connect_nbft
       require "yast2/execute"
 
-      Yast::Execute.locally!("nvme", "connect-nbft")
+      # Replaced 'connect-nbft' by 'connect-all --nbft' (bsc#1222246).
+      Yast::Execute.locally!("nvme", "connect-all", "--nbft")
     rescue Cheetah::ExecutionFailed
       Builtins.y2error("Error connecting NBFT")
     end


### PR DESCRIPTION
## Problem

When **linuxrc** (see [openSUSE/linuxrc#310](https://github.com/openSUSE/linuxrc/pull/310 "‌")) detects that there is some NBFT configured interface it will sets the **UseNBFT** variable and YaST calls `nvme connect-nbft` in order to discover and connect to all discovered **NVMe-over-Fabrics subsystems** as was [requested](https://github.com/yast/yast-installation/pull/1078 "‌") at implementation time.

As the nvme cli has been adapted supporting NBFT table the call should be also adapted calling `nvme connect-all --nbft` as requested in the bug and also as we can see in the [implementation PR description](https://github.com/linux-nvme/nvme-cli/pull/1791).

- https://bugzilla.suse.com/show_bug.cgi?id=1222246


## Solution

Adapted the call as requested.


