### PR TITLE
Calling kdump after bootloader settings have been written

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Fri Sep 19 12:08:48 UTC 2025 - Stefan Schubert <schubi@suse.de>
+
+- Writing kdump settings must be after writing bootloader settings.
+  Otherwise mkdumprd has no information about the installed kernel.
+  If kdump has to set bootloader settings, the bootloader write function
+  will be called again (bsc#1249370, bsc#1226676, bsc#1226676).
+- 5.0.18
+
+-------------------------------------------------------------------
 Tue Aug 12 13:45:09 UTC 2025 - Josef Reidinger <jreidinger@suse.com>
 
 - Drop dependency and usage of initviocons (bsc#1247578)

--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -4,7 +4,7 @@ Fri Sep 19 12:08:48 UTC 2025 - Stefan Schubert <schubi@suse.de>
 - Writing kdump settings must be after writing bootloader settings.
   Otherwise mkdumprd has no information about the installed kernel.
   If kdump has to set bootloader settings, the bootloader write function
-  will be called again (bsc#1249370, bsc#1226676, bsc#1226676).
+  will be called again (bsc#1249370, bsc#1226676).
 - 5.0.18
 
 -------------------------------------------------------------------

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        5.0.17
+Version:        5.0.18
 Release:        0
 Summary:        YaST2 - Installation Parts
 License:        GPL-2.0-only

--- a/src/lib/installation/clients/inst_finish.rb
+++ b/src/lib/installation/clients/inst_finish.rb
@@ -409,8 +409,8 @@ module Yast
       else
         [
           "cio_ignore", # needs to be run before initrd is created (bsc#933177)
-          (ProductFeatures.GetBooleanFeature("globals", "enable_kdump") == true) ? "kdump" : "",
-          "bootloader"
+          "bootloader",
+          (ProductFeatures.GetBooleanFeature("globals", "enable_kdump") == true) ? "kdump" : ""
         ]
       end
     end

--- a/src/lib/installation/clients/inst_finish.rb
+++ b/src/lib/installation/clients/inst_finish.rb
@@ -410,6 +410,10 @@ module Yast
         [
           "cio_ignore", # needs to be run before initrd is created (bsc#933177)
           "bootloader",
+          # Writing kdump settings must be after writing bootloader settings.
+          # Otherwise mkdumprd has no information about the installed kernel.
+          # If kdump has to set bootloader settings, the bootloader write function
+          # will be called again (bsc#1249370, bsc#1226676, bsc#1226676)
           (ProductFeatures.GetBooleanFeature("globals", "enable_kdump") == true) ? "kdump" : ""
         ]
       end

--- a/src/lib/installation/clients/inst_finish.rb
+++ b/src/lib/installation/clients/inst_finish.rb
@@ -413,7 +413,7 @@ module Yast
           # Writing kdump settings must be after writing bootloader settings.
           # Otherwise mkdumprd has no information about the installed kernel.
           # If kdump has to set bootloader settings, the bootloader write function
-          # will be called again (bsc#1249370, bsc#1226676, bsc#1226676)
+          # will be called again (bsc#1249370, bsc#1226676)
           (ProductFeatures.GetBooleanFeature("globals", "enable_kdump") == true) ? "kdump" : ""
         ]
       end


### PR DESCRIPTION
## Problem

kdump finish is calling mkdumprd. This should be called after the bootloader settings
have been written. Otherwise no kernel information is available.

- bsc#1249370, bsc#1226676, bsc#1226676
- https://openqa.opensuse.org/tests/5294128/modules/installation/steps/45

## Solution

Calling bootloader finish before kdump finish.


## Testing

- Tested manually


