### PR TITLE
Fix microos typo

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Oct 16 19:29:19 UTC 2024 - Josef Reidinger <jreidinger@suse.com>
+
+- Fix for previous change which contain typo in class name causing
+  crash in microos installer (gh#yast/yast-installation#1126)
+- 5.0.14
+
+-------------------------------------------------------------------
 Tue Oct 15 09:00:15 UTC 2024 - Josef Reidinger <jreidinger@suse.com>
 
 - Move microos system role dialog from yast2-caasp here to be able

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        5.0.13
+Version:        5.0.14
 Release:        0
 Summary:        YaST2 - Installation Parts
 License:        GPL-2.0-only

--- a/src/lib/installation/clients/microos_role_dialog.rb
+++ b/src/lib/installation/clients/microos_role_dialog.rb
@@ -26,7 +26,7 @@ module Installation
   # This library provides a simple dialog for setting
   # the admin role specific settings:
   #   - the NTP server names
-  class AdminRoleDialog < CWM::Dialog
+  class MicroOSRoleDialog < CWM::Dialog
     include DhcpNtpServers
 
     def initialize


### PR DESCRIPTION
## Problem

There is a crash in microos installation caused by the last change in #1125.


## Solution

Fix the typo


## Testing

- *Tested manually* using `rake run[inst_microos_role]` to verify that it will show proper dialog.

