### PR TITLE
Fix brokenmodules

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Oct 23 11:18:09 UTC 2024 - Josef Reidinger <jreidinger@suse.com>
+
+- Improve handling spaces when list of blacklisted modules are
+  specified (bsc#1231313)
+- 4.7.1
+
+-------------------------------------------------------------------
 Fri Sep 06 07:14:32 UTC 2024 - Ladislav Slezák <lslezak@suse.com>
 
 - Branch package for SP7 (bsc#1230201)

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.7.0
+Version:        4.7.1
 Release:        0
 Summary:        YaST2 - Installation Parts
 License:        GPL-2.0-only

--- a/src/lib/installation/clients/copy_files_finish.rb
+++ b/src/lib/installation/clients/copy_files_finish.rb
@@ -190,7 +190,7 @@ module Yast
       end
 
       # comma-separated list of modules
-      blacklisted_modules = brokenmodules.split(", ")
+      blacklisted_modules = brokenmodules.split(/\s*,\s*/)
 
       # run before SCR switch
       blacklist_file = ::File.join(


### PR DESCRIPTION
## Problem

When there are multiple blacklisted modules then parsing does not work correctly and add it as single entry.

trello: https://trello.com/c/YrsSjjRG/3860-1231313-brokenmodulesab-results-in-invalid-blacklist
bugzilla: https://bugzilla.suse.com/show_bug.cgi?id=1231313


## Solution

Make parsing more robust regarding spaces around comma.


## Testing

- *Added a new unit test*

