### PR TITLE
Show dialog explicit

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Dec 17 12:56:21 UTC 2024 - Josef Reidinger <jreidinger@suse.com>
+
+- skip showing reboot message in autoinstallation and
+  autoupgrade mode only if not explicitly set on command line
+  (bsc#1231522)
+- 4.7.2
+
+-------------------------------------------------------------------
 Wed Oct 23 11:18:09 UTC 2024 - Josef Reidinger <jreidinger@suse.com>
 
 - Improve handling spaces when list of blacklisted modules are

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.7.1
+Version:        4.7.2
 Release:        0
 Summary:        YaST2 - Installation Parts
 License:        GPL-2.0-only

--- a/src/lib/installation/clients/inst_finish.rb
+++ b/src/lib/installation/clients/inst_finish.rb
@@ -137,7 +137,6 @@ module Yast
 
     def report_messages
       return if Misc.boot_msg.empty?
-      return if Mode.auto
 
       # --------------------------------------------------------------
       # Check if there is a message left to display
@@ -148,6 +147,9 @@ module Yast
       if Linuxrc.reboot_timeout
         Report.DisplayMessages(true, Linuxrc.reboot_timeout)
       else
+        # Skip in autoinstallation and autoupgrade mode only if not explicitelly
+        # set on command line (bsc#1231522)
+        return if Mode.auto
         # Display the message and wait for user to accept it
         # also live installation - bzilla #297691
         Report.DisplayMessages(true,

--- a/src/lib/installation/clients/inst_finish.rb
+++ b/src/lib/installation/clients/inst_finish.rb
@@ -147,7 +147,7 @@ module Yast
       if Linuxrc.reboot_timeout
         Report.DisplayMessages(true, Linuxrc.reboot_timeout)
       else
-        # Skip in autoinstallation and autoupgrade mode only if not explicitelly
+        # Skip in autoinstallation and autoupgrade mode only if not explicitly
         # set on command line (bsc#1231522)
         return if Mode.auto
 

--- a/src/lib/installation/clients/inst_finish.rb
+++ b/src/lib/installation/clients/inst_finish.rb
@@ -150,6 +150,7 @@ module Yast
         # Skip in autoinstallation and autoupgrade mode only if not explicitelly
         # set on command line (bsc#1231522)
         return if Mode.auto
+
         # Display the message and wait for user to accept it
         # also live installation - bzilla #297691
         Report.DisplayMessages(true,


### PR DESCRIPTION
## Problem

openqa needs a window to collect logs before reboot even in auto modes


## Solution

Respect explicit reboot timeout on command line even in automatic modes.


## Testing

- *Added a new unit test*
- *Tested manually*


## Screenshots

*If the fix affects the UI attach some screenshots here.*

