### PR TITLE
Use a Longer  ZYPP Timeout in Second Stage [SLE-15-SP7]

### DIFF
--- a/package/YaST2-Second-Stage.service
+++ b/package/YaST2-Second-Stage.service
@@ -20,7 +20,10 @@ Type=oneshot
 # clash), empty path causes that the installed modules are not found. Sysconfig
 # and envvar extensions are still loaded, /etc/sysconfig/proxy values are still
 # used correctly (see bnc#866692 and bnc#866692 for details).
-Environment=TERM=linux PX_MODULE_PATH=""
+#
+# Use a 30 seconds zypp timeout (will be retried up to 5 times total) to allow
+# the purge-kernels.service to finish (bsc#1249643).
+Environment=TERM=linux PX_MODULE_PATH="" ZYPP_LOCK_TIMEOUT=30
 # Block non-privileged user login (bsc#1195059)
 ExecStartPre=-/usr/bin/plymouth quit
 ExecStart=/usr/lib/YaST2/startup/YaST2.Second-Stage

--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Oct 28 14:03:25 UTC 2025 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Use a longer ZYPP_LOCK_TIMEOUT (30 sec * 5) in YaST2-Second-Stage.service
+  to allow the purge-kernels.service to finish before trying to
+  obtain the libzypp lock (bsc#1249643)
+- 4.7.4
+
+-------------------------------------------------------------------
 Tue Dec 17 15:56:21 UTC 2024 - Josef Reidinger <jreidinger@suse.com>
 
 - skip showing reboot message in autoinstallation and

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-installation
-Version:        4.7.3
+Version:        4.7.4
 Release:        0
 Summary:        YaST2 - Installation Parts
 License:        GPL-2.0-only


### PR DESCRIPTION
## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1249643


## Target Branch

This is for SLE-15-SP7. The merge to _master_ is #1139.


## Problem

When using a _second stage_ for a (YaST) product upgrade (SP6 -> SP7) it can happen that the _purge-kernels.service_ is still busy and still holding on to the libzypp lock when the _YaST2-Second-Stage.service_ starts. If this second stage needs to install more packages, it has to obtain that libzypp lock, and that might time out with the normal timeout values.

In that case, the user is prompted to repeat to continue (without the lock; which will fail) or to retry obtaining the lock.


## When Can this Happen?

Only during a product upgrade (because there will not be any old kernels to purge for a fresh installation), and only  if there actually is a second stage after rebooting into the upgraded system, and that second stage needs the zypp lock for package operations like installing more packages.

This will typically only be the case when upgrading products that are based on SLE-15, like the Micro Focus _Open Enterprise Server (OES)_, or maybe _SLE for SAP_. Other SUSE products will typically not need additional packages to be installed after the first stage of the product upgrade. 

Even in this case, purging old kernels is typcally quick enough to be finished before the normal zypp timeout expires. But sometimes a _dracut_ run might be needed which might take a bit longer.


## Fix

This PR extends the timeout to 30 seconds. The YaST package bindings will automatically retry obtaining the lock up to 5 times total, so this will wait 5*30 = 150 seconds total before the user is prompted to retry or just continue (implicitly without the lock).


## Related PR

- Merge to _master_ / _Factory_: #1139