### PR TITLE
[SLE15-SP6] Fixed comparing versions in the self-update version check

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,16 @@
 -------------------------------------------------------------------
+Tue Dec 17 15:05:22 UTC 2024 - Ladislav Slezák <lslezak@suse.com>
+
+- Self-update fix (bsc#1234661)
+  - Properly compare the package versions from the inst-sys and
+    the self-update repository
+  - Remove the architecture suffix when reading the package version
+    from the inst-sys (the /.packages.root file)
+  - This fixes false alarm about incorrect self-update repository
+    when the installation is booted from PXE using the updated
+    tftpboot-installation-* packages (not the GA version)
+
+-------------------------------------------------------------------
 Tue Aug 27 09:06:22 UTC 2024 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Don't block in AutoYaST upgrade (bsc#1181625)

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.6.13
+Version:        4.6.14
 Release:        0
 Summary:        YaST2 - Installation Parts
 License:        GPL-2.0-only

--- a/src/lib/installation/instsys_packages.rb
+++ b/src/lib/installation/instsys_packages.rb
@@ -27,6 +27,9 @@ module Installation
         name, version = /^(\S+) \[(\S+)\]/.match(line)[1, 2]
         next unless name && version
 
+        # remove the architecture suffix
+        version.sub!(/\.(noarch|aarch64|i[3-6]86|ppc64|ppc64le|s390x?|x86_64)$/, "")
+
         # nil repository ID
         packages << Y2Packager::Package.new(name, nil, version)
       end

--- a/test/instsys_packages_test.rb
+++ b/test/instsys_packages_test.rb
@@ -29,9 +29,15 @@ describe Installation::InstsysPackages do
 
     it "reads the package versions" do
       pkgs = Installation::InstsysPackages.read(test_file)
-      yast2 = pkgs.find { |p| p.name == "yast2" }
 
-      expect(yast2.version).to eq("4.2.67-1.7.x86_64")
+      yast2 = pkgs.find { |p| p.name == "yast2" }
+      yast2_add_on = pkgs.find { |p| p.name == "yast2-add-on" }
+
+      # no "x86_64" suffix
+      expect(yast2.version).to eq("4.2.67-1.7")
+
+      # no "noarch" suffix
+      expect(yast2_add_on.version).to eq("4.2.15-1.30")
     end
   end
 end


### PR DESCRIPTION
## Problem

![broken_self_update](https://github.com/user-attachments/assets/5d68de85-99fc-44fd-a02c-e1194051119f)

- https://bugzilla.suse.com/show_bug.cgi?id=1234661
- YaST displays a false alarm error, there is actually no problem with the self-update repository
- The problem was in reading the versions from the `/.packages.root` file, the package version additionally contains the architecture at the end
- When comparing versions the "4.6.5-150600.3.6.1" version from the self-update looks older as "4.6.5-150600.3.6.1.x86_64" from the inst-sys so then YaST complains about downgrade
- This happens only when the installation is booted from PXE using the updated `tftpboot-installation-*` packages (not the GA version, that works fine)

## Solution

- Remove the architecture suffix from the version

## Testing

- Updated unit test
- Tested manually by the SUMA team
