### PR TITLE
Drop initviocons

### DIFF
--- a/doc/startup/firststage.tex
+++ b/doc/startup/firststage.tex
@@ -43,7 +43,7 @@ The following tasks are handled in the specified level scripts
 \subsection{F04-cmdline}
 \item Handle kernel parameters
 \subsection{F05-terminal}
-\item Init virtual consoles (initviocons)
+\item Init virtual consoles
 \subsection{F06-config}
 \item Create mtab according to /proc/mounts
 \subsection{F07-logging}

--- a/doc/startup/stage.ps
+++ b/doc/startup/stage.ps
@@ -7661,7 +7661,7 @@ SDict begin 14.5 H.A end
 a 345 2776 a
 SDict begin [ /View [/XYZ H.V] /Dest (Item.14) cvn H.B /DEST pdfmark end
  345 2776 a Black 457 2934 a Fe(5.)p Black
-49 w(Init)27 b(virtual)h(consoles)f(\(initviocons\))345
+49 w(Init)27 b(virtual)h(consoles)345
 3105 y
 SDict begin H.S end
  345 3105 a 345 3105 a

--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -245,7 +245,8 @@ Tue Nov 15 13:42:41 UTC 2022 - José Iván López González <jlopez@suse.com>
 - Write config for ssg-apply script according to the enabled
   security policy (part of jsc#SLE-24764).
 
- Tue Nov 15 13:41:41 UTC 2022 - Knut Anderssen <kanderssen@suse.com>
+-------------------------------------------------------------------
+Tue Nov 15 13:41:41 UTC 2022 - Knut Anderssen <kanderssen@suse.com>
 
 - Fix copy of entropy pool during installation (bsc#1204559).
 

--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -245,7 +245,6 @@ Tue Nov 15 13:42:41 UTC 2022 - José Iván López González <jlopez@suse.com>
 - Write config for ssg-apply script according to the enabled
   security policy (part of jsc#SLE-24764).
 
--------------------------------------------------------------------
  Tue Nov 15 13:41:41 UTC 2022 - Knut Anderssen <kanderssen@suse.com>
 
 - Fix copy of entropy pool during installation (bsc#1204559).
@@ -1003,8 +1002,8 @@ Fri Jun 12 16:09:32 UTC 2020 - David Diaz <dgonzalez@suse.com>
 - Improve the UX of the Previously Used Repositories dialog by
   using more accurate labels.
 
--------------------------------------------------------------------
 
+-------------------------------------------------------------------
 Fri Jun 12 15:03:11 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
 
 - Remove ssh_import section from AY when cloning (bsc#1172749)
@@ -1182,8 +1181,8 @@ Sun Nov 10 18:56:53 UTC 2019 - David Diaz <dgonzalez@suse.com>
 - Improve the role selection dialog using a new scrollable widget
   to select a role (related to bsc#1084674, bsc#bsc#1086187).
 - 4.2.21
--------------------------------------------------------------------
 
+-------------------------------------------------------------------
 Thu Nov  7 09:32:00 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
 
 - Implement upgrade for the Full medium (jsc#SLE-7101)

--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Aug 12 13:45:09 UTC 2025 - Josef Reidinger <jreidinger@suse.com>
+
+- Drop dependency and usage of initviocons (bsc#1247578)
+- 5.0.17
+
+-------------------------------------------------------------------
 Tue Dec 17 15:56:21 UTC 2024 - Josef Reidinger <jreidinger@suse.com>
 
 - skip showing reboot message in autoinstallation and

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        5.0.16
+Version:        5.0.17
 Release:        0
 Summary:        YaST2 - Installation Parts
 License:        GPL-2.0-only

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -56,8 +56,6 @@ BuildRequires:  rubygem(%{rb_default_ruby_abi}:yast-rake)
 Requires:       augeas-lenses
 Requires:       coreutils
 Requires:       gzip
-# use in startup scripts
-Requires:       initviocons
 # bsc#1214277; require awk, not gawk, to allow for lighterweight alternatives like busybox
 Requires:       awk
 # Needed call /sbin/ip in vnc.sh/network.sh

--- a/startup/First-Stage/F06-terminal
+++ b/startup/First-Stage/F06-terminal
@@ -5,17 +5,6 @@ log "========================"
 #=============================================
 # 6) setup virtual console
 #---------------------------------------------
-if ! skip_initviocons ; then
-	eval `/bin/initviocons -e`
-
-	#export TERM only, initviocons takes care about
-	#LINES and COLUMNS automatically (#184179)
-	export TERM
-	log "\tSetup virtual console:"
-	log "\tLines:   $LINES"
-	log "\tColumns: $COLUMNS"
-	log "\tType:    $TERM"
-fi
 
 #=============================================
 # 6.1) setup TERM variable

--- a/startup/Second-Stage/S05-config
+++ b/startup/Second-Stage/S05-config
@@ -6,19 +6,3 @@ log "======================"
 # 8) provide configuration files
 #---------------------------------------------
 log "\tNo configuration files needs to be provided..."
-
-#=============================================
-# 8.1) setup virtual console
-#---------------------------------------------
-
-if ! skip_initviocons ; then
-	eval `/bin/initviocons -e`
-
-	#export TERM only, initviocons takes care about
-        #LINES and COLUMNS automatically (#184179)
-	export TERM
-	log "\tSetup virtual console:"
-	log "\tLines:   $LINES"
-	log "\tColumns: $COLUMNS"
-	log "\tType:    $TERM"
-fi

--- a/startup/common/misc.sh
+++ b/startup/common/misc.sh
@@ -233,25 +233,6 @@ function load_module () {
 	/sbin/modprobe $1
 }
 
-#----[ skip_initviocons ]----#
-function skip_initviocons () {
-#------------------------------------------------------
-# check if the call to initviocons must be skipped
-# ---
-	# bnc #173426#c17: it is missing on single-CD repos
-	if [ ! -x /bin/initviocons ] ; then
-		return 0
-	fi
-
-	# initviocons should only be required on consoles, see bnc #800790
-	TTY=`/usr/bin/tty`
-	if [ "$TTY" != "/dev/console" -a "$TTY" == "${TTY#/dev/tty[0-9]}" ] ; then
-		return 0
-	fi
-
-	grep -qw TERM /proc/cmdline && return 0 || return 1
-}
-
 function log_export()
 {
     IFS_SAVE=$IFS


### PR DESCRIPTION
## Problem

The package initviocons has problem to build and will be dropped from TW.

bugzilla: https://bugzilla.suse.com/show_bug.cgi?id=1247578


## Solution

Drop dependency and its usage as it is useful for obsolete and no longer supported hardware.


