### PR TITLE
Fixing the self_update documentation

### DIFF
--- a/doc/SELF_UPDATE.md
+++ b/doc/SELF_UPDATE.md
@@ -198,7 +198,7 @@ certificate fingerprint before importing it.
 
 If there are other issues with the certificate (signed by an unknown certificate
 authority, expired certificate, ...) then you can disable the SSL check by
-the `ptoptions=reg_ssl_verify reg_ssl_verify=0` boot options. But this is
+the `ptoptions=+reg_ssl_verify reg_ssl_verify=0` boot options. But this is
 a security risk and should be used only in a trusted network, using a valid
 SSL certificate should be preferred.
 

--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Mon Sep  2 07:55:45 UTC 2024 - locilka@suse.com
+
+- Fixing ptoptions usage in self_update documentation
+
+-------------------------------------------------------------------
 Tue May 14 13:55:18 UTC 2024 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Drop fbiterm (bsc#1224053)


### PR DESCRIPTION
Reported by L3, ptoptions need to use the "+" sign to "add" something as described in https://en.opensuse.org/SDB:Linuxrc#p_ptoptions