### PR TITLE
Microos role

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Oct 15 09:00:15 UTC 2024 - Josef Reidinger <jreidinger@suse.com>
+
+- Move microos system role dialog from yast2-caasp here to be able
+  to drop yast2-caasp (gh#yast/yast-caasp#49)
+- 5.0.13
+
+-------------------------------------------------------------------
 Mon Sep  9 12:33:25 UTC 2024 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Don't block in AutoYaST upgrade (bsc#1181625)

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        5.0.12
+Version:        5.0.13
 Release:        0
 Summary:        YaST2 - Installation Parts
 License:        GPL-2.0-only
@@ -124,6 +124,9 @@ Conflicts:      yast2-registration < 3.2.3
 # Top bar with logo
 Conflicts:      yast2-ycp-ui-bindings < 3.1.7
 Obsoletes:      yast2-installation-devel-doc
+# we provide here only client that is used in microos from caasp package
+# and those clients conflicts on file level
+Conflicts:      yast2-caasp <= 5.0.0
 BuildArch:      noarch
 %if 0%{?suse_version} >= 1210
 %{systemd_requires}

--- a/src/clients/inst_microos_role.rb
+++ b/src/clients/inst_microos_role.rb
@@ -1,0 +1,3 @@
+
+require "installation/clients/microos_role_dialog"
+Installation::MicroOSRoleDialog.new.run

--- a/src/lib/installation/clients/microos_role_dialog.rb
+++ b/src/lib/installation/clients/microos_role_dialog.rb
@@ -1,0 +1,62 @@
+# encoding: utf-8
+
+# ------------------------------------------------------------------------------
+# Copyright (c) 2024 SUSE LLC
+#
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of version 2 of the GNU General Public License as published by the
+# Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, contact SUSE.
+#
+# To contact SUSE about this file by physical or electronic mail, you may find
+# current contact information at www.suse.com.
+# ------------------------------------------------------------------------------
+
+require "yast"
+require "cwm/dialog"
+require "installation/widgets/ntp_server"
+require "installation/dhcp_ntp_servers"
+
+module Installation
+  # This library provides a simple dialog for setting
+  # the admin role specific settings:
+  #   - the NTP server names
+  class AdminRoleDialog < CWM::Dialog
+    include DhcpNtpServers
+
+    def initialize
+      textdomain "installation"
+
+      Yast.import "Product"
+      Yast.import "ProductFeatures"
+      super
+    end
+
+    #
+    # The dialog title
+    #
+    # @return [String] the title
+    #
+    def title
+      # TRANSLATORS: dialog title
+      _("NTP Configuration")
+    end
+
+    def contents
+      return @content if @content
+
+      @content = HSquash(
+        MinWidth(50,
+          # preselect the servers from the DHCP response
+          Installation::Widgets::NtpServer.new(ntp_servers))
+      )
+    end
+  end
+end

--- a/src/lib/installation/dhcp_ntp_servers.rb
+++ b/src/lib/installation/dhcp_ntp_servers.rb
@@ -1,0 +1,69 @@
+# ------------------------------------------------------------------------------
+# Copyright (c) 2017 SUSE LLC
+#
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of version 2 of the GNU General Public License as published by the
+# Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, contact SUSE.
+#
+# To contact SUSE about this file by physical or electronic mail, you may find
+# current contact information at www.suse.com.
+# ------------------------------------------------------------------------------
+
+require "yast"
+
+module Installation
+  # This module provides a functionality for reading the NTP servers
+  module DhcpNtpServers
+    #
+    # List of NTP servers from DHCP
+    #
+    # @return [Array<String>] List of servers (IP or host names), empty if not provided
+    #
+    def dhcp_ntp_servers
+      Yast.import "Lan"
+
+      Yast::Lan.dhcp_ntp_servers
+    end
+
+    #
+    # Propose the NTP servers from the DHCP response, fallback to a random
+    # machine from the ntp.org pool if enabled in control.xml.
+    #
+    # @return [Array<String>] proposed NTP servers, empty if nothing suitable found
+    #
+    def ntp_servers
+      # TODO: use Yast::NtpClient.ntp_conf if configured
+      # to better handle going back
+      servers = dhcp_ntp_servers
+      servers = ntp_fallback if servers.empty?
+
+      servers
+    end
+
+    #
+    # The fallback servers for NTP configuration
+    #
+    # @return [Array<String>] the fallback servers, empty if disabled in control.xml
+    #
+    def ntp_fallback
+      Yast.import "ProductFeatures"
+      require "y2network/ntp_server"
+
+      # propose the fallback when enabled in control file
+      return [] unless Yast::ProductFeatures.GetBooleanFeature("globals", "default_ntp_setup")
+
+      default_servers = Y2Network::NtpServer.default_servers
+      return [] if default_servers.empty?
+
+      [default_servers.sample.hostname]
+    end
+  end
+end


### PR DESCRIPTION
## Problem

We would like to drop yast2-caasp. But one small part of it is used as additional dialog for opensuse-microos.


## Solution

Move that small part to yast2-installation, so we are able to drop yast2-caasp.

### Related Pull Requests

- https://github.com/yast/yast-caasp/pull/49