### PR TITLE
Do report an error on `yupdate overlay`.

### DIFF
--- a/bin/yupdate
+++ b/bin/yupdate
@@ -570,7 +570,7 @@ module YUpdate
       when "diff"
         OverlayFS.find_all.map(&:print_diff)
       else
-        InvalidCommand.new(command)
+        InvalidCommand.new(command).run
       end
     end
   end


### PR DESCRIPTION
Before: it would silently do nothing
 (and I would wonder why my intent, `yupdate overlay create`, did not work)
Now: report an error, as intended
