### PR TITLE
WIP: Handle autoinst AND autoupgrade (bsc#1222153)

### DIFF
--- a/src/lib/installation/clients/yast_inf_finish.rb
+++ b/src/lib/installation/clients/yast_inf_finish.rb
@@ -84,7 +84,7 @@ module Yast
         Ops.set(@linuxrc, "Root", "kexec") if LoadKexec()
 
         # Override linuxrc settings in autoinst mode
-        if Mode.autoinst
+        if Mode.auto
           if AutoinstConfig.ForceBoot
             Ops.set(@linuxrc, "Root", "reboot")
           elsif AutoinstConfig.RebootMsg


### PR DESCRIPTION
## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1222153


## Problem

In AutoYaST upgrade mode, the `halt` instruction doesn't work:

```XML
<general>
  <mode>
    <halt config:type="boolean">false</halt>
  </mode>
  ...
</general>
```

## Cause

The code only checked for `Mode.autoinst`, not also for `Mode.autoupgrade`, or, more generally, for `Mode.auto` which checks for both.


## Fix

Check for `Mode.auto`, not just for `Mode.autoinst`.


## Test

This is intended as a DUD for the customer to test.