### PR TITLE
Don't Block in AutoYaST Upgrade with Reboot Message [SLE-15-SP5]

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Aug 27 09:06:22 UTC 2024 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Don't block in AutoYaST upgrade (bsc#1181625)
+- 4.5.20
+
+-------------------------------------------------------------------
 Wed Nov 29 16:27:50 UTC 2023 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Enclose IPv6 addresses within square brackets when calling

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.5.19
+Version:        4.5.20
 Release:        0
 Summary:        YaST2 - Installation Parts
 License:        GPL-2.0-only

--- a/src/lib/installation/clients/inst_finish.rb
+++ b/src/lib/installation/clients/inst_finish.rb
@@ -137,7 +137,7 @@ module Yast
 
     def report_messages
       return if Misc.boot_msg.empty?
-      return if Mode.autoinst
+      return if Mode.auto
 
       # --------------------------------------------------------------
       # Check if there is a message left to display


### PR DESCRIPTION
## Target Branch

**This is for SLE-15-SP5**. A merge to SLE-15-SP6, -SP7 and master / Factory will follow.


## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1181625


## Trello

https://trello.com/c/jxGwssL6/


## Problem

In certain situations, an AutoYaST upgrade may block with a pop-up dialog "The system will reboot now" message that does not continue after a timeout as it should; the user needs to confirm it interactively which is against the idea of an auto-upgrade.


## Cause

The pop-up is suppressed only in `Mode.autoinst`, not also in `Mode.autoupgrade`.


## Fix

Instead of just checking for `Mode.autoinst`, check for `Mode.auto` which includes both `Mode.autoinst` and `Mode.autoupgrade`.

See also https://github.com/yast/yast-yast2/blob/master/library/general/src/modules/Mode.rb#L283-L286


## Related PRs

- Merge to SLE-15-SP6: _TBD_
- Merge to SLE-15-SP7: _TBD_
- Merge to master / Factory: _TBD_
