### PR TITLE
Drop fbiterm in Tumbleweed Installation

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue May 14 13:55:18 UTC 2024 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Drop fbiterm (bsc#1224053)
+- 5.0.11
+
+-------------------------------------------------------------------
 Wed May  8 07:22:28 UTC 2024 - Stefan Schubert <schubi@suse.com>
 
 - Added encryption_method and encryption_pbkdf in the product

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        5.0.10
+Version:        5.0.11
 Release:        0
 Summary:        YaST2 - Installation Parts
 License:        GPL-2.0-only

--- a/startup/AUTHOR
+++ b/startup/AUTHOR
@@ -1,1 +1,0 @@
-Marcus Schäfer <ms@suse.de>

--- a/startup/YaST2.call
+++ b/startup/YaST2.call
@@ -302,10 +302,11 @@ function prepare_for_ncurses () {
 	fi
 	fi
 	#=============================================
-	# Check for FbIterm
+	# Check for supported locales in NCurses
 	#---------------------------------------------
-	check_run_fbiterm
-	log "\tCheck for FB-I-terminal: RUN_FBITERM = $RUN_FBITERM"
+        log "\tChecking supported NCurses locales"
+        check_supported_ncurses_locales
+        log "\tLANG: $LANG  LC_CTYPE: $LC_CTYPE"
 	set_inst_ncurses_env
 	#=============================================================
 	# Disable display of status messages on the console, as
@@ -533,12 +534,6 @@ function start_yast () {
 	fi
 	export QT_IM_MODULE=xim
 
-	if [ "$RUN_FBITERM" = "1" ]; then
-	    OPT_FBITERM="/usr/bin/fbiterm --"
-	else
-	    OPT_FBITERM=
-	fi
-
 	log "\tMODULE_NAME:  $Y2_MODULE_NAME"
 	log "\tMODE_FLAGS:   $Y2_MODE_FLAGS"
 	log "\tMODULE_ARGS:  $Y2_MODULE_ARGS"
@@ -571,9 +566,7 @@ function start_yast () {
         fi
 
 	if [ "$Y2GDB" != "1" ]; then
-	    $OPT_FBITERM \
-                "$Y2START"		\
-		$Y2START_ARGS
+            "$Y2START" $Y2START_ARGS
 	    Y2_EXIT_CODE=$?
 	else
 	    GDBCMDS=/var/lib/YaST2/gdb-cmds

--- a/startup/YaST2.call
+++ b/startup/YaST2.call
@@ -666,8 +666,6 @@ function start_yast_again () {
 # This sources the files at /usr/lib/YaST2/startup/common/
 # as well as /usr/lib/YaST2/bin/yast2-funcs (from yast2.rpm)
 . /usr/lib/YaST2/startup/common/functions.sh
-
-. /usr/lib/YaST2/startup/common/network.sh
 . /usr/lib/YaST2/startup/requires
 
 

--- a/startup/YaST2.call
+++ b/startup/YaST2.call
@@ -277,6 +277,7 @@ function prepare_for_x11 () {
 
 
 function prepare_for_qt () {
+    # From /usr/lib/YaST2/bin/yast2-funcs (pkg yast2.rpm)
     set_inst_qt_env
     prepare_for_x11
 }
@@ -307,7 +308,10 @@ function prepare_for_ncurses () {
         log "\tChecking supported NCurses locales"
         check_supported_ncurses_locales
         log "\tLANG: $LANG  LC_CTYPE: $LC_CTYPE"
+
+        # From /usr/lib/YaST2/bin/yast2-funcs (pkg yast2.rpm)
 	set_inst_ncurses_env
+
 	#=============================================================
 	# Disable display of status messages on the console, as
 	# controlled via systemd.show_status=0 on the kernel command.
@@ -326,6 +330,7 @@ function prepare_for_ssh () {
 # prepare SSH installation
 # ---
 #
+        # From /usr/lib/YaST2/bin/yast2-funcs (pkg yast2.rpm)
 	set_inst_qt_env
 }
 
@@ -363,7 +368,9 @@ function prepare_for_vnc () {
 	#=============================================
 	# Use YaST theme
 	#---------------------------------------------
-	set_inst_qt_env
+
+        # From /usr/lib/YaST2/bin/yast2-funcs (pkg yast2.rpm)
+        set_inst_qt_env
 }
 
 
@@ -655,7 +662,11 @@ function start_yast_again () {
 #=============================================
 # 1) Source common script functions
 #---------------------------------------------
+
+# This sources the files at /usr/lib/YaST2/startup/common/
+# as well as /usr/lib/YaST2/bin/yast2-funcs (from yast2.rpm)
 . /usr/lib/YaST2/startup/common/functions.sh
+
 . /usr/lib/YaST2/startup/common/network.sh
 . /usr/lib/YaST2/startup/requires
 

--- a/startup/common/language.sh
+++ b/startup/common/language.sh
@@ -12,43 +12,28 @@
 # DESCRIPTION   : Common used functions used for the YaST2 startup process
 #               : refering to language environment issues
 #               :
-# STATUS        : $Id$
 #----------------
 #
-#----[ check_run_fbiterm ]----#
-function check_run_fbiterm () {
+
 #--------------------------------------------------
-# check whether the system can use fbiterm also
-# handle the CJK language mangle on linux console
-# set flag value in RUN_FBITERM
+# Check whether the locale is supported in ncurses mode
+# and fall back to en_US.UTF-8 if it is not
 # ---
-	RUN_FBITERM=0
-	if test "$MEM_TOTAL" -lt "57344" ; then
-		return
-	fi
-	TTY=`/usr/bin/tty`
+function check_supported_ncurses_locales () {
+        TTY=`/usr/bin/tty`
 	if test "$TERM" = "linux" -a \
 		\( "$TTY" = /dev/console -o "$TTY" != "${TTY#/dev/tty[0-9]}" \);
 	then
-	    # check whether fbiterm can run on console
-	    if test -x /usr/bin/fbiterm && \
-		    /usr/bin/fbiterm echo >/dev/null 2>&1;
-	    then
-		RUN_FBITERM=1
-	    else
-		# use english
-		export LANG=en_US.UTF-8
-		export LC_CTYPE=en_US.UTF-8
-		log "\tfbiterm is not available or it does not work in this environment"
-	    fi
+                # We are no longer using fbiterm to support nontrivial locales
+                # (bsc#1224053), so we fall back to English if we are on the
+                # system console
 
-	    case "$LANG" in
-		# These languages are not properly supported by fbiterm causing YaST to crash
-		# (fate#325746).
-		ar*|bn*|gu*|hi*|km*|mr*|pa*|ta*|th*)
-		    export LANG=en_US.UTF-8
-		    export LC_CTYPE=en_US.UTF-8
-	    esac
+                case "$LANG" in
+                        zh*|ja*|ko*|ar*|bn*|gu*|hi*|km*|mr*|pa*|ta*|th*)
+                                log "\tLanguage $LANG is unsupported in NCurses, falling back to en_US.UTF-8"
+                                export LANG=en_US.UTF-8
+                                export LC_CTYPE=en_US.UTF-8
+                esac
 	fi
 }
 


### PR DESCRIPTION
## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1224053


## Trello

https://trello.com/c/haqsYySu


## Problem

We are using _fbiterm_ for much improved support for nontrivial locales like Chinese, Japanese, Korean in NCurses. But _fbiterm_ is part of the _xiterm_ package (it's the framebuffer version of _xiterm_, hence **FB**-**I**term) which has been abandoned upstream many years ago. With the upcoming GCC 14, it has build problems. The maintainer of the _xiterm_ package feels unable to continue supporting it; so we need to drop the _xiterm_ package and with it _fbiterm_.


## Fix

- ~Don't require _xiterm_ in the YaST packages anymore.~
  It turns out we never required _xiterm_ or _fbiterm_ in any YaST package: We always checked at runtime if `/usr/bin/fbiterm` was available and used it only if it was.

- Don't use `fbiterm` in the YaST startup scripts anymore.
  Strictly speaking, we could simply rely on the check if it was available, but this PR cleans up a lot of legacy that goes back a long time, and that obscured the code in the startup scripts.


## Caveat

Installing in certain languages won't work anymore in NCurses (text mode). Those languages will use a fallback to English from now on; but only in NCurses. The Qt (graphical) installation will work as before.


## Target Distributions

For now, only Tumbleweed / Factory / YaST master is affected. SLE-15 SPx and SLE-12 SPx will retain _fbiterm_.


## Test

Manual test in a modified inst-sys with the new scripts